### PR TITLE
Fix taxonomy link navigation on client-side routing

### DIFF
--- a/app/components/NavHeader.vue
+++ b/app/components/NavHeader.vue
@@ -27,7 +27,7 @@ var isOpen = ref(false);
             <li><NuxtLinkLocale to="/governance" @click="isOpen-false">Governance</NuxtLinkLocale></li>
             <li><NuxtLinkLocale to="/awards" @click="isOpen-false">Awards</NuxtLinkLocale></li>
             <li><NuxtLinkLocale to="/get-involved" @click="isOpen = false">Get Involved</NuxtLinkLocale></li>
-            <li><NuxtLinkLocale to="/taxonomy" @click="isOpen = false">Taxonomy</NuxtLinkLocale></li>
+            <li><NuxtLinkLocale to="/taxonomy/device" @click="isOpen = false">Taxonomy</NuxtLinkLocale></li>
             <!-- <li><a href="https://vision.dtpr.io" class="flex items-center">Vision<Icon class="inline text-gray-400 ml-1" icon="fa6-solid:up-right-from-square" /></a></li> -->
           </ul>
         </nav>


### PR DESCRIPTION
## Summary
The NavHeader link to `/taxonomy` was causing a blank page when clicked from other pages. This happened because the child page `taxonomy/index.vue` redirected to `/taxonomy/device` within its script setup, which conflicts with Nuxt's client-side routing lifecycle.

## Fix
Changed the NavHeader link to point directly to `/taxonomy/device`, bypassing the problematic redirect. Users can still navigate between Devices and AI tabs within the taxonomy page.

## Test Plan
- [x] Click "Taxonomy" in the top navigation from another page — page loads correctly
- [x] Refresh on `/taxonomy/device` — still works
- [x] Navigate between tabs within taxonomy page — still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)