### PR TITLE
Enhance symbol generation with multi-result preview, shape swapping, and style references

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       openai:
         specifier: ^4.85.0
         version: 4.104.0(ws@8.19.0)(zod@4.3.6)
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       simple-git:
         specifier: ^3.27.0
         version: 3.32.3
@@ -8349,8 +8352,7 @@ snapshots:
       '@iconify/types': 2.0.0
       vue: 3.5.29(typescript@5.9.3)
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -8764,7 +8766,7 @@ snapshots:
   '@nuxt/content@3.12.0(better-sqlite3@12.6.2)(magicast@0.5.2)':
     dependencies:
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
-      '@nuxtjs/mdc': 0.20.1(magicast@0.5.2)
+      '@nuxtjs/mdc': 0.20.2(magicast@0.5.2)
       '@shikijs/langs': 3.23.0
       '@sqlite.org/sqlite-wasm': 3.50.4-build1
       '@standard-schema/spec': 1.1.0
@@ -16175,7 +16177,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:

--- a/studio/components/icons/BrainstormChat.vue
+++ b/studio/components/icons/BrainstormChat.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
-import { isTextUIPart, DefaultChatTransport } from 'ai'
-import { Chat } from '@ai-sdk/vue'
+import { isTextUIPart } from 'ai'
 
 const props = defineProps<{
   elementId: string
   elementName: string
   elementDescription: string
-  shapeName?: string
   referenceSymbols: string[]
 }>()
 
@@ -15,32 +13,22 @@ const emit = defineEmits<{
 }>()
 
 const toast = useToast()
-const input = ref('')
 const generatingPrompt = ref(false)
 
-const chat = new Chat({
-  transport: new DefaultChatTransport({
-    api: '/api/icons/chat',
-    body: {
-      elementId: props.elementId,
-      referenceSymbols: props.referenceSymbols,
-    },
-  }),
-  onError(error) {
-    toast.add({ title: 'Chat error', description: error.message, color: 'error' })
-  },
-})
+// Use persistent chat from composable — survives slideover open/close
+const chat = useBrainstormChat(props.elementId, props.referenceSymbols)
 
-// Send initial context message when the component mounts
+// Pre-fill the suggested first message if chat is empty
+const input = ref('')
 onMounted(() => {
-  const refCount = props.referenceSymbols.length
-  const refText = refCount > 0
-    ? ` I've selected ${refCount} reference symbol${refCount > 1 ? 's' : ''} from our existing set for style context.`
-    : ''
+  if (chat.messages.length === 0) {
+    const refCount = props.referenceSymbols.length
+    const refText = refCount > 0
+      ? ` I've selected ${refCount} reference symbol${refCount > 1 ? 's' : ''} from our existing set for style context.`
+      : ''
 
-  const initialMessage = `I need to create a symbol for "${props.elementName}": ${props.elementDescription}. The symbol needs to work at 36×36px as monochrome line art — just the inner graphic, no outer shape or border.${refText} What visual metaphors would work well for this concept?`
-
-  chat.sendMessage({ text: initialMessage })
+    input.value = `I need to create a symbol for "${props.elementName}": ${props.elementDescription}. The symbol needs to work at 36×36px as monochrome line art — just the inner graphic, no outer shape or border.${refText} What visual metaphors would work well for this concept?`
+  }
 })
 
 function onSubmit() {
@@ -52,7 +40,6 @@ function onSubmit() {
 async function generatePrompt() {
   generatingPrompt.value = true
   try {
-    // Extract message text for the prompt endpoint
     const messagesForPrompt = chat.messages.map((m) => ({
       role: m.role,
       content: m.parts
@@ -79,59 +66,62 @@ async function generatePrompt() {
   }
 }
 
-const hasMessages = computed(() => chat.messages.length > 1)
+const hasAssistantMessage = computed(() => chat.messages.some((m) => m.role === 'assistant'))
 const isStreaming = computed(() => chat.status === 'streaming')
 </script>
 
 <template>
-  <div class="flex flex-col h-full overflow-hidden">
-    <div class="flex-1 overflow-hidden flex flex-col">
+  <div class="flex flex-col" style="height: calc(100vh - 8rem)">
+    <!-- Scrollable message area -->
+    <div class="flex-1 overflow-y-auto min-h-0">
       <UChatMessages
         :messages="chat.messages"
         :status="chat.status"
         :assistant="{ icon: 'i-lucide-bot', side: 'left', variant: 'naked' }"
         :user="{ side: 'right', variant: 'soft' }"
         :should-auto-scroll="true"
-        class="flex-1"
       >
         <template #content="{ message }">
           <template
             v-for="(part, index) in message.parts"
             :key="`${message.id}-${part.type}-${index}`"
           >
-            <p
+            <MDC
               v-if="isTextUIPart(part)"
-              class="whitespace-pre-wrap text-sm"
-            >{{ part.text }}</p>
+              :value="part.text"
+              :cache-key="`${message.id}-${index}`"
+              class="prose prose-sm max-w-none *:first:mt-0 *:last:mb-0"
+            />
           </template>
         </template>
       </UChatMessages>
+    </div>
 
-      <div class="border-t border-default p-3">
-        <UButton
-          v-if="hasMessages"
-          label="Use this to generate Recraft prompt"
-          icon="i-lucide-sparkles"
-          size="sm"
-          :loading="generatingPrompt"
-          :disabled="isStreaming"
-          class="w-full mb-3"
-          @click="generatePrompt"
+    <!-- Fixed bottom: prompt + actions -->
+    <div class="shrink-0 border-t border-default p-3 space-y-3">
+      <UButton
+        v-if="hasAssistantMessage"
+        label="Use this to generate Recraft prompt"
+        icon="i-lucide-sparkles"
+        size="sm"
+        :loading="generatingPrompt"
+        :disabled="isStreaming"
+        class="w-full"
+        @click="generatePrompt"
+      />
+
+      <UChatPrompt
+        v-model="input"
+        placeholder="Describe what you're envisioning..."
+        :error="chat.error"
+        @submit="onSubmit"
+      >
+        <UChatPromptSubmit
+          :status="chat.status"
+          @stop="chat.stop()"
+          @reload="chat.regenerate()"
         />
-
-        <UChatPrompt
-          v-model="input"
-          placeholder="Describe what you're envisioning..."
-          :error="chat.error"
-          @submit="onSubmit"
-        >
-          <UChatPromptSubmit
-            :status="chat.status"
-            @stop="chat.stop()"
-            @reload="chat.regenerate()"
-          />
-        </UChatPrompt>
-      </div>
+      </UChatPrompt>
     </div>
   </div>
 </template>

--- a/studio/components/icons/BrainstormChat.vue
+++ b/studio/components/icons/BrainstormChat.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { isTextUIPart } from 'ai'
+import { isTextUIPart, DefaultChatTransport } from 'ai'
 import { Chat } from '@ai-sdk/vue'
 
 const props = defineProps<{
@@ -19,13 +19,13 @@ const input = ref('')
 const generatingPrompt = ref(false)
 
 const chat = new Chat({
-  transport: {
+  transport: new DefaultChatTransport({
     api: '/api/icons/chat',
-    body: computed(() => ({
+    body: {
       elementId: props.elementId,
       referenceSymbols: props.referenceSymbols,
-    })).value,
-  },
+    },
+  }),
   onError(error) {
     toast.add({ title: 'Chat error', description: error.message, color: 'error' })
   },

--- a/studio/composables/useBrainstormChat.ts
+++ b/studio/composables/useBrainstormChat.ts
@@ -1,0 +1,33 @@
+import { DefaultChatTransport } from 'ai'
+import { Chat } from '@ai-sdk/vue'
+
+// Holds chat instances per element so they survive slideover open/close.
+// Keyed by elementId — chat resets when a different element is selected.
+const chatInstances = new Map<string, Chat>()
+
+export function useBrainstormChat(elementId: string, referenceSymbols: string[]) {
+  const key = elementId
+
+  if (!chatInstances.has(key)) {
+    chatInstances.set(key, new Chat({
+      transport: new DefaultChatTransport({
+        api: '/api/icons/chat',
+        body: {
+          elementId,
+          referenceSymbols,
+        },
+      }),
+    }))
+  }
+
+  const chat = chatInstances.get(key)!
+  return chat
+}
+
+export function clearBrainstormChat(elementId: string) {
+  chatInstances.delete(elementId)
+}
+
+export function clearAllBrainstormChats() {
+  chatInstances.clear()
+}

--- a/studio/lib/recraft-config.ts
+++ b/studio/lib/recraft-config.ts
@@ -12,6 +12,8 @@ export interface RecraftOptions {
   prompt?: string
   model?: string
   colors?: [number, number, number][]
+  n?: number
+  styleId?: string
 }
 
 export const RECRAFT_MODELS = [

--- a/studio/lib/recraft-generator.ts
+++ b/studio/lib/recraft-generator.ts
@@ -17,11 +17,11 @@ export interface IconGenerationResult {
   filePath?: string
 }
 
-export async function generateInnerIcon(
+export async function generateInnerIcons(
   apiKey: string,
   request: IconGenerationRequest,
   options?: RecraftOptions,
-): Promise<string> {
+): Promise<string[]> {
   const client = new OpenAI({
     apiKey,
     baseURL: 'https://external.api.recraft.ai/v1',
@@ -29,11 +29,12 @@ export async function generateInnerIcon(
 
   const prompt = options?.prompt || buildDefaultPrompt(request)
   const model = options?.model || 'recraftv4_vector'
+  const n = Math.min(Math.max(options?.n ?? 3, 1), 6)
 
   const generateParams: Record<string, any> = {
     model,
     prompt,
-    n: 1,
+    n,
     response_format: 'url',
     size: '1024x1024',
   }
@@ -45,15 +46,37 @@ export async function generateInnerIcon(
     }
   }
 
-  const response = await client.images.generate(generateParams as any)
-
-  const imageUrl = response.data?.[0]?.url
-  if (!imageUrl) {
-    throw new Error('No image returned from Recraft API')
+  // Pass style_id if provided (created from reference symbols)
+  if (options?.styleId) {
+    generateParams.style_id = options.styleId
   }
 
-  const svgResponse = await fetch(imageUrl)
-  return await svgResponse.text()
+  const response = await client.images.generate(generateParams as any)
+
+  if (!response.data?.length) {
+    throw new Error('No images returned from Recraft API')
+  }
+
+  // Fetch all SVGs in parallel
+  const svgs = await Promise.all(
+    response.data.map(async (item) => {
+      if (!item.url) throw new Error('Missing URL in Recraft response')
+      const res = await fetch(item.url)
+      return res.text()
+    }),
+  )
+
+  return svgs
+}
+
+/** @deprecated Use generateInnerIcons for multiple results */
+export async function generateInnerIcon(
+  apiKey: string,
+  request: IconGenerationRequest,
+  options?: RecraftOptions,
+): Promise<string> {
+  const svgs = await generateInnerIcons(apiKey, request, { ...options, n: 1 })
+  return svgs[0]
 }
 
 export async function generateIcon(

--- a/studio/package.json
+++ b/studio/package.json
@@ -18,6 +18,7 @@
     "gray-matter": "^4.0.3",
     "nuxt": "^4.0.0",
     "openai": "^4.85.0",
+    "sharp": "^0.34.5",
     "simple-git": "^3.27.0",
     "tailwindcss": "^4.2.1"
   },

--- a/studio/pages/icons/generate.vue
+++ b/studio/pages/icons/generate.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { ShapeType } from '~/lib/icon-shapes'
 import { RECRAFT_MODELS, buildDefaultPrompt } from '~/lib/recraft-config'
 
 const toast = useToast()
@@ -18,14 +19,30 @@ const generating = ref(false)
 const saving = ref(false)
 const brainstormOpen = ref(false)
 
-// Preview state
+// Multi-result preview state
+interface GeneratedResult {
+  innerSvg: string
+  light: string
+}
+const generatedResults = ref<GeneratedResult[]>([])
+const selectedResultIndex = ref(0)
+const previewShape = ref<ShapeType>('hexagon')
+const compositing = ref(false)
+
+// Full variant preview for the selected result
 const previewVariants = ref<{ light: string; dark: string; colored: string } | null>(null)
-const innerSvg = ref<string>('')
 
 const modelOptions = RECRAFT_MODELS.map((m) => ({
   label: m.label,
   value: m.id,
 }))
+
+const shapeOptions = [
+  { label: 'Hexagon', value: 'hexagon' as ShapeType },
+  { label: 'Circle', value: 'circle' as ShapeType },
+  { label: 'Rounded Square', value: 'rounded-square' as ShapeType },
+  { label: 'Octagon', value: 'octagon' as ShapeType },
+]
 
 // Sort elements alphabetically by English name
 const sortedElements = computed(() => {
@@ -61,13 +78,17 @@ const elementDescription = computed(() => {
 })
 
 // Auto-build default prompt when element changes
-watch(selectedElementId, async (id) => {
+watch(selectedElementId, async (id, oldId) => {
   if (!id) return
 
   // Reset state
+  generatedResults.value = []
+  selectedResultIndex.value = 0
   previewVariants.value = null
-  innerSvg.value = ''
   suggestedColors.value = []
+
+  // Clear old element's brainstorm chat
+  if (oldId) clearBrainstormChat(oldId)
 
   try {
     const el = await $fetch<any>(`/api/elements/${id}`)
@@ -102,13 +123,33 @@ async function generate() {
   }
 
   generating.value = true
+  generatedResults.value = []
+  selectedResultIndex.value = 0
   previewVariants.value = null
   try {
+    // Create a Recraft style from reference symbols if any are selected
+    let styleId: string | undefined
+    if (referenceSymbols.value.length > 0) {
+      try {
+        const styleResult = await $fetch<{ styleId: string }>('/api/icons/style', {
+          method: 'POST',
+          body: { symbolIds: referenceSymbols.value },
+        })
+        styleId = styleResult.styleId
+      } catch (e: any) {
+        toast.add({
+          title: 'Style creation failed',
+          description: `Generating without style reference. ${e.data?.message || e.message}`,
+          color: 'warning',
+        })
+      }
+    }
+
     const result = await $fetch<{
       success: boolean
       elementId: string
-      innerSvg: string
-      variants: { light: string; dark: string; colored: string }
+      shape: ShapeType
+      results: GeneratedResult[]
     }>('/api/icons/generate', {
       method: 'POST',
       body: {
@@ -116,17 +157,51 @@ async function generate() {
         model: selectedModel.value,
         prompt: prompt.value,
         colors: suggestedColors.value.length > 0 ? suggestedColors.value : undefined,
+        styleId,
       },
     })
 
-    innerSvg.value = result.innerSvg
-    previewVariants.value = result.variants
+    generatedResults.value = result.results
+    previewShape.value = result.shape
+
+    // Auto-select first and load full variants
+    if (result.results.length > 0) {
+      await selectResult(0)
+    }
   } catch (e: any) {
     toast.add({ title: 'Generation failed', description: e.data?.message || e.message, color: 'error' })
   } finally {
     generating.value = false
   }
 }
+
+async function selectResult(index: number) {
+  selectedResultIndex.value = index
+  await compositeWithShape(generatedResults.value[index].innerSvg, previewShape.value)
+}
+
+async function compositeWithShape(innerSvg: string, shape: ShapeType) {
+  compositing.value = true
+  try {
+    const result = await $fetch<{ light: string; dark: string; colored: string }>('/api/icons/composite', {
+      method: 'POST',
+      body: { innerSvg, shape },
+    })
+    previewVariants.value = result
+  } catch (e: any) {
+    toast.add({ title: 'Composite failed', description: e.message, color: 'error' })
+  } finally {
+    compositing.value = false
+  }
+}
+
+// Re-composite when shape changes
+watch(previewShape, async (shape) => {
+  const result = generatedResults.value[selectedResultIndex.value]
+  if (result) {
+    await compositeWithShape(result.innerSvg, shape)
+  }
+})
 
 async function approveAndSave() {
   if (!previewVariants.value || !selectedElementId.value) return
@@ -140,7 +215,6 @@ async function approveAndSave() {
       },
     })
     toast.add({ title: 'Icon saved', description: `Saved icon for ${elementName.value}`, color: 'success' })
-    previewVariants.value = null
   } catch (e: any) {
     toast.add({ title: 'Save failed', description: e.message, color: 'error' })
   } finally {
@@ -242,7 +316,7 @@ async function approveAndSave() {
 
           <!-- Generate button -->
           <UButton
-            label="Generate"
+            label="Generate 3 Variations"
             icon="i-lucide-sparkles"
             size="lg"
             :loading="generating"
@@ -254,27 +328,66 @@ async function approveAndSave() {
 
         <!-- Right: Preview -->
         <div class="space-y-4">
-          <div v-if="previewVariants" class="space-y-4">
-            <h3 class="text-sm font-medium">Preview</h3>
-            <div class="flex gap-4 justify-center py-4 rounded-lg border border-default">
-              <div class="flex flex-col items-center gap-2">
-                <div class="w-20 h-20 flex items-center justify-center rounded-lg border border-default bg-white">
-                  <img :src="svgToDataUrl(previewVariants.light)" class="w-16 h-16" />
+          <!-- Pick from 3 generated options -->
+          <div v-if="generatedResults.length > 0" class="space-y-4">
+            <h3 class="text-sm font-medium">Choose a Symbol</h3>
+            <div class="flex gap-3 justify-center">
+              <button
+                v-for="(result, i) in generatedResults"
+                :key="i"
+                type="button"
+                class="flex flex-col items-center gap-1.5 p-2 rounded-lg border-2 transition-all cursor-pointer"
+                :class="selectedResultIndex === i
+                  ? 'border-primary bg-primary/5'
+                  : 'border-default hover:border-muted-foreground/30'"
+                @click="selectResult(i)"
+              >
+                <div class="w-20 h-20 flex items-center justify-center rounded bg-white">
+                  <img :src="svgToDataUrl(result.light)" class="w-16 h-16" />
                 </div>
-                <span class="text-xs text-muted">Light</span>
-              </div>
-              <div class="flex flex-col items-center gap-2">
-                <div class="w-20 h-20 flex items-center justify-center rounded-lg border border-default bg-gray-900">
-                  <img :src="svgToDataUrl(previewVariants.dark)" class="w-16 h-16" />
+                <span class="text-xs text-muted">Option {{ i + 1 }}</span>
+              </button>
+            </div>
+
+            <!-- Shape selector for preview -->
+            <div class="space-y-1.5">
+              <label class="text-sm font-medium">Preview Shape</label>
+              <USelectMenu
+                v-model="previewShape"
+                :items="shapeOptions"
+                value-key="value"
+                class="w-full"
+              />
+            </div>
+
+            <!-- Full variant preview -->
+            <div v-if="previewVariants && !compositing" class="space-y-3">
+              <h3 class="text-sm font-medium">Variants</h3>
+              <div class="flex gap-4 justify-center py-4 rounded-lg border border-default">
+                <div class="flex flex-col items-center gap-2">
+                  <div class="w-20 h-20 flex items-center justify-center rounded-lg border border-default bg-white">
+                    <img :src="svgToDataUrl(previewVariants.light)" class="w-16 h-16" />
+                  </div>
+                  <span class="text-xs text-muted">Light</span>
                 </div>
-                <span class="text-xs text-muted">Dark</span>
-              </div>
-              <div class="flex flex-col items-center gap-2">
-                <div class="w-20 h-20 flex items-center justify-center rounded-lg border border-default bg-white">
-                  <img :src="svgToDataUrl(previewVariants.colored)" class="w-16 h-16" />
+                <div class="flex flex-col items-center gap-2">
+                  <div class="w-20 h-20 flex items-center justify-center rounded-lg border border-default bg-gray-900">
+                    <img :src="svgToDataUrl(previewVariants.dark)" class="w-16 h-16" />
+                  </div>
+                  <span class="text-xs text-muted">Dark</span>
                 </div>
-                <span class="text-xs text-muted">Colored</span>
+                <div class="flex flex-col items-center gap-2">
+                  <div class="w-20 h-20 flex items-center justify-center rounded-lg border border-default bg-white">
+                    <img :src="svgToDataUrl(previewVariants.colored)" class="w-16 h-16" />
+                  </div>
+                  <span class="text-xs text-muted">Colored</span>
+                </div>
               </div>
+            </div>
+
+            <div v-else-if="compositing" class="flex items-center justify-center py-8 text-muted">
+              <UIcon name="i-lucide-loader" class="size-4 animate-spin mr-2" />
+              Compositing...
             </div>
 
             <div class="flex gap-2">
@@ -292,6 +405,7 @@ async function approveAndSave() {
                 icon="i-lucide-check"
                 color="primary"
                 :loading="saving"
+                :disabled="!previewVariants"
                 class="flex-1"
                 @click="approveAndSave"
               />
@@ -300,7 +414,7 @@ async function approveAndSave() {
 
           <div v-else-if="generating" class="flex items-center justify-center py-16 text-muted">
             <UIcon name="i-lucide-loader" class="size-5 animate-spin mr-2" />
-            Generating with Recraft V4...
+            Generating 3 variations...
           </div>
 
           <div v-else class="flex items-center justify-center py-16 text-muted border border-dashed border-default rounded-lg">
@@ -316,16 +430,15 @@ async function approveAndSave() {
       title="Brainstorm with Claude"
       description="Chat with Claude to explore visual metaphors for this symbol."
       side="right"
-      :ui="{ content: 'sm:max-w-lg' }"
+      :ui="{ content: 'sm:max-w-lg', body: 'flex flex-col min-h-0 overflow-hidden' }"
     >
       <template #body>
         <IconsBrainstormChat
-          v-if="brainstormOpen && selectedElementId"
-          :key="`${selectedElementId}-${brainstormOpen}`"
+          v-if="selectedElementId"
+          :key="selectedElementId"
           :element-id="selectedElementId"
           :element-name="elementName"
           :element-description="elementDescription"
-          :shape-name="'symbol'"
           :reference-symbols="referenceSymbols"
           @prompt-ready="onPromptReady"
         />

--- a/studio/server/api/icons/composite.post.ts
+++ b/studio/server/api/icons/composite.post.ts
@@ -1,0 +1,22 @@
+import { compositeIconFromFullSvg } from '~/lib/icon-compositor'
+import type { ShapeType, ShapeVariant } from '~/lib/icon-shapes'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const { innerSvg, shape, variant, color } = body as {
+    innerSvg: string
+    shape: ShapeType
+    variant?: ShapeVariant
+    color?: string
+  }
+
+  if (!innerSvg || !shape) {
+    throw createError({ statusCode: 400, message: 'innerSvg and shape are required' })
+  }
+
+  return {
+    light: compositeIconFromFullSvg(innerSvg, shape, 'light'),
+    dark: compositeIconFromFullSvg(innerSvg, shape, 'dark'),
+    colored: compositeIconFromFullSvg(innerSvg, shape, 'colored', color || '#FFDD00'),
+  }
+})

--- a/studio/server/api/icons/generate.post.ts
+++ b/studio/server/api/icons/generate.post.ts
@@ -1,10 +1,7 @@
-import { writeFile } from 'fs/promises'
-import { join } from 'path'
-import { generateInnerIcon } from '~/lib/recraft-generator'
+import { generateInnerIcons } from '~/lib/recraft-generator'
 import { compositeIconFromFullSvg } from '~/lib/icon-compositor'
-import { getShapeFromCategories, type ShapeVariant, type ShapeType } from '~/lib/icon-shapes'
+import { getShapeFromCategories, type ShapeType } from '~/lib/icon-shapes'
 import { getProvider } from '~/server/utils/provider'
-import { getIconsDir } from '~/server/utils/paths'
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
@@ -13,14 +10,14 @@ export default defineEventHandler(async (event) => {
   }
 
   const body = await readBody(event)
-  const { elementId, save, variant, shape: shapeOverride, prompt: promptOverride, model, colors } = body as {
+  const { elementId, shape: shapeOverride, prompt: promptOverride, model, colors, n, styleId } = body as {
     elementId?: string
-    save?: boolean
-    variant?: ShapeVariant
     shape?: ShapeType
     prompt?: string
     model?: string
     colors?: [number, number, number][]
+    n?: number
+    styleId?: string
   }
 
   if (!elementId) {
@@ -28,14 +25,13 @@ export default defineEventHandler(async (event) => {
   }
 
   const provider = getProvider()
-  const iconsDir = getIconsDir()
 
   // Get element info
   const element = await provider.readFile('elements', 'en', elementId)
   const fm = element.frontmatter
 
-  // Generate inner icon via Recraft V4
-  const innerSvg = await generateInnerIcon(config.recraftApiKey, {
+  // Generate inner icons via Recraft V4 (multiple)
+  const innerSvgs = await generateInnerIcons(config.recraftApiKey, {
     elementId: fm.id,
     elementName: fm.name,
     elementDescription: fm.description,
@@ -44,35 +40,23 @@ export default defineEventHandler(async (event) => {
     prompt: promptOverride,
     model,
     colors,
+    n: n ?? 3,
+    styleId,
   })
 
-  // Determine shape — use override if provided, otherwise derive from categories
+  // Determine shape
   const shape = shapeOverride || getShapeFromCategories(fm.category || [])
 
-  // Composite all three variants for preview
-  const variants = {
+  // Composite each result into light variant for preview
+  const results = innerSvgs.map((innerSvg) => ({
+    innerSvg,
     light: compositeIconFromFullSvg(innerSvg, shape, 'light'),
-    dark: compositeIconFromFullSvg(innerSvg, shape, 'dark'),
-    colored: compositeIconFromFullSvg(innerSvg, shape, 'colored', '#FFDD00'),
-  }
-
-  // The saved version uses the requested variant (default: light)
-  const saveVariant = variant || 'light'
-  let filePath: string | undefined
-
-  if (save) {
-    const fileName = `${fm.id}.svg`
-    filePath = join(iconsDir, fileName)
-    await writeFile(filePath, variants[saveVariant], 'utf-8')
-  }
+  }))
 
   return {
     success: true,
     elementId: fm.id,
     shape,
-    innerSvg,
-    variants,
-    filePath,
-    saved: !!save,
+    results,
   }
 })

--- a/studio/server/api/icons/style.post.ts
+++ b/studio/server/api/icons/style.post.ts
@@ -1,0 +1,87 @@
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+import sharp from 'sharp'
+import { getIconsDir } from '~/server/utils/paths'
+
+/**
+ * Creates a Recraft style from reference SVG symbols.
+ * Converts SVGs to PNGs (Recraft requires raster images), uploads them,
+ * and returns a style_id for use in generation.
+ */
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  if (!config.recraftApiKey) {
+    throw createError({ statusCode: 500, message: 'RECRAFT_API_KEY not configured' })
+  }
+
+  const body = await readBody(event)
+  const { symbolIds, baseStyle } = body as {
+    symbolIds: string[]
+    baseStyle?: string
+  }
+
+  if (!symbolIds?.length) {
+    throw createError({ statusCode: 400, message: 'symbolIds is required (array of symbol file names)' })
+  }
+
+  if (symbolIds.length > 5) {
+    throw createError({ statusCode: 400, message: 'Maximum 5 reference symbols allowed' })
+  }
+
+  const symbolsDir = join(getIconsDir(), 'symbols')
+
+  // Read SVGs and convert to PNG buffers
+  const pngBuffers: { name: string; buffer: Buffer }[] = []
+  for (const id of symbolIds) {
+    try {
+      const fileName = id.endsWith('.svg') ? id : `${id}.svg`
+      const svgContent = await readFile(join(symbolsDir, fileName), 'utf-8')
+
+      // Convert SVG to 512x512 PNG for style reference
+      const pngBuffer = await sharp(Buffer.from(svgContent))
+        .resize(512, 512, { fit: 'contain', background: { r: 255, g: 255, b: 255, alpha: 1 } })
+        .png()
+        .toBuffer()
+
+      pngBuffers.push({ name: fileName.replace('.svg', '.png'), buffer: pngBuffer })
+    } catch (e: any) {
+      console.warn(`Skipping symbol ${id}: ${e.message}`)
+    }
+  }
+
+  if (pngBuffers.length === 0) {
+    throw createError({ statusCode: 400, message: 'No valid symbols could be converted' })
+  }
+
+  // Upload to Recraft style endpoint via multipart form
+  const formData = new FormData()
+  formData.append('style', baseStyle || 'digital_illustration')
+
+  for (let i = 0; i < pngBuffers.length; i++) {
+    const blob = new Blob([pngBuffers[i].buffer], { type: 'image/png' })
+    formData.append(`file${i > 0 ? i + 1 : ''}`, blob, pngBuffers[i].name)
+  }
+
+  const response = await fetch('https://external.api.recraft.ai/v1/styles', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${config.recraftApiKey}`,
+    },
+    body: formData,
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    throw createError({
+      statusCode: response.status,
+      message: `Recraft style creation failed: ${errorText}`,
+    })
+  }
+
+  const result = await response.json() as { id: string }
+
+  return {
+    styleId: result.id,
+    symbolCount: pngBuffers.length,
+  }
+})


### PR DESCRIPTION
## Summary

- Generate 3 Recraft V4 variations per request with side-by-side selection UI (configurable n=1-6)
- Add shape selector in preview panel to re-composite selected symbol into different shapes (hexagon, circle, rounded-square, octagon) via new `/api/icons/composite` endpoint
- Wire reference symbol picker to Recraft style API: converts SVGs to PNGs via `sharp`, creates a `style_id` so reference symbols actually influence generation output
- New `/api/icons/style` endpoint handles SVG-to-PNG conversion and Recraft style creation (max 5 references, PNG/JPG/WEBP only)
- Fix brainstorm chat: pre-fill initial prompt instead of auto-sending, persist chat history across slideover open/close via `useBrainstormChat` composable, render markdown with MDC, fix scroll overflow

## Test plan

- [ ] Select an element and verify 3 symbol variations appear after generation
- [ ] Click between the 3 options and confirm the variant preview updates
- [ ] Change the shape dropdown and verify the composited preview re-renders
- [ ] Select reference symbols, generate, and confirm style creation doesn't error (check server logs for style_id)
- [ ] Open/close the brainstorm slideover and verify chat history persists
- [ ] Verify markdown renders properly in brainstorm chat responses
- [ ] Test scrolling in the brainstorm chat with long responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)