### PR TITLE
Add draft-2026-03 experimental taxonomy (RFC #260)

### DIFF
--- a/app/content.config.ts
+++ b/app/content.config.ts
@@ -79,5 +79,51 @@ export default defineContentConfig({
         _locale: z.string()
       })
     }),
+
+    // Draft 2026-03 collections (experimental — RFC #260)
+    draft_2026_03_datachain_categories: defineCollection({
+      type: 'data',
+      source: 'dtpr.draft-2026-03/datachain_categories/*.yaml',
+      schema: z.object({
+        dtpr_id: z.string(),
+        name: z.record(z.string()),
+        description: z.record(z.string()),
+        prompt: z.record(z.string()),
+        required: z.boolean().optional(),
+        order: z.number().min(0).optional(),
+        element_variables: z.array(z.object({
+          id: z.string(),
+          label: z.record(z.string()).optional(),
+          required: z.boolean().optional(),
+          type: z.enum(['text', 'select', 'multiselect']).optional(),
+        })).optional(),
+        context: z.object({
+          id: z.string(),
+          name: z.record(z.string()),
+          description: z.record(z.string()),
+          values: z.array(z.object({
+            id: z.string(),
+            name: z.record(z.string()),
+            description: z.record(z.string()),
+            color: z.string(),
+          })),
+        }).optional(),
+        updated_at: z.string(),
+      })
+    }),
+
+    draft_2026_03_elements: defineCollection({
+      type: 'data',
+      source: 'dtpr.draft-2026-03/elements/*.yaml',
+      schema: z.object({
+        dtpr_id: z.string(),
+        category: z.array(z.string()),
+        name: z.record(z.string()),
+        description: z.record(z.string()),
+        icon: z.string(),
+        symbol: z.string().optional(),
+        updated_at: z.string(),
+      })
+    }),
   }
 })

--- a/app/content/dtpr.draft-2026-03/datachain_categories/access.yaml
+++ b/app/content/dtpr.draft-2026-03/datachain_categories/access.yaml
@@ -1,0 +1,18 @@
+dtpr_id: access
+name:
+  en: Access
+  fr: Accéder
+description:
+  en: The access controls and permissions for the data produced by the AI system.
+  fr: Les contrôles d’accès et les autorisations pour les données produites par le système d’IA.
+prompt:
+  en: Who has access to the data produced by the AI system?
+  fr: Qui a accès aux données produites par le système d’IA ?
+required: false
+order: 7
+element_variables:
+  - id: additional_description
+    label:
+      en: Description
+      fr: Description
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/datachain_categories/accountable.yaml
+++ b/app/content/dtpr.draft-2026-03/datachain_categories/accountable.yaml
@@ -1,0 +1,24 @@
+dtpr_id: accountable
+name:
+  en: Accountable
+  fr: Responsable
+description:
+  en: The organization accountable for the deployment of this AI system.
+  fr: L'organisation responsable du déploiement de ce système d'IA.
+prompt:
+  en: Who is accountable for this AI system?
+  fr: Qui est responsable de ce système d’IA ?
+required: true
+order: 1
+element_variables:
+  - id: title
+    label:
+      en: Title
+      fr: Titre
+    required: true
+  - id: description
+    label:
+      en: Description
+      fr: Description
+    required: true
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/datachain_categories/data_flow.yaml
+++ b/app/content/dtpr.draft-2026-03/datachain_categories/data_flow.yaml
@@ -1,0 +1,18 @@
+dtpr_id: data_flow
+name:
+  en: Data Flow
+  fr: Flux de données
+description:
+  en: The types of data that flow into and out of the AI system.
+  fr: Les types de données qui entrent et sortent du système d'IA.
+prompt:
+  en: What data flows into and out of this AI system?
+  fr: Quelles données entrent et sortent de ce système d'IA ?
+required: false
+order: 4
+element_variables:
+  - id: additional_description
+    label:
+      en: Description
+      fr: Description
+updated_at: "2025-08-29T00:00:00Z"

--- a/app/content/dtpr.draft-2026-03/datachain_categories/functional_modes.yaml
+++ b/app/content/dtpr.draft-2026-03/datachain_categories/functional_modes.yaml
@@ -1,0 +1,70 @@
+dtpr_id: functional_modes
+name:
+  en: Functional Modes
+  fr: Modes fonctionnels
+description:
+  en: The functional mode of the AI system, describing what the system fundamentally does.
+  fr: Le mode fonctionnel du système d'IA, décrivant ce que le système fait fondamentalement.
+prompt:
+  en: What does this AI system fundamentally do?
+  fr: Que fait fondamentalement ce système d'IA ?
+required: true
+order: 3
+context:
+  id: functional_mode
+  name:
+    en: Functional Mode
+    fr: Mode fonctionnel
+  description:
+    en: Indicates the primary way in which the AI system operates.
+    fr: Indique le mode principal de fonctionnement du système d'IA.
+  values:
+    - id: analytical
+      name:
+        en: Analytical AI
+        fr: IA analytique
+      description:
+        en: Analyzes data for decisions and predictions.
+        fr: Analyse les données pour les décisions et les prédictions.
+      color: "#4A90D9"
+    - id: semantic
+      name:
+        en: Semantic AI
+        fr: IA sémantique
+      description:
+        en: Interprets meaning from text, speech, or images.
+        fr: Interprète le sens à partir de textes, de la parole ou d'images.
+      color: "#7B61FF"
+    - id: generative
+      name:
+        en: Generative AI
+        fr: IA générative
+      description:
+        en: Generates new content such as text, images, or code.
+        fr: Génère du nouveau contenu tel que du texte, des images ou du code.
+      color: "#F28C28"
+    - id: agentic
+      name:
+        en: Agentic AI
+        fr: IA agentique
+      description:
+        en: Takes autonomous actions on behalf of users or systems.
+        fr: Prend des actions autonomes au nom des utilisateurs ou des systèmes.
+      color: "#E74C3C"
+    - id: perceptive
+      name:
+        en: Perceptive AI
+        fr: IA perceptive
+      description:
+        en: Perceives the environment via sensors and signals.
+        fr: Perçoit l'environnement via des capteurs et des signaux.
+      color: "#2ECC71"
+    - id: physical
+      name:
+        en: Physical AI
+        fr: IA physique
+      description:
+        en: Controls physical movement and manipulation.
+        fr: Contrôle le mouvement physique et la manipulation.
+      color: "#95A5A6"
+updated_at: "2025-08-29T00:00:00Z"

--- a/app/content/dtpr.draft-2026-03/datachain_categories/purpose.yaml
+++ b/app/content/dtpr.draft-2026-03/datachain_categories/purpose.yaml
@@ -1,0 +1,18 @@
+dtpr_id: purpose
+name:
+  en: Purpose
+  fr: But
+description:
+  en: The purpose of this AI system.
+  fr: Le but de ce système d’IA.
+prompt:
+  en: What is the purpose of this AI system?
+  fr: Quel est le but de ce système d’IA ?
+required: true
+order: 2
+element_variables:
+  - id: additional_description
+    label:
+      en: Description
+      fr: Description
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/datachain_categories/retention.yaml
+++ b/app/content/dtpr.draft-2026-03/datachain_categories/retention.yaml
@@ -1,0 +1,23 @@
+dtpr_id: retention
+name:
+  en: Retention
+  fr: Rétention
+description:
+  en: The policies and practices governing the retention of data produced by the AI system.
+  fr: Les politiques et pratiques régissant la conservation des données produites par le système d’IA.
+prompt:
+  en: How long is the data kept?
+  fr: Combien de temps les données sont-elles conservées ?
+required: false
+order: 8
+element_variables:
+  - id: additional_description
+    label:
+      en: Description
+      fr: Description
+  - id: duration
+    label:
+      en: Duration
+      fr: Durée
+    required: true
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/datachain_categories/rights.yaml
+++ b/app/content/dtpr.draft-2026-03/datachain_categories/rights.yaml
@@ -1,0 +1,19 @@
+dtpr_id: rights
+name:
+  en: Rights
+  fr: Droits
+description:
+  en: The user's rights in relation to the AI system.
+  fr: Les droits de l'utilisateur par rapport au système d'IA.
+prompt:
+  en: What are the user's rights in relation to the AI system?
+  fr: Quels sont les droits de l’utilisateur par rapport au système d’IA ?
+required: false
+order: 11
+element_variables:
+  - id: rights
+    label:
+      en: Description of Rights
+      fr: Description des droits
+    required: true
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/datachain_categories/risks_mitigation.yaml
+++ b/app/content/dtpr.draft-2026-03/datachain_categories/risks_mitigation.yaml
@@ -1,0 +1,19 @@
+dtpr_id: risks_mitigation
+name:
+  en: Risks & Mitigation
+  fr: Risques et atténuation
+description:
+  en: The risks associated with this AI system and the mitigation strategies in place.
+  fr: Les risques associés à ce système d’IA et les stratégies d’atténuation en place.
+prompt:
+  en: What are the risks associated with this AI system and what mitigation strategies are in place?
+  fr: Quels sont les risques associés à ce système d’IA et quelles stratégies d’atténuation sont en place ?
+required: false
+order: 10
+element_variables:
+  - id: mitigation
+    label:
+      en: Description of Risks & Mitigations
+      fr: Description des risques et des mesures d'atténuation
+    required: true
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/datachain_categories/storage.yaml
+++ b/app/content/dtpr.draft-2026-03/datachain_categories/storage.yaml
@@ -1,0 +1,23 @@
+dtpr_id: storage
+name:
+  en: Data Storage
+  fr: Stockage de données
+description:
+  en: Where the data produced by the AI system is stored.
+  fr: Où sont stockées les données produites par le système d'IA.
+prompt:
+  en: Where is the data produced by the AI system stored?
+  fr: Où sont stockées les données produites par le système d’IA ?
+required: false
+order: 9
+element_variables:
+  - id: additional_description
+    label:
+      en: Description
+      fr: Description
+  - id: duration
+    label:
+      en: Duration
+      fr: Durée
+    required: true
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/accessibility.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/accessibility.yaml
@@ -1,0 +1,12 @@
+dtpr_id: accessibility
+category:
+  - purpose
+name:
+  en: Accessibility
+  fr: Accessibilité
+description:
+  en: Ensures that everyone has equal access to a space or a service.
+  fr: Garantit l'égalité d'accés de tous à un espace ou à un service.
+icon: /dtpr-icons/accessibility.svg
+symbol: /dtpr-icons/symbols/accessibility.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/agency_interaction.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/agency_interaction.yaml
@@ -1,0 +1,12 @@
+dtpr_id: agency_interaction
+category:
+  - purpose
+name:
+  en: Agency & Interaction
+  fr: Capacité à agir & Interaction
+description:
+  en: Enables you to control or interact with aspects of a space or a technology.
+  fr: Permet de contrôler ou d'interagir avec certains aspects d'un espace ou d'une technologie.
+icon: /dtpr-icons/agency_interaction.svg
+symbol: /dtpr-icons/symbols/agency_interaction.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/arts_culture.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/arts_culture.yaml
@@ -1,0 +1,12 @@
+dtpr_id: arts_culture
+category:
+  - purpose
+name:
+  en: Arts & Culture
+  fr: Arts et culture
+description:
+  en: Enables artistic and/or cultural expression.
+  fr: Permet l'expression artistique et/ou culturelle.
+icon: /dtpr-icons/arts_culture.svg
+symbol: /dtpr-icons/symbols/arts_culture.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/available_for_resale.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/available_for_resale.yaml
@@ -1,0 +1,12 @@
+dtpr_id: available_for_resale
+category:
+  - access
+name:
+  en: Available for resale
+  fr: Disponible à la revente
+description:
+  en: The data collected may be resold to other 3rd parties
+  fr: Les données collectées peuvent être revendues à d'autres tiers.
+icon: /dtpr-icons/available_for_resale.svg
+symbol: /dtpr-icons/symbols/available_for_resale.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/available_to_3rd_parties.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/available_to_3rd_parties.yaml
@@ -1,0 +1,12 @@
+dtpr_id: available_to_3rd_parties
+category:
+  - access
+name:
+  en: Available to 3rd parties
+  fr: Données mise à la disposition de tiers
+description:
+  en: Data is available to 3rd parties not involved in the data activity. This does not always mean that data is being resold.
+  fr: Les données sont disponibles pour des tiers non impliqués dans l'activité de données
+icon: /dtpr-icons/available_to_3rd_parties.svg
+symbol: /dtpr-icons/symbols/available_to_3rd_parties.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/available_to_download.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/available_to_download.yaml
@@ -1,0 +1,12 @@
+dtpr_id: available_to_download
+category:
+  - access
+name:
+  en: Available to download
+  fr: Disponible pour le téléchargement
+description:
+  en: Data that can be accessed and downloaded online, either for free or for a fee
+  fr: Des données qui peuvent être consultées et téléchargées en ligne.
+icon: /dtpr-icons/available_to_download.svg
+symbol: /dtpr-icons/symbols/available_to_download.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/available_to_me.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/available_to_me.yaml
@@ -1,0 +1,12 @@
+dtpr_id: available_to_me
+category:
+  - access
+name:
+  en: Available to me
+  fr: Disponible pour moi
+description:
+  en: Available to me but not to other individuals. For example, as an individual you have access to all your electronic toll records for your car, but other individuals do not have access to that.
+  fr: Disponible pour moi mais pas pour d'autres individus. Par exemple, en tant qu'individu, vous avez accés à tous vos enregistrements de péage électronique pour votre voiture, mais les autres individus n'y ont pas accés.
+icon: /dtpr-icons/available_to_me.svg
+symbol: /dtpr-icons/symbols/available.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/available_to_the_accountable_organization.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/available_to_the_accountable_organization.yaml
@@ -1,0 +1,12 @@
+dtpr_id: available_to_the_accountable_organization
+category:
+  - access
+name:
+  en: Available to the accountable organization
+  fr: Données mises à la disposition de l’organisation responsable
+description:
+  en: Data is available to the accountable organization
+  fr: Les données sont mises à disposition de l’organisation responsable
+icon: /dtpr-icons/available_to_the_accountable_organization.svg
+symbol: /dtpr-icons/symbols/available.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/available_to_vendor.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/available_to_vendor.yaml
@@ -1,0 +1,12 @@
+dtpr_id: available_to_vendor
+category:
+  - access
+name:
+  en: Available to vendor
+  fr: Disponible pour le vendeur
+description:
+  en: Data is available to the data collection or technology provider
+  fr: Les données sont disponibles pour le fournisseur de la collecte de données ou de la technologie
+icon: /dtpr-icons/available_to_vendor.svg
+symbol: /dtpr-icons/symbols/available.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/backed_up_internationally.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/backed_up_internationally.yaml
@@ -1,0 +1,12 @@
+dtpr_id: backed_up_internationally
+category:
+  - storage
+name:
+  en: Backed up internationally
+  fr: Sauvegardé à internationale
+description:
+  en: Data is backed up outside the jurisdiction where it was collected.
+  fr: Les données sont sauvegardées en dehors de la juridiction où elles ont été collectées.
+icon: /dtpr-icons/backed_up_internationally.svg
+symbol: /dtpr-icons/symbols/stored.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/backed_up_locally.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/backed_up_locally.yaml
@@ -1,0 +1,12 @@
+dtpr_id: backed_up_locally
+category:
+  - storage
+name:
+  en: Backed up locally
+  fr: Sauvegardé localement
+description:
+  en: Data is backed up with the jurisdiction where it was collected.
+  fr: Les données sont sauvegardées dans la juridiction où elles ont été collectées.
+icon: /dtpr-icons/backed_up_locally.svg
+symbol: /dtpr-icons/symbols/stored.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/binary.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/binary.yaml
@@ -1,0 +1,12 @@
+dtpr_id: binary
+category:
+  - data_flow
+name:
+  en: Binary
+  fr: Binaire
+description:
+  en: Compressed data into a binary format.
+  fr: Compression de données dans un format binaire.
+icon: /dtpr-icons/binary.svg
+symbol: /dtpr-icons/symbols/binary.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/boolean.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/boolean.yaml
@@ -1,0 +1,12 @@
+dtpr_id: boolean
+category:
+  - data_flow
+name:
+  en: Boolean
+  fr: Booléen
+description:
+  en: Data that has one of two data values, for example true and false.
+  fr: Données qui ont l'une des deux valeurs suivantes, par exemple vrai et faux.
+icon: /dtpr-icons/boolean.svg
+symbol: /dtpr-icons/symbols/boolean.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/commerce.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/commerce.yaml
@@ -1,0 +1,12 @@
+dtpr_id: commerce
+category:
+  - purpose
+name:
+  en: Commerce
+  fr: Commerce
+description:
+  en: Enables the buying and selling of goods and services.
+  fr: Permet l'achat et la vente de biens et de services.
+icon: /dtpr-icons/commerce.svg
+symbol: /dtpr-icons/symbols/commerce.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/compromise_of_privacy.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/compromise_of_privacy.yaml
@@ -1,0 +1,12 @@
+dtpr_id: compromise_of_privacy
+category:
+  - risks_mitigation
+name:
+  en: Compromise of privacy
+  fr: Compromission de la vie privée
+description:
+  en: The risk that the AI system could access, expose, or deduce private information about individuals without their consent. This includes risks of data breaches, misuse of collected data, or the system's ability to infer sensitive characteristics from seemingly non-sensitive inputs. Mitigations may include data minimization practices, robust security measures, differential privacy techniques, and rigorous access controls.
+  fr: Le risque que le système d'IA accède, expose ou déduise des informations privées sur des personnes sans leur consentement. Il s'agit notamment des risques de violation des données, d'utilisation abusive des données collectées ou de la capacité du système à déduire des caractéristiques sensibles à partir d'entrées apparemment non sensibles. Les mesures d'atténuation peuvent inclure des pratiques de minimisation des données, des mesures de sécurité robustes, des techniques de protection différentielle de la vie privée et des contrôles d'accès rigoureux.
+icon: /dtpr-icons/risks_compromise-of-privacy.svg
+symbol: /dtpr-icons/symbols/risks_compromise-of-privacy.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/connectivity.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/connectivity.yaml
@@ -1,0 +1,12 @@
+dtpr_id: connectivity
+category:
+  - purpose
+name:
+  en: Connectivity
+  fr: Accés à internet
+description:
+  en: Enables connectivity of devices to a digital network.
+  fr: Permettre la connexion à internet.
+icon: /dtpr-icons/connectivity.svg
+symbol: /dtpr-icons/symbols/connectivity.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/data_retained.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/data_retained.yaml
@@ -1,0 +1,12 @@
+dtpr_id: data_retained
+category:
+  - retention
+name:
+  en: Retained {{duration}}
+  fr: Retenu {{duration}}
+description:
+  en: Data is stored for {{duration}}, and after this time period is deleted
+  fr: Les données sont stockées pendant {{duration}} et sont supprimées après cette période.
+icon: /dtpr-icons/is_retained.svg
+symbol: /dtpr-icons/symbols/is_retained.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/dining.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/dining.yaml
@@ -1,0 +1,12 @@
+dtpr_id: dining
+category:
+  - purpose
+name:
+  en: Dining
+  fr: Restauration
+description:
+  en: For providing food or meal services.
+  fr: Pour la fourniture de services de restauration ou de repas.
+icon: /dtpr-icons/dining.svg
+symbol: /dtpr-icons/symbols/dining.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/ecology.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/ecology.yaml
@@ -1,0 +1,12 @@
+dtpr_id: ecology
+category:
+  - purpose
+name:
+  en: Ecology
+  fr: Écologie
+description:
+  en: Supports the measurement or monitoring of the natural environment.
+  fr: Permet la mesure ou la surveillance de l'environnement naturel.
+icon: /dtpr-icons/ecology.svg
+symbol: /dtpr-icons/symbols/ecology.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/energy_efficiency.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/energy_efficiency.yaml
@@ -1,0 +1,12 @@
+dtpr_id: energy_efficiency
+category:
+  - purpose
+name:
+  en: Energy Efficiency
+  fr: Efficacité énergétique
+description:
+  en: Reduces energy use and/or helps conserve energy.
+  fr: Réduit la consommation d'énergie et/ou aide à conserver l'énergie.
+icon: /dtpr-icons/energy_efficiency.svg
+symbol: /dtpr-icons/symbols/energy_efficiency.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/enforcement.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/enforcement.yaml
@@ -1,0 +1,12 @@
+dtpr_id: enforcement
+category:
+  - purpose
+name:
+  en: Enforcement
+  fr: Cadre légal
+description:
+  en: Used for enforcement of rules or regulations.
+  fr: Utilisé pour l'application de lois ou de réglements.
+icon: /dtpr-icons/enforcement.svg
+symbol: /dtpr-icons/symbols/enforcement.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/entry.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/entry.yaml
@@ -1,0 +1,12 @@
+dtpr_id: entry
+category:
+  - purpose
+name:
+  en: Entry
+  fr: Entrée
+description:
+  en: Supports authentication or validation in order to access a space or a service.
+  fr: Permet l'authentification ou la validation afin d'accéder à un espace ou à un service.
+icon: /dtpr-icons/entry.svg
+symbol: /dtpr-icons/symbols/entry.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/fire_emergency.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/fire_emergency.yaml
@@ -1,0 +1,12 @@
+dtpr_id: fire_emergency
+category:
+  - purpose
+name:
+  en: Fire & Emergency
+  fr: Incendie et urgence
+description:
+  en: Supports services that ensure public safety and health related to emergencies.
+  fr: Contribue au fonctionnement des services qui assurent la sécurité et la santé publiques en cas d'urgences.
+icon: /dtpr-icons/fire_emergency.svg
+symbol: /dtpr-icons/symbols/fire_emergency.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/function_creep.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/function_creep.yaml
@@ -1,0 +1,12 @@
+dtpr_id: function_creep
+category:
+  - risks_mitigation
+name:
+  en: Unforeseen Use or Function Creep
+  fr: Utilisation imprévue ou glissement de fonction
+description:
+  en: The risk that AI systems originally deployed for specific, limited purposes gradually expand in scope or are repurposed for applications beyond their original intent without proper evaluation or transparency. What begins as a system for one purpose (e.g., traffic management) might expand to others (e.g., law enforcement) without adequate assessment of new risks or public notification. This can undermine public trust and potentially lead to uses that weren't properly designed for or vetted.
+  fr: Le risque que des systèmes d'IA déployés à l'origine pour des objectifs spécifiques et limités voient leur champ d'application s'étendre progressivement ou soient réaffectés à des applications dépassant leur objectif initial, sans évaluation ni transparence adéquates. Ce qui commence comme un système destiné à un objectif (par exemple, la gestion du trafic) peut s'étendre à d'autres (par exemple, l'application de la loi) sans évaluation adéquate des nouveaux risques ou sans notification au public. Cela peut saper la confiance du public et conduire à des utilisations qui n'ont pas été correctement conçues ou approuvées.
+icon: /dtpr-icons/risks_unforseen-or-function-creep.svg
+symbol: /dtpr-icons/symbols/risks_unforseen-or-function-creep.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/functional_modes__agentic_ai.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/functional_modes__agentic_ai.yaml
@@ -1,0 +1,11 @@
+dtpr_id: agentic_ai
+category:
+  - functional_modes
+name:
+  en: Agentic AI
+  fr: IA agentique
+description:
+  en: '"Acts" — takes autonomous actions on behalf of users or systems, often chaining multiple steps. Examples include autonomous agents, workflow automation, and self-driving systems.'
+  fr: '"Agit" — prend des actions autonomes au nom des utilisateurs ou des systèmes, enchaînant souvent plusieurs étapes. Exemples : agents autonomes, automatisation de flux de travail et systèmes de conduite autonome.'
+icon: /dtpr-icons/functional_modes__agentic_ai.svg
+updated_at: "2025-08-29T00:00:00Z"

--- a/app/content/dtpr.draft-2026-03/elements/functional_modes__analytical_ai.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/functional_modes__analytical_ai.yaml
@@ -1,0 +1,11 @@
+dtpr_id: analytical_ai
+category:
+  - functional_modes
+name:
+  en: Analytical AI
+  fr: IA analytique
+description:
+  en: '"Decides" — analyzes data to produce decisions, predictions, or classifications. Examples include risk scoring, demand forecasting, and anomaly detection.'
+  fr: '"Décide" — analyse les données pour produire des décisions, des prédictions ou des classifications. Exemples : évaluation des risques, prévision de la demande et détection d''anomalies.'
+icon: /dtpr-icons/functional_modes__analytical_ai.svg
+updated_at: "2025-08-29T00:00:00Z"

--- a/app/content/dtpr.draft-2026-03/elements/functional_modes__generative_ai.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/functional_modes__generative_ai.yaml
@@ -1,0 +1,11 @@
+dtpr_id: generative_ai
+category:
+  - functional_modes
+name:
+  en: Generative AI
+  fr: IA générative
+description:
+  en: '"Creates" — generates new content such as text, images, audio, or code. Examples include large language models, image generators, and code assistants.'
+  fr: '"Crée" — génère du nouveau contenu tel que du texte, des images, de l''audio ou du code. Exemples : grands modèles de langage, générateurs d''images et assistants de code.'
+icon: /dtpr-icons/functional_modes__generative_ai.svg
+updated_at: "2025-08-29T00:00:00Z"

--- a/app/content/dtpr.draft-2026-03/elements/functional_modes__perceptive_ai.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/functional_modes__perceptive_ai.yaml
@@ -1,0 +1,11 @@
+dtpr_id: perceptive_ai
+category:
+  - functional_modes
+name:
+  en: Perceptive AI
+  fr: IA perceptive
+description:
+  en: '"Senses" — perceives the environment via sensors, cameras, or other signals. Examples include computer vision, LiDAR processing, and environmental monitoring.'
+  fr: '"Perçoit" — perçoit l''environnement via des capteurs, des caméras ou d''autres signaux. Exemples : vision par ordinateur, traitement LiDAR et surveillance environnementale.'
+icon: /dtpr-icons/functional_modes__perceptive_ai.svg
+updated_at: "2025-08-29T00:00:00Z"

--- a/app/content/dtpr.draft-2026-03/elements/functional_modes__physical_ai.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/functional_modes__physical_ai.yaml
@@ -1,0 +1,11 @@
+dtpr_id: physical_ai
+category:
+  - functional_modes
+name:
+  en: Physical AI
+  fr: IA physique
+description:
+  en: '"Moves" — controls physical movement, manipulation, or navigation in the real world. Examples include robotics, drone control, and automated manufacturing.'
+  fr: '"Bouge" — contrôle le mouvement physique, la manipulation ou la navigation dans le monde réel. Exemples : robotique, contrôle de drones et fabrication automatisée.'
+icon: /dtpr-icons/functional_modes__physical_ai.svg
+updated_at: "2025-08-29T00:00:00Z"

--- a/app/content/dtpr.draft-2026-03/elements/functional_modes__semantic_ai.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/functional_modes__semantic_ai.yaml
@@ -1,0 +1,11 @@
+dtpr_id: semantic_ai
+category:
+  - functional_modes
+name:
+  en: Semantic AI
+  fr: IA sémantique
+description:
+  en: '"Understands" — interprets meaning from text, speech, or images. Examples include natural language processing, sentiment analysis, and speech recognition.'
+  fr: '"Comprend" — interprète le sens à partir de textes, de la parole ou d''images. Exemples : traitement du langage naturel, analyse de sentiment et reconnaissance vocale.'
+icon: /dtpr-icons/functional_modes__semantic_ai.svg
+updated_at: "2025-08-29T00:00:00Z"

--- a/app/content/dtpr.draft-2026-03/elements/health.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/health.yaml
@@ -1,0 +1,12 @@
+dtpr_id: health
+category:
+  - purpose
+name:
+  en: Health
+  fr: Santé
+description:
+  en: Supports the measurement or monitoring of the aspects of the physical environment that impacts human health, such as radiation or air quality, or in specific contexts such as the workplace.
+  fr: "Permet la mesure ou la surveillance des aspects de l'environnement physique qui ont un impact sur la santé humaine, comme les [rayonnements](https://fr.wikipedia.org/wiki/Radioprotection) ou la [qualité de l'air](https://fr.wikipedia.org/wiki/Pollution_de_l%27air), ou dans des contextes spécifiques comme le lieu de travail. Pour en savoir plus sur [la surveillance de l'environnement](https://fr.wikipedia.org/wiki/Observatoire_de_l%27environnement) et [la santé et la sécurité au travail](https://fr.wikipedia.org/wiki/Santé_et_sécurité_au_travail) "
+icon: /dtpr-icons/health.svg
+symbol: /dtpr-icons/symbols/health.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/inform.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/inform.yaml
@@ -1,0 +1,12 @@
+dtpr_id: inform
+category:
+  - purpose
+name:
+  en: Inform
+  fr: Informer
+description:
+  en: Supports the provision of information, for example about a location, a service, or to provide assistance
+  fr: Permet de fournir des informations, par exemple sur un lieu ou un service, ou de fournir une assistance.
+icon: /dtpr-icons/inform.svg
+symbol: /dtpr-icons/symbols/light_waves.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/institution.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/institution.yaml
@@ -1,0 +1,12 @@
+dtpr_id: institution
+category:
+  - accountable
+name:
+  en: Institution
+  fr: Institution
+description:
+  en: The entity that is responsible and accountable for this data collection activity
+  fr: L'entité qui est responsable et redevable de cette activité de collecte de données
+icon: /dtpr-icons/institution.svg
+symbol: /dtpr-icons/symbols/institution.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/logistics.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/logistics.yaml
@@ -1,0 +1,12 @@
+dtpr_id: logistics
+category:
+  - purpose
+name:
+  en: Logistics
+  fr: Logistique
+description:
+  en: Supports the movements of goods or materials.
+  fr: Favorise la circulation des marchandises ou des matériaux.
+icon: /dtpr-icons/logistics.svg
+symbol: /dtpr-icons/symbols/logistics.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/mobility.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/mobility.yaml
@@ -1,0 +1,12 @@
+dtpr_id: mobility
+category:
+  - purpose
+name:
+  en: Mobility
+  fr: Mobilité
+description:
+  en: Supports how people and materials move around.
+  fr: Contribue à la maniére dont les personnes et les matériaux se déplacent.
+icon: /dtpr-icons/mobility.svg
+symbol: /dtpr-icons/symbols/mobility.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/no_data_retained.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/no_data_retained.yaml
@@ -1,0 +1,12 @@
+dtpr_id: no_data_retained
+category:
+  - retention
+name:
+  en: No data retained
+  fr: Aucune donnée conservée
+description:
+  en: No data is kept or stored
+  fr: Aucune donnée n'est conservée ou stockée
+icon: /dtpr-icons/no_data_retained.svg
+symbol: /dtpr-icons/symbols/no_data_retained.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/not_available_to_me.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/not_available_to_me.yaml
@@ -1,0 +1,12 @@
+dtpr_id: not_available_to_me
+category:
+  - access
+name:
+  en: Not available to me
+  fr: Non disponible pour moi
+description:
+  en: Not available to me or other individuals. As an individual, there isn't a way for you to access this data.
+  fr: Non disponible pour moi ou d'autres individus. En tant qu'individu, il n'y a aucun moyen pour vous d'accéder à ces données.
+icon: /dtpr-icons/not_available_to_me.svg
+symbol: /dtpr-icons/symbols/not_available.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/not_available_to_the_accountable_organization.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/not_available_to_the_accountable_organization.yaml
@@ -1,0 +1,12 @@
+dtpr_id: not_available_to_the_accountable_organization
+category:
+  - access
+name:
+  en: Not available to the accountable organization
+  fr: Non disponible pour l'organisation responsable
+description:
+  en: Data is not available to the accountable organization
+  fr: Les données ne sont pas disponibles pour l'organisation responsable
+icon: /dtpr-icons/not_available_to_the_accountable_organization.svg
+symbol: /dtpr-icons/symbols/not_available.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/not_available_to_vendor.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/not_available_to_vendor.yaml
@@ -1,0 +1,12 @@
+dtpr_id: not_available_to_vendor
+category:
+  - access
+name:
+  en: Not available to vendor
+  fr: Non disponible pour le vendeur
+description:
+  en: Data is not available to the data collection or technology provider.
+  fr: Les données ne sont pas disponibles pour le fournisseur de la collecte de données ou de la technologie.
+icon: /dtpr-icons/not_available_to_vendor.svg
+symbol: /dtpr-icons/symbols/not_available.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/opaque_decision_making.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/opaque_decision_making.yaml
@@ -1,0 +1,12 @@
+dtpr_id: opaque_decision_making
+category:
+  - risks_mitigation
+name:
+  en: Opaque decision-making
+  fr: Prise de décision opaque
+description:
+  en: The risk that AI systems make decisions through processes that are difficult or impossible for humans to understand or explain. This lack of transparency makes it challenging to identify errors, biases, or other issues. Mitigations may include using interpretable AI models when possible, developing explanation methods, and maintaining documentation of system design and training processes.
+  fr: Le risque que les systèmes d'IA prennent des décisions par le biais de processus qu'il est difficile, voire impossible, pour les humains de comprendre ou d'expliquer. Ce manque de transparence rend difficile l'identification des erreurs, des biais ou d'autres problèmes. Les mesures d'atténuation peuvent comprendre l'utilisation de modèles d'IA interprétables lorsque cela est possible, l'élaboration de méthodes d'explication et la tenue d'une documentation sur la conception du système et les processus de formation.
+icon: /dtpr-icons/risks_opaque-decision-making.svg
+symbol: /dtpr-icons/symbols/risks_opaque-decision-making.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/organization.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/organization.yaml
@@ -1,0 +1,12 @@
+dtpr_id: organization
+category:
+  - accountable
+name:
+  en: Organization
+  fr: Organisation
+description:
+  en: The entity that is responsible and accountable for this data collection activity
+  fr: L'entité qui est responsable et redevable de cette activité de collecte de données
+icon: /dtpr-icons/organization.svg
+symbol: /dtpr-icons/symbols/organization.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/overreliance_automation_bias.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/overreliance_automation_bias.yaml
@@ -1,0 +1,12 @@
+dtpr_id: overreliance_automation_bias
+category:
+  - risks_mitigation
+name:
+  en: Over-reliance and automation bias
+  fr: Dépendance excessive et biais d'automatisation
+description:
+  en: The risk that people place excessive trust in AI systems, leading to insufficient human oversight or inability to question algorithmic decisions. This can result in uncritical acceptance of AI outputs even when they are incorrect or harmful. Mitigations may include clear communication about system limitations, training for users on appropriate reliance, and maintaining meaningful human involvement in critical decisions.
+  fr: Le risque que les gens accordent une confiance excessive aux systèmes d'IA, conduisant à une surveillance humaine insuffisante ou à l'incapacité de remettre en question les décisions algorithmiques. Il peut en résulter une acceptation non critique des résultats de l'IA, même lorsqu'ils sont incorrects ou nuisibles. Les mesures d'atténuation peuvent inclure une communication claire sur les limites du système, la formation des utilisateurs à une confiance appropriée et le maintien d'une participation humaine significative dans les décisions critiques.
+icon: /dtpr-icons/risks_overreliance-and-automation.svg
+symbol: /dtpr-icons/symbols/risks_overreliance-and-automation.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/personal.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/personal.yaml
@@ -1,0 +1,12 @@
+dtpr_id: personal
+category:
+  - data_flow
+name:
+  en: Personal
+  fr: Personnel
+description:
+  en: Information about identifiable individuals.
+  fr: Informations sur des personnes identifiables.
+icon: /dtpr-icons/personal.svg
+symbol: /dtpr-icons/symbols/personal.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/pixel_based_image.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/pixel_based_image.yaml
@@ -1,0 +1,12 @@
+dtpr_id: pixel_based_image
+category:
+  - data_flow
+name:
+  en: Pixel-based Image
+  fr: Image basée sur les pixels
+description:
+  en: A digital image is composed of a grid of individual pixels.
+  fr: Une image numérique est composée d'une grille de pixels individuels.
+icon: /dtpr-icons/pixel_based_image.svg
+symbol: /dtpr-icons/symbols/pixel_based_image.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/planning_decision_making.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/planning_decision_making.yaml
@@ -1,0 +1,12 @@
+dtpr_id: planning_decision_making
+category:
+  - purpose
+name:
+  en: Planning & Decision-making
+  fr: Planification et prise de décision
+description:
+  en: Supports the development of future plans; or to enable or measure the impact of a decision.
+  fr: "Aide à l'élaboration de plans futurs, ou à la mesure de l'impact d'une décision. Exemples : urbanisme"
+icon: /dtpr-icons/planning_decision_making.svg
+symbol: /dtpr-icons/symbols/planning_decision_making.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/research_development.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/research_development.yaml
@@ -1,0 +1,12 @@
+dtpr_id: research_development
+category:
+  - purpose
+name:
+  en: Research & Development
+  fr: Recherche et développement
+description:
+  en: Supports exploratory research and testing.
+  fr: Favorise la recherche exploratoire et les tests.
+icon: /dtpr-icons/research_development.svg
+symbol: /dtpr-icons/symbols/research_development.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/right_access.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/right_access.yaml
@@ -1,0 +1,12 @@
+dtpr_id: right_access
+category:
+  - rights
+name:
+  en: Right to Access
+  fr: Droit d'accès
+description:
+  en: The right to request and receive information about what personal data an AI system has collected about you, how this data is being used, and what decisions have been made using this information. This includes the right to obtain a copy of your data in a readable format.
+  fr: Le droit de demander et de recevoir des informations sur les données à caractère personnel qu'un système d'IA a collectées à votre sujet, sur la manière dont ces données sont utilisées et sur les décisions qui ont été prises sur la base de ces informations. Cela inclut le droit d'obtenir une copie de vos données dans un format lisible.
+icon: /dtpr-icons/rights_access.svg
+symbol: /dtpr-icons/symbols/rights_access.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/right_algorithmic_transparency.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/right_algorithmic_transparency.yaml
@@ -1,0 +1,12 @@
+dtpr_id: right_algorithmic_transparency
+category:
+  - rights
+name:
+  en: Right to Algorithmic Transparency
+  fr: Droit à la transparence algorithmique
+description:
+  en: The right to understand how an AI system makes decisions that affect you, including meaningful information about the logic involved, the significance of the processing, and the likely consequences. This information should be provided in clear, plain language that allows you to understand how the system works and how it arrived at a particular decision.
+  fr: Le droit de comprendre comment un système d'IA prend des décisions qui vous affectent, y compris des informations significatives sur la logique impliquée, la signification du traitement et les conséquences probables. Ces informations doivent être fournies dans un langage clair et simple qui vous permette de comprendre comment le système fonctionne et comment il est parvenu à une décision particulière.
+icon: /dtpr-icons/rights_algorithmic-transparency.svg
+symbol: /dtpr-icons/symbols/rights_algorithmic-transparency.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/right_be_forgotten.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/right_be_forgotten.yaml
@@ -1,0 +1,12 @@
+dtpr_id: right_be_forgotten
+category:
+  - rights
+name:
+  en: Right to Be Forgotten
+  fr: Droit à l'oubli
+description:
+  en: The right to request the deletion of your personal data from an AI system under certain conditions, such as when the data is no longer necessary for its original purpose, when you withdraw consent, or when there is no legitimate interest in continuing to process it. This includes the right to have the system "unlearn" information derived from your data where technically feasible.
+  fr: Le droit de demander l'effacement de vos données à caractère personnel d'un système d'IA dans certaines conditions, par exemple lorsque les données ne sont plus nécessaires à leur finalité initiale, lorsque vous retirez votre consentement ou lorsqu'il n'y a pas d'intérêt légitime à continuer de les traiter. Cela inclut le droit de demander au système de "désapprendre" les informations dérivées de vos données lorsque cela est techniquement possible.
+icon: /dtpr-icons/rights_forgotten.svg
+symbol: /dtpr-icons/symbols/rights_forgotten.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/right_contest.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/right_contest.yaml
@@ -1,0 +1,12 @@
+dtpr_id: right_contest
+category:
+  - rights
+name:
+  en: Right to Contest
+  fr: Droit de contestation
+description:
+  en: The right to challenge decisions made by an AI system that affect you, particularly when these decisions have legal or similarly significant effects. This includes the right to request human review of automated decisions, provide additional information, express your point of view, and have the decision reconsidered based on your input.
+  fr: Le droit de contester les décisions prises par un système d'IA qui vous concernent, en particulier lorsque ces décisions ont des effets juridiques ou des effets similaires importants. Cela inclut le droit de demander un examen humain des décisions automatisées, de fournir des informations supplémentaires, d'exprimer votre point de vue et d'obtenir que la décision soit réexaminée sur la base de votre contribution.
+icon: /dtpr-icons/rights_contest.svg
+symbol: /dtpr-icons/symbols/rights_contest.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/right_non_discrimination.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/right_non_discrimination.yaml
@@ -1,0 +1,12 @@
+dtpr_id: right_non_discrimination
+category:
+  - rights
+name:
+  en: Right to Non-discrimination
+  fr: Droit à la non-discrimination
+description:
+  en: The right to be free from discriminatory treatment by AI systems based on protected characteristics such as race, gender, age, religion, disability, or sexual orientation. Organizations must implement and demonstrate appropriate technical and organizational measures to prevent discriminatory outcomes from their AI systems.
+  fr: Le droit de ne pas être traité de manière discriminatoire par les systèmes d'IA sur la base de caractéristiques protégées telles que la race, le sexe, l'âge, la religion, le handicap ou l'orientation sexuelle. Les organisations doivent mettre en œuvre et démontrer des mesures techniques et organisationnelles appropriées pour éviter que leurs systèmes d'IA ne produisent des résultats discriminatoires.
+icon: /dtpr-icons/rights_non-discrimination.svg
+symbol: /dtpr-icons/symbols/rights_non-discrimination.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/right_purpose_limitation.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/right_purpose_limitation.yaml
@@ -1,0 +1,12 @@
+dtpr_id: right_purpose_limitation
+category:
+  - rights
+name:
+  en: Right to Purpose Limitation
+  fr: Limitation du droit à l'objet
+description:
+  en: The right to ensure your data is only used for the specific purposes that were clearly stated when it was collected. This prevents organizations from using your data for new, unrelated purposes without your knowledge or consent. The data collector must specify and document the intended purposes before collection begins, and adhere to these limitations.
+  fr: Le droit de s'assurer que vos données ne sont utilisées qu'aux fins spécifiques qui ont été clairement énoncées lors de leur collecte. Cela empêche les organisations d'utiliser vos données à des fins nouvelles et sans rapport avec celles-ci, sans que vous en soyez informé ou que vous y consentiez. Le collecteur de données doit préciser et documenter les finalités prévues avant le début de la collecte et respecter ces limitations.
+icon: /dtpr-icons/rights_purpose-limitation.svg
+symbol: /dtpr-icons/symbols/rights_purpose-limitation.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/safety_security.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/safety_security.yaml
@@ -1,0 +1,12 @@
+dtpr_id: safety_security
+category:
+  - purpose
+name:
+  en: Safety & Security
+  fr: Tranquillité Prévention
+description:
+  en: Enables a safe and/or secure environment, for example for the purposes of fire safety, home security or ensuring safe passage in places such as airports or roads
+  fr: Permet de créer un environnement sór et/ou sécurisé, par exemple à des fins de sécurité incendie, de détection des intrusions ou pour assurer la sécurité du passage dans des lieux tels que les aéroports ou les routes.
+icon: /dtpr-icons/safety_security.svg
+symbol: /dtpr-icons/symbols/safety_security.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/shared_storage_and_governance.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/shared_storage_and_governance.yaml
@@ -1,0 +1,12 @@
+dtpr_id: shared_storage_and_governance
+category:
+  - storage
+name:
+  en: Shared storage and governance
+  fr: Stockage et gouvernance partagés
+description:
+  en: In a shared data store model the data store is shared across multiple parties and because the infrastructure is shared it becomes possible to enforce governance around the retention, access and destruction of the data by policies built into the structure of the data itself.
+  fr: Dans un modéle de magasin de données partagé, le magasin de données est partagé entre plusieurs parties et, comme l'infrastructure est partagée, il devient possible d'appliquer la gouvernance autour de la conservation, de l'accés et de la destruction des données par des politiques intégrées à la structure des données elles-mêmes.
+icon: /dtpr-icons/shared_storage_and_governance.svg
+symbol: /dtpr-icons/symbols/stored.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/social.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/social.yaml
@@ -1,0 +1,12 @@
+dtpr_id: social
+category:
+  - purpose
+name:
+  en: Social
+  fr: Social
+description:
+  en: For interacting with another person or a group.
+  fr: Pour interagir avec une autre personne ou un groupe.
+icon: /dtpr-icons/social.svg
+symbol: /dtpr-icons/symbols/social.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/spatial.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/spatial.yaml
@@ -1,0 +1,12 @@
+dtpr_id: spatial
+category:
+  - data_flow
+name:
+  en: Spatial
+  fr: Spatial
+description:
+  en: Data that represents a location, such as an address, a place name or geographic coordinates; or a structure, such as a floorplan.
+  fr: Données qui représentent un emplacement, comme une adresse, un nom de lieu ou des coordonnées géographiques ou encore une structure, comme un plan d'étage.
+icon: /dtpr-icons/spatial.svg
+symbol: /dtpr-icons/symbols/spatial.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/stored_locally.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/stored_locally.yaml
@@ -1,0 +1,12 @@
+dtpr_id: stored_locally
+category:
+  - storage
+name:
+  en: Stored locally
+  fr: Stocké localement
+description:
+  en: Data is stored in the jurisdiction where it was collected.
+  fr: Les données sont stockées dans une zone soumise aux mêmes lois que celle où elles sont collectées.
+icon: /dtpr-icons/stored_locally.svg
+symbol: /dtpr-icons/symbols/stored.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/stored_on_3rd_party_cloud.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/stored_on_3rd_party_cloud.yaml
@@ -1,0 +1,12 @@
+dtpr_id: stored_on_3rd_party_cloud
+category:
+  - storage
+name:
+  en: Stored on 3rd Party Cloud
+  fr: Stocké sur un cloud tiers
+description:
+  en: Data is stored on behalf of the organization or the data collector in an off-site data centre, such as Amazon Web Services, Google Cloud and Microsoft Azure
+  fr: Les données sont stockées au nom de l'organisation ou du collecteur de données dans un centre de données hors site.
+icon: /dtpr-icons/stored_on_3rd_party_cloud.svg
+symbol: /dtpr-icons/symbols/stored.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/stored_primarily_internationally.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/stored_primarily_internationally.yaml
@@ -1,0 +1,12 @@
+dtpr_id: stored_primarily_internationally
+category:
+  - storage
+name:
+  en: Stored primarily internationally
+  fr: Stockés principalement à l'international
+description:
+  en: Data is stored outside the jurisdiction where it was collected.
+  fr: Les données sont stockées en dehors de la juridiction où elles ont été collectées.
+icon: /dtpr-icons/stored_primarily_internationally.svg
+symbol: /dtpr-icons/symbols/stored.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/stored_primarily_locally.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/stored_primarily_locally.yaml
@@ -1,0 +1,12 @@
+dtpr_id: stored_primarily_locally
+category:
+  - storage
+name:
+  en: Stored primarily locally
+  fr: Stocké principalement localement
+description:
+  en: Data is stored mainly in the jurisdiction where it was collected.
+  fr: Les données sont stockées principalement dans la juridiction où elles ont été collectées.
+icon: /dtpr-icons/stored_primarily_locally.svg
+symbol: /dtpr-icons/symbols/stored.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/switch.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/switch.yaml
@@ -1,0 +1,12 @@
+dtpr_id: switch
+category:
+  - purpose
+name:
+  en: Switch
+  fr: Interrupteur
+description:
+  en: Supports a mechanical function - such as turning a device on or off, opening or closing, or adjusting brightness and intensity.
+  fr: Prend en charge une fonction mécanique - comme la mise en marche ou l'arrêt d'un appareil, son ouverture ou sa fermeture, ou le réglage de la luminosité et de l'intensité.
+icon: /dtpr-icons/switch_tech.svg
+symbol: /dtpr-icons/symbols/switch_tech.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/system_drift.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/system_drift.yaml
@@ -1,0 +1,12 @@
+dtpr_id: system_drift
+category:
+  - risks_mitigation
+name:
+  en: System Drift and Temporal Validity
+  fr: Dérive du système et validité temporelle
+description:
+  en: The risk that an AI system's performance degrades over time as real-world conditions change from those present in training data. This occurs when the relationships between variables in the real world evolve, but the model remains static, leading to increasingly inaccurate outputs. Examples include urban planning models that don't account for demographic shifts or transportation patterns that change seasonally or with new infrastructure.
+  fr: Le risque que les performances d'un système d'IA se dégradent au fil du temps lorsque les conditions du monde réel changent par rapport à celles présentes dans les données d'apprentissage. Cela se produit lorsque les relations entre les variables du monde réel évoluent, mais que le modèle reste statique, ce qui conduit à des résultats de plus en plus imprécis. Parmi les exemples, citons les modèles de planification urbaine qui ne tiennent pas compte des changements démographiques ou des schémas de transport qui changent au fil des saisons ou avec l'arrivée de nouvelles infrastructures.
+icon: /dtpr-icons/risks_system-drift-and-temporal-validity.svg
+symbol: /dtpr-icons/symbols/risks_system-drift-and-temporal-validity.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/tabular.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/tabular.yaml
@@ -1,0 +1,12 @@
+dtpr_id: tabular
+category:
+  - data_flow
+name:
+  en: Tabular
+  fr: Tabulaire
+description:
+  en: Data that is stored in a table, where values are stored in rows and columns.
+  fr: Données stockées dans un tableau, où les valeurs sont stockées en lignes et en colonnes.
+icon: /dtpr-icons/tabular.svg
+symbol: /dtpr-icons/symbols/tabular.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/unequal_performance.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/unequal_performance.yaml
@@ -1,0 +1,12 @@
+dtpr_id: unequal_performance
+category:
+  - risks_mitigation
+name:
+  en: Unequal performance across groups
+  fr: Des performances inégales entre les groupes
+description:
+  en: The risk that the AI system performs differently (typically worse) for certain demographic groups based on characteristics such as race, gender, age, disability status, or socioeconomic background. This can lead to biased or unfair outcomes that disproportionately impact vulnerable communities. Mitigations may include diverse training data, routine fairness audits, and regular performance monitoring across different demographic groups.
+  fr: Le risque que le système d'IA fonctionne différemment (généralement moins bien) pour certains groupes démographiques sur la base de caractéristiques telles que la race, le sexe, l'âge, le statut de handicapé ou le contexte socio-économique. Cela peut conduire à des résultats biaisés ou injustes qui ont un impact disproportionné sur les communautés vulnérables. Les mesures d'atténuation peuvent inclure des données de formation diversifiées, des audits d'équité de routine et un contrôle régulier des performances au sein de différents groupes démographiques.
+icon: /dtpr-icons/risks_unequal-performance.svg
+symbol: /dtpr-icons/symbols/risks_unequal-performance.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/values_time.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/values_time.yaml
@@ -1,0 +1,12 @@
+dtpr_id: values_time
+category:
+  - data_flow
+name:
+  en: Values / Time
+  fr: Valeurs / Temps
+description:
+  en: Measurements that are collected at regular intervals over a period of time.
+  fr: Mesures recueillies à intervalles réguliers sur une période de temps donnée.
+icon: /dtpr-icons/values_time.svg
+symbol: /dtpr-icons/symbols/values_time.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/waste_management.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/waste_management.yaml
@@ -1,0 +1,12 @@
+dtpr_id: waste_management
+category:
+  - purpose
+name:
+  en: Waste Management
+  fr: Gestion des déchets
+description:
+  en: Supports the handling and disposal of waste, including as recyclables, compost and hazardous materials.
+  fr: Contribue à la manipulation et l'élimination des déchets, y compris les matiéres recyclables, le compost et les matiéres dangereuses.
+icon: /dtpr-icons/waste_management.svg
+symbol: /dtpr-icons/symbols/waste_management.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/water_efficiency.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/water_efficiency.yaml
@@ -1,0 +1,12 @@
+dtpr_id: water_efficiency
+category:
+  - purpose
+name:
+  en: Water Efficiency
+  fr: Efficacité de l'eau
+description:
+  en: Reduces water use and/or helps conserve water.
+  fr: Réduit la consommation d'eau et/ou contribue à sa conservation. Pour en savoir plus sur l'efficacité et la conservation de l'eau, ainsi que sur l'infrastructure verte.
+icon: /dtpr-icons/water_efficiency.svg
+symbol: /dtpr-icons/symbols/water_efficiency.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/content/dtpr.draft-2026-03/elements/wayfinding_services.yaml
+++ b/app/content/dtpr.draft-2026-03/elements/wayfinding_services.yaml
@@ -1,0 +1,12 @@
+dtpr_id: wayfinding_services
+category:
+  - purpose
+name:
+  en: Wayfinding & Services
+  fr: Signalisation et services
+description:
+  en: Enables navigation of a location and its amenities and services.
+  fr: Permet la navigation d'un lieu et de ses équipements et services.
+icon: /dtpr-icons/wayfinding_services.svg
+symbol: /dtpr-icons/symbols/light_waves.svg
+updated_at: 2025-08-29T00:00:00.000Z

--- a/app/server/api/dtpr/draft-2026-03/datachain-categories.ts
+++ b/app/server/api/dtpr/draft-2026-03/datachain-categories.ts
@@ -1,0 +1,74 @@
+import { getQuery } from 'h3'
+import type { SchemaMetadata, DatachainCategory, LocaleMap, ElementVariable, Context, ContextValue } from './types'
+import { parseLocalesQuery, calculateLatestVersion, filterLocaleMap } from './utils'
+
+interface CategoryResponse {
+  schema: SchemaMetadata
+  category: DatachainCategory
+}
+
+export default eventHandler(async (event) => {
+  const query = getQuery(event)
+  const requestedLocales = parseLocalesQuery(query)
+
+  const categories = await queryCollection(event, 'draft_2026_03_datachain_categories').all()
+
+  const results: CategoryResponse[] = categories.map((raw: any) => {
+    const category: DatachainCategory = {
+      id: raw.dtpr_id,
+      name: filterLocaleMap(raw.name, requestedLocales),
+      description: filterLocaleMap(raw.description, requestedLocales),
+      prompt: filterLocaleMap(raw.prompt, requestedLocales),
+      version: raw.updated_at || new Date().toISOString(),
+    }
+
+    if (raw.required !== undefined) category.required = raw.required
+    if (raw.order !== undefined) category.order = raw.order
+
+    if (raw.element_variables) {
+      category.element_variables = raw.element_variables.map((v: any): ElementVariable => {
+        const variable: ElementVariable = { id: v.id }
+        if (v.label) variable.label = filterLocaleMap(v.label, requestedLocales)
+        if (v.required !== undefined) variable.required = v.required
+        if (v.type) variable.type = v.type
+        return variable
+      })
+    }
+
+    if (raw.context) {
+      category.context = {
+        id: raw.context.id,
+        name: filterLocaleMap(raw.context.name, requestedLocales),
+        description: filterLocaleMap(raw.context.description, requestedLocales),
+        values: raw.context.values.map((v: any): ContextValue => ({
+          id: v.id,
+          name: filterLocaleMap(v.name, requestedLocales),
+          description: filterLocaleMap(v.description, requestedLocales),
+          color: v.color,
+        })),
+      }
+    }
+
+    return {
+      schema: {
+        name: 'DTPR Category',
+        id: 'dtpr_category',
+        version: '0.1',
+        namespace: 'https://dtpr.io/schemas/draft-2026-03/category',
+      },
+      category,
+    }
+  })
+
+  // Sort by order field; categories without order go to the end
+  results.sort((a, b) => {
+    if (a.category.order !== undefined && b.category.order !== undefined) {
+      return a.category.order - b.category.order
+    }
+    if (a.category.order !== undefined) return -1
+    if (b.category.order !== undefined) return 1
+    return 0
+  })
+
+  return results
+})

--- a/app/server/api/dtpr/draft-2026-03/elements.ts
+++ b/app/server/api/dtpr/draft-2026-03/elements.ts
@@ -1,0 +1,40 @@
+import { getQuery } from 'h3'
+import type { SchemaMetadata, Element } from './types'
+import { parseLocalesQuery, filterLocaleMap } from './utils'
+
+interface ElementResponse {
+  schema: SchemaMetadata
+  element: Element
+}
+
+export default eventHandler(async (event) => {
+  const query = getQuery(event)
+  const requestedLocales = parseLocalesQuery(query)
+
+  const elements = await queryCollection(event, 'draft_2026_03_elements').all()
+
+  const results: ElementResponse[] = elements.map((raw: any) => {
+    const element: Element = {
+      id: raw.dtpr_id,
+      category: raw.category,
+      name: filterLocaleMap(raw.name, requestedLocales),
+      description: filterLocaleMap(raw.description, requestedLocales),
+      icon: raw.icon,
+      version: raw.updated_at || new Date().toISOString(),
+    }
+
+    if (raw.symbol) element.symbol = raw.symbol
+
+    return {
+      schema: {
+        name: 'DTPR Element',
+        id: 'dtpr_element',
+        version: '0.1',
+        namespace: 'https://dtpr.io/schemas/draft-2026-03/element',
+      },
+      element,
+    }
+  })
+
+  return results
+})

--- a/app/server/api/dtpr/draft-2026-03/taxonomy.ts
+++ b/app/server/api/dtpr/draft-2026-03/taxonomy.ts
@@ -1,0 +1,110 @@
+import { getQuery } from 'h3'
+import type { SchemaMetadata, DatachainCategory, Element, LocaleMap, ElementVariable, ContextValue } from './types'
+import { parseLocalesQuery, filterLocaleMap } from './utils'
+
+interface CategoryResponse {
+  schema: SchemaMetadata
+  category: DatachainCategory
+}
+
+interface ElementResponse {
+  schema: SchemaMetadata
+  element: Element
+}
+
+interface TaxonomyResponse {
+  datachain_categories: CategoryResponse[]
+  elements: ElementResponse[]
+}
+
+export default eventHandler(async (event): Promise<TaxonomyResponse> => {
+  const query = getQuery(event)
+  const requestedLocales = parseLocalesQuery(query)
+
+  const [rawCategories, rawElements] = await Promise.all([
+    queryCollection(event, 'draft_2026_03_datachain_categories').all(),
+    queryCollection(event, 'draft_2026_03_elements').all(),
+  ])
+
+  const datachain_categories: CategoryResponse[] = rawCategories.map((raw: any) => {
+    const category: DatachainCategory = {
+      id: raw.dtpr_id,
+      name: filterLocaleMap(raw.name, requestedLocales),
+      description: filterLocaleMap(raw.description, requestedLocales),
+      prompt: filterLocaleMap(raw.prompt, requestedLocales),
+      version: raw.updated_at || new Date().toISOString(),
+    }
+
+    if (raw.required !== undefined) category.required = raw.required
+    if (raw.order !== undefined) category.order = raw.order
+
+    if (raw.element_variables) {
+      category.element_variables = raw.element_variables.map((v: any): ElementVariable => {
+        const variable: ElementVariable = { id: v.id }
+        if (v.label) variable.label = filterLocaleMap(v.label, requestedLocales)
+        if (v.required !== undefined) variable.required = v.required
+        if (v.type) variable.type = v.type
+        return variable
+      })
+    }
+
+    if (raw.context) {
+      category.context = {
+        id: raw.context.id,
+        name: filterLocaleMap(raw.context.name, requestedLocales),
+        description: filterLocaleMap(raw.context.description, requestedLocales),
+        values: raw.context.values.map((v: any): ContextValue => ({
+          id: v.id,
+          name: filterLocaleMap(v.name, requestedLocales),
+          description: filterLocaleMap(v.description, requestedLocales),
+          color: v.color,
+        })),
+      }
+    }
+
+    return {
+      schema: {
+        name: 'DTPR Category',
+        id: 'dtpr_category',
+        version: '0.1',
+        namespace: 'https://dtpr.io/schemas/draft-2026-03/category',
+      },
+      category,
+    }
+  })
+
+  // Sort categories by order
+  datachain_categories.sort((a, b) => {
+    if (a.category.order !== undefined && b.category.order !== undefined) {
+      return a.category.order - b.category.order
+    }
+    if (a.category.order !== undefined) return -1
+    if (b.category.order !== undefined) return 1
+    return 0
+  })
+
+  const elements: ElementResponse[] = rawElements.map((raw: any) => {
+    const element: Element = {
+      id: raw.dtpr_id,
+      category: raw.category,
+      name: filterLocaleMap(raw.name, requestedLocales),
+      description: filterLocaleMap(raw.description, requestedLocales),
+      icon: raw.icon,
+      version: raw.updated_at || new Date().toISOString(),
+    }
+
+    if (raw.symbol) element.symbol = raw.symbol
+
+    return {
+      schema: {
+        name: 'DTPR Element',
+        id: 'dtpr_element',
+        version: '0.1',
+        namespace: 'https://dtpr.io/schemas/draft-2026-03/element',
+      },
+      element,
+    }
+  })
+
+  return { datachain_categories, elements }
+})

--- a/app/server/api/dtpr/draft-2026-03/types.ts
+++ b/app/server/api/dtpr/draft-2026-03/types.ts
@@ -1,0 +1,49 @@
+// Types for the draft-2026-03 experimental taxonomy API
+
+export type LocaleMap = Record<string, string>
+
+export interface ElementVariable {
+  id: string
+  label?: LocaleMap
+  required?: boolean
+  type?: 'text' | 'select' | 'multiselect'
+}
+
+export interface ContextValue {
+  id: string
+  name: LocaleMap
+  description: LocaleMap
+  color: string
+}
+
+export interface Context {
+  id: string
+  name: LocaleMap
+  description: LocaleMap
+  values: ContextValue[]
+}
+
+export interface DatachainCategory {
+  id: string
+  name: LocaleMap
+  description: LocaleMap
+  prompt: LocaleMap
+  required?: boolean
+  order?: number
+  element_variables?: ElementVariable[]
+  context?: Context
+  version: string
+}
+
+export interface Element {
+  id: string
+  category: string[]
+  name: LocaleMap
+  description: LocaleMap
+  icon: string
+  symbol?: string
+  version: string
+}
+
+// Reuse SchemaMetadata from v1
+export type { SchemaMetadata } from '../v1/types'

--- a/app/server/api/dtpr/draft-2026-03/utils.ts
+++ b/app/server/api/dtpr/draft-2026-03/utils.ts
@@ -1,0 +1,17 @@
+import type { LocaleMap } from './types'
+export { parseLocalesQuery, calculateLatestVersion } from '../v1/utils'
+
+/**
+ * Filters a locale map to only include requested locales.
+ * Returns the full map if no locales are requested.
+ */
+export function filterLocaleMap(map: LocaleMap, requestedLocales: string[] | null): LocaleMap {
+  if (!requestedLocales || requestedLocales.length === 0) return map
+  const filtered: LocaleMap = {}
+  for (const locale of requestedLocales) {
+    if (locale in map) {
+      filtered[locale] = map[locale]
+    }
+  }
+  return filtered
+}

--- a/app/test/api/draft-2026-03/datachain-categories.test.ts
+++ b/app/test/api/draft-2026-03/datachain-categories.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { CategoriesResponseSchema } from './schemas'
+
+describe('GET /api/dtpr/draft-2026-03/datachain-categories', () => {
+  it('conforms to CategoriesResponseSchema', async () => {
+    const data = await $fetch('/api/dtpr/draft-2026-03/datachain-categories')
+    const result = CategoriesResponseSchema.safeParse(data)
+    if (!result.success) {
+      console.error(result.error.format())
+    }
+    expect(result.success).toBe(true)
+  })
+
+  it('returns 9 categories', async () => {
+    const data = await $fetch('/api/dtpr/draft-2026-03/datachain-categories')
+    const parsed = CategoriesResponseSchema.parse(data)
+    expect(parsed).toHaveLength(9)
+  })
+
+  it('includes both en and fr locales', async () => {
+    const data = await $fetch('/api/dtpr/draft-2026-03/datachain-categories')
+    const parsed = CategoriesResponseSchema.parse(data)
+    for (const item of parsed) {
+      expect(item.category.name).toHaveProperty('en')
+      expect(item.category.name).toHaveProperty('fr')
+    }
+  })
+
+  it('schema metadata has version 0.1', async () => {
+    const data = await $fetch('/api/dtpr/draft-2026-03/datachain-categories')
+    const parsed = CategoriesResponseSchema.parse(data)
+    for (const item of parsed) {
+      expect(item.schema.version).toBe('0.1')
+      expect(item.schema.id).toBe('dtpr_category')
+    }
+  })
+
+  it('categories are sorted by order field', async () => {
+    const data = await $fetch('/api/dtpr/draft-2026-03/datachain-categories')
+    const parsed = CategoriesResponseSchema.parse(data)
+    const orders = parsed
+      .map((item) => item.category.order)
+      .filter((o): o is number => typeof o === 'number')
+
+    for (let i = 1; i < orders.length; i++) {
+      expect(orders[i]).toBeGreaterThanOrEqual(orders[i - 1])
+    }
+  })
+
+  it('functional_modes category has context with 6 modes', async () => {
+    const data = await $fetch('/api/dtpr/draft-2026-03/datachain-categories')
+    const parsed = CategoriesResponseSchema.parse(data)
+    const functionalModes = parsed.find((c) => c.category.id === 'functional_modes')
+    expect(functionalModes).toBeDefined()
+    expect(functionalModes!.category.context).toBeDefined()
+    expect(functionalModes!.category.context!.values).toHaveLength(6)
+  })
+
+  it('filters locales with ?locales=en', async () => {
+    const data = await $fetch('/api/dtpr/draft-2026-03/datachain-categories?locales=en')
+    const parsed = CategoriesResponseSchema.parse(data)
+    for (const item of parsed) {
+      expect(Object.keys(item.category.name)).toEqual(['en'])
+      expect(item.category.name).not.toHaveProperty('fr')
+    }
+  })
+})

--- a/app/test/api/draft-2026-03/elements.test.ts
+++ b/app/test/api/draft-2026-03/elements.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { ElementsResponseSchema, CategoriesResponseSchema } from './schemas'
+
+describe('GET /api/dtpr/draft-2026-03/elements', () => {
+  it('conforms to ElementsResponseSchema', async () => {
+    const data = await $fetch('/api/dtpr/draft-2026-03/elements')
+    const result = ElementsResponseSchema.safeParse(data)
+    if (!result.success) {
+      console.error(result.error.format())
+    }
+    expect(result.success).toBe(true)
+  })
+
+  it('returns 68 elements', async () => {
+    const data = await $fetch('/api/dtpr/draft-2026-03/elements')
+    const parsed = ElementsResponseSchema.parse(data)
+    expect(parsed).toHaveLength(68)
+  })
+
+  it('includes both en and fr locales', async () => {
+    const data = await $fetch('/api/dtpr/draft-2026-03/elements')
+    const parsed = ElementsResponseSchema.parse(data)
+    for (const item of parsed) {
+      expect(item.element.name).toHaveProperty('en')
+      expect(item.element.name).toHaveProperty('fr')
+    }
+  })
+
+  it('all element category references are valid', async () => {
+    const [elementsData, categoriesData] = await Promise.all([
+      $fetch('/api/dtpr/draft-2026-03/elements'),
+      $fetch('/api/dtpr/draft-2026-03/datachain-categories'),
+    ])
+    const elements = ElementsResponseSchema.parse(elementsData)
+    const categories = CategoriesResponseSchema.parse(categoriesData)
+    const categoryIds = new Set(categories.map((c) => c.category.id))
+
+    for (const item of elements) {
+      for (const catRef of item.element.category) {
+        expect(categoryIds).toContain(catRef)
+      }
+    }
+  })
+
+  it('includes 6 functional mode elements', async () => {
+    const data = await $fetch('/api/dtpr/draft-2026-03/elements')
+    const parsed = ElementsResponseSchema.parse(data)
+    const functionalModeElements = parsed.filter((e) =>
+      e.element.category.includes('functional_modes'),
+    )
+    expect(functionalModeElements).toHaveLength(6)
+  })
+
+  it('schema metadata has version 0.1', async () => {
+    const data = await $fetch('/api/dtpr/draft-2026-03/elements')
+    const parsed = ElementsResponseSchema.parse(data)
+    for (const item of parsed) {
+      expect(item.schema.version).toBe('0.1')
+      expect(item.schema.id).toBe('dtpr_element')
+    }
+  })
+
+  it('filters locales with ?locales=en', async () => {
+    const data = await $fetch('/api/dtpr/draft-2026-03/elements?locales=en')
+    const parsed = ElementsResponseSchema.parse(data)
+    for (const item of parsed) {
+      expect(Object.keys(item.element.name)).toEqual(['en'])
+      expect(item.element.name).not.toHaveProperty('fr')
+    }
+  })
+})

--- a/app/test/api/draft-2026-03/schemas.ts
+++ b/app/test/api/draft-2026-03/schemas.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod'
+
+// Locale map: { en: "...", fr: "..." }
+export const LocaleMapSchema = z.record(z.string(), z.string())
+
+export const SchemaMetadataSchema = z.object({
+  name: z.string(),
+  id: z.string(),
+  version: z.string(),
+  namespace: z.string().url(),
+})
+
+export const ElementVariableSchema = z.object({
+  id: z.string(),
+  label: LocaleMapSchema.optional(),
+  required: z.boolean().optional(),
+  type: z.enum(['text', 'select', 'multiselect']).optional(),
+})
+
+export const ContextValueSchema = z.object({
+  id: z.string(),
+  name: LocaleMapSchema,
+  description: LocaleMapSchema,
+  color: z.string(),
+})
+
+export const ContextSchema = z.object({
+  id: z.string(),
+  name: LocaleMapSchema,
+  description: LocaleMapSchema,
+  values: z.array(ContextValueSchema),
+})
+
+// Category response
+export const CategoryDataSchema = z.object({
+  schema: SchemaMetadataSchema,
+  category: z.object({
+    id: z.string(),
+    name: LocaleMapSchema,
+    description: LocaleMapSchema,
+    prompt: LocaleMapSchema,
+    required: z.boolean().optional(),
+    order: z.number().optional(),
+    element_variables: z.array(ElementVariableSchema).optional(),
+    context: ContextSchema.optional(),
+    version: z.string(),
+  }),
+})
+
+export const CategoriesResponseSchema = z.array(CategoryDataSchema)
+
+// Element response
+export const ElementDataSchema = z.object({
+  schema: SchemaMetadataSchema,
+  element: z.object({
+    id: z.string(),
+    category: z.array(z.string()),
+    name: LocaleMapSchema,
+    description: LocaleMapSchema,
+    icon: z.string(),
+    symbol: z.string().optional(),
+    version: z.string(),
+  }),
+})
+
+export const ElementsResponseSchema = z.array(ElementDataSchema)
+
+// Taxonomy combined response
+export const TaxonomyResponseSchema = z.object({
+  datachain_categories: CategoriesResponseSchema,
+  elements: ElementsResponseSchema,
+})

--- a/app/test/api/draft-2026-03/taxonomy.test.ts
+++ b/app/test/api/draft-2026-03/taxonomy.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { TaxonomyResponseSchema } from './schemas'
+
+describe('GET /api/dtpr/draft-2026-03/taxonomy', () => {
+  it('conforms to TaxonomyResponseSchema', async () => {
+    const data = await $fetch('/api/dtpr/draft-2026-03/taxonomy')
+    const result = TaxonomyResponseSchema.safeParse(data)
+    if (!result.success) {
+      console.error(result.error.format())
+    }
+    expect(result.success).toBe(true)
+  })
+
+  it('returns both datachain_categories and elements', async () => {
+    const data = await $fetch('/api/dtpr/draft-2026-03/taxonomy')
+    const parsed = TaxonomyResponseSchema.parse(data)
+    expect(parsed.datachain_categories.length).toBe(9)
+    expect(parsed.elements.length).toBe(68)
+  })
+
+  it('filters locales with ?locales=fr', async () => {
+    const data = await $fetch('/api/dtpr/draft-2026-03/taxonomy?locales=fr')
+    const parsed = TaxonomyResponseSchema.parse(data)
+
+    // Check categories have only fr
+    for (const item of parsed.datachain_categories) {
+      expect(Object.keys(item.category.name)).toEqual(['fr'])
+    }
+
+    // Check elements have only fr
+    for (const item of parsed.elements) {
+      expect(Object.keys(item.element.name)).toEqual(['fr'])
+    }
+  })
+})

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
           include: ['test/api/**/*.test.ts'],
           setupFiles: ['test/api/setup.ts'],
           testTimeout: 60_000,
+          fileParallelism: false,
         },
       },
     ],

--- a/docs-site/content/4.api/0.index.md
+++ b/docs-site/content/4.api/0.index.md
@@ -51,3 +51,11 @@ The `datachain_type` parameter must be one of the supported types: `device`, `ai
 ## Response format
 
 All responses are JSON. Element endpoints return arrays of element objects; category endpoints return arrays of category objects. See the [v1 reference](/api/v1/overview) for full schema details.
+
+## Experimental drafts
+
+Draft APIs are available for testing upcoming taxonomy changes. These are **not stable** and will change without notice.
+
+| Draft | Description | Docs |
+|-------|-------------|------|
+| `draft-2026-03` | RFC #260 — functional modes, new categories, locale maps | [Overview](/api/draft-2026-03/overview) |

--- a/docs-site/content/4.api/draft-2026-03/1.overview.md
+++ b/docs-site/content/4.api/draft-2026-03/1.overview.md
@@ -1,0 +1,40 @@
+---
+title: Draft 2026-03 Overview
+description: Experimental draft taxonomy API for RFC #260. Subject to breaking changes.
+---
+
+# Draft 2026-03 API (Experimental)
+
+::callout{type="warning"}
+This is an **experimental draft API** implementing [RFC #260](https://github.com/Helpful-Places/dtpr/issues/260). The data model is unstable and will change without notice. Do not build production integrations against these endpoints.
+::
+
+## What's different from v1
+
+- **Locale maps** instead of locale arrays — `{ "en": "...", "fr": "..." }` instead of `[{ locale: "en", value: "..." }]`
+- **YAML source files** — one file per entity with all locales embedded
+- **AI-only** — no `datachain_type` parameter; device taxonomy stays in v1
+- **New categories** — `functional_modes` (with 6 AI mode elements) and `data_flow`
+- **Flat structure** — categories and elements returned directly, no per-locale aggregation
+
+## Base URL
+
+```
+https://dtpr.io/api/dtpr/draft-2026-03
+```
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/dtpr/draft-2026-03/datachain-categories` | All 9 datachain categories |
+| `GET` | `/api/dtpr/draft-2026-03/elements` | All ~68 elements |
+| `GET` | `/api/dtpr/draft-2026-03/taxonomy` | Combined: categories + elements |
+
+## Locale filtering
+
+Same as v1 — use `?locales=en` or `?locales=en,fr` to filter locale maps.
+
+## Schema version
+
+All responses use schema version `0.1` with namespace `https://dtpr.io/schemas/draft-2026-03/...`.

--- a/docs-site/content/4.api/draft-2026-03/2.categories.md
+++ b/docs-site/content/4.api/draft-2026-03/2.categories.md
@@ -1,0 +1,63 @@
+---
+title: Datachain Categories
+description: Draft 2026-03 datachain categories endpoint reference.
+---
+
+# Datachain Categories
+
+```
+GET /api/dtpr/draft-2026-03/datachain-categories
+```
+
+Returns all 9 datachain categories, sorted by `order`.
+
+## Categories
+
+| ID | Name | New? |
+|----|------|------|
+| `accountable` | Accountable | Migrated from v1 |
+| `purpose` | Purpose | Migrated from v1 |
+| `functional_modes` | Functional Modes | New — replaces `decision` |
+| `data_flow` | Data Flow | New — replaces `input_dataset` + `output_dataset` |
+| `access` | Access | Migrated from v1 |
+| `retention` | Retention | Migrated from v1 |
+| `storage` | Data Storage | Migrated from v1 |
+| `risks_mitigation` | Risks & Mitigation | Migrated from v1 |
+| `rights` | Rights | Migrated from v1 |
+
+## Response shape
+
+```json
+[
+  {
+    "schema": {
+      "name": "DTPR Category",
+      "id": "dtpr_category",
+      "version": "0.1",
+      "namespace": "https://dtpr.io/schemas/draft-2026-03/category"
+    },
+    "category": {
+      "id": "functional_modes",
+      "name": { "en": "Functional Modes", "fr": "Modes fonctionnels" },
+      "description": { "en": "...", "fr": "..." },
+      "prompt": { "en": "...", "fr": "..." },
+      "required": true,
+      "order": 3,
+      "context": {
+        "id": "functional_mode",
+        "name": { "en": "Functional Mode", "fr": "Mode fonctionnel" },
+        "description": { "en": "...", "fr": "..." },
+        "values": [
+          {
+            "id": "analytical",
+            "name": { "en": "Analytical AI", "fr": "IA analytique" },
+            "description": { "en": "...", "fr": "..." },
+            "color": "#4A90D9"
+          }
+        ]
+      },
+      "version": "2025-08-29T00:00:00Z"
+    }
+  }
+]
+```

--- a/docs-site/content/4.api/draft-2026-03/3.elements.md
+++ b/docs-site/content/4.api/draft-2026-03/3.elements.md
@@ -1,0 +1,61 @@
+---
+title: Elements
+description: Draft 2026-03 elements endpoint reference.
+---
+
+# Elements
+
+```
+GET /api/dtpr/draft-2026-03/elements
+```
+
+Returns all ~68 elements: 62 migrated from v1 AI elements + 6 new functional mode elements.
+
+## New functional mode elements
+
+| ID | Category | Verb |
+|----|----------|------|
+| `analytical_ai` | `functional_modes` | Decides |
+| `semantic_ai` | `functional_modes` | Understands |
+| `generative_ai` | `functional_modes` | Creates |
+| `agentic_ai` | `functional_modes` | Acts |
+| `perceptive_ai` | `functional_modes` | Senses |
+| `physical_ai` | `functional_modes` | Moves |
+
+## Response shape
+
+```json
+[
+  {
+    "schema": {
+      "name": "DTPR Element",
+      "id": "dtpr_element",
+      "version": "0.1",
+      "namespace": "https://dtpr.io/schemas/draft-2026-03/element"
+    },
+    "element": {
+      "id": "analytical_ai",
+      "category": ["functional_modes"],
+      "name": { "en": "Analytical AI", "fr": "IA analytique" },
+      "description": { "en": "...", "fr": "..." },
+      "icon": "/dtpr-icons/functional_modes__analytical_ai.svg",
+      "version": "2025-08-29T00:00:00Z"
+    }
+  }
+]
+```
+
+## Combined endpoint
+
+```
+GET /api/dtpr/draft-2026-03/taxonomy
+```
+
+Returns both collections in a single response:
+
+```json
+{
+  "datachain_categories": [...],
+  "elements": [...]
+}
+```


### PR DESCRIPTION
## Summary

- Adds a parallel draft taxonomy space (`draft-2026-03`) for iterating on RFC #260 without breaking the production v1 API
- Migrates 62 v1 AI elements + 7 AI categories to YAML format with embedded locale maps (`{en: "...", fr: "..."}`)
- Introduces 2 new categories (`functional_modes` with context/6 modes, `data_flow`) and 6 new functional mode elements
- Serves 3 new API endpoints: `/api/dtpr/draft-2026-03/datachain-categories`, `/elements`, `/taxonomy`
- Adds schema conformance tests, count validation, locale filtering, and category reference integrity tests
- Adds experimental draft API documentation to docs-site

## Details

**Content (77 YAML files):**
- `app/content/dtpr.draft-2026-03/datachain_categories/` — 9 categories
- `app/content/dtpr.draft-2026-03/elements/` — 68 elements

**API layer:**
- Types, utils (reuses v1's `parseLocalesQuery` and `calculateLatestVersion`)
- Locale maps filtered via `filterLocaleMap()` — much simpler than v1's per-locale aggregation

**Tests:**
- 17 new draft API tests across 3 test files
- All 76 tests pass (v1 + draft)
- Fixes pre-existing API test parallelism race condition with `fileParallelism: false`

## Test plan

- [x] `pnpm vitest run` — all 76 tests pass (32 unit + 44 API)
- [ ] Manual: `curl localhost:3000/api/dtpr/draft-2026-03/taxonomy` returns both sections
- [ ] Manual: `curl localhost:3000/api/dtpr/v1/categories/ai` still works identically
- [ ] Docs-site builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)