### PR TITLE
Fix docs-site Cloudflare Workers build failure

### DIFF
--- a/docs-site/nuxt.config.ts
+++ b/docs-site/nuxt.config.ts
@@ -7,7 +7,10 @@ export default defineNuxtConfig({
 
   $production: {
     nitro: {
-      preset: 'cloudflare-module'
+      preset: 'cloudflare-module',
+      rollupConfig: {
+        external: ['agents/mcp']
+      }
     }
   },
 

--- a/docs-site/nuxt.config.ts
+++ b/docs-site/nuxt.config.ts
@@ -9,7 +9,19 @@ export default defineNuxtConfig({
     nitro: {
       preset: 'cloudflare-module',
       rollupConfig: {
-        external: ['agents/mcp']
+        // Stub out agents/mcp — required by @nuxtjs/mcp-toolkit's Cloudflare
+        // provider (from docus) but not available in Workers Builds
+        plugins: [{
+          name: 'stub-agents-mcp',
+          resolveId(id: string) {
+            if (id === 'agents/mcp') return id
+          },
+          load(id: string) {
+            if (id === 'agents/mcp') {
+              return 'export function createMcpHandler() { throw new Error("agents/mcp not available") }'
+            }
+          }
+        }]
       }
     }
   },


### PR DESCRIPTION
The Cloudflare Workers Build check on main has been failing since docus@5.7.0 added `@nuxtjs/mcp-toolkit`, which tries to resolve `agents/mcp` at build time. The cloudflare-module Nitro preset disallows externals, causing the build to error. This marks `agents/mcp` as a rollup external since the MCP provider uses a dynamic import and is not used by this docs site.