### PR TITLE
Fix docs-site Cloudflare Workers deploy (wrangler not found)

### DIFF
--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -11,5 +11,8 @@
     "better-sqlite3": "^12.2.0",
     "docus": "latest",
     "nuxt": "^4.0.0"
+  },
+  "devDependencies": {
+    "wrangler": "^4.83.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,10 @@ importers:
       nuxt:
         specifier: ^4.0.0
         version: 4.3.1(@parcel/watcher@2.5.6)(@types/node@25.3.3)(@vue/compiler-sfc@3.5.29)(better-sqlite3@12.6.2)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4(better-sqlite3@12.6.2))(eslint@10.0.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+    devDependencies:
+      wrangler:
+        specifier: ^4.83.0
+        version: 4.83.0
 
   studio:
     dependencies:


### PR DESCRIPTION
## Summary
- Build on main succeeded but the Cloudflare Workers deploy step failed with `sh: 1: wrangler: not found`
- docs-site didn't declare wrangler as a dependency, so `pnpm install --frozen-lockfile` never brought it into `docs-site/node_modules/.bin`, and `npx wrangler deploy` (the configured deploy command) couldn't resolve it
- Adds `wrangler` as a devDependency of docs-site

## Context
Build ID that failed: [bfeb4971](https://dash.cloudflare.com/f978769622a3e15ad770688a80811aa8/workers/services/view/dtpr-docs/production/builds/bfeb4971-c764-442b-aadf-be66a205fc67). The Workers Builds trigger is configured with build command `pnpm run build` and deploy command `npx wrangler deploy` at root `/docs-site`. The previous fix (#263) got the build passing; this one gets the deploy running.

## Test plan
- [ ] Workers Builds check on this PR runs `npx wrangler deploy` successfully and publishes to docs.dtpr.io