### PR TITLE
feat(api): REST + MCP read path on Cloudflare Workers (Units 7-12)

### DIFF
--- a/api/docs/mcp-fallback.md
+++ b/api/docs/mcp-fallback.md
@@ -1,0 +1,92 @@
+# MCP transport: hand-rolled JSON-RPC fallback
+
+## Why this exists
+
+The plan ([Unit 10](../../docs/plans/2026-04-16-001-feat-dtpr-api-mcp-plan.md))
+intended to mount the MCP read-side tools through `@hono/mcp` +
+`@modelcontextprotocol/sdk@^1.29`. During implementation we hit a hard
+incompatibility between that SDK chain and the workerd runtime that
+`@cloudflare/vitest-pool-workers` uses for tests:
+
+> `SyntaxError: Unexpected token ':'`
+> `at .../ajv@8.18.0/dist/core.js?mf_vitest_no_cjs_esm_shim`
+
+The MCP SDK pulls in **Ajv 8** transitively (for JSON Schema validation
+inside the server transport). Ajv 8 is CommonJS-only and
+`require()`-loads its own `data.json` meta-schema; vitest-pool-workers'
+module loader explicitly skips the CJS-to-ESM shim for that path
+(`?mf_vitest_no_cjs_esm_shim`), and the file ends up parsed as JS,
+failing on the JSON's first `:` character. Enabling
+`nodejs_compat_v2 + nodejs_als` did not change the outcome (the shim
+opt-out fires earlier).
+
+The plan's risk table already anticipated this:
+
+> **MCP SDK Workers compatibility (flagged unverified in brainstorm)**
+> Research confirmed `@hono/mcp` + `@modelcontextprotocol/sdk@^1` +
+> `nodejs_compat` flag is the supported path; spike validated during
+> Unit 1 workspace scaffolding. **If the SDK path breaks, fallback is
+> a hand-rolled JSON-RPC handler over `fetch` — documented in
+> `api/docs/mcp-fallback.md` but not built unless needed.**
+
+The Unit 1 spike was deferred to a real Cloudflare account; we hit the
+incompatibility in test-runtime before we had a chance to validate
+against production workerd. Rather than wait, we shipped the
+documented fallback.
+
+## What we built instead
+
+`api/src/mcp/server.ts` is a ~150-line JSON-RPC dispatcher implementing
+exactly the methods the DTPR read surface needs:
+
+- `initialize` — protocol handshake, returns `serverInfo` + capabilities.
+- `notifications/initialized` (and the unprefixed alias) — accepted,
+  no response per JSON-RPC notification semantics.
+- `tools/list` — returns the 7 tool descriptors.
+- `tools/call` — dispatches to the registered tool handler.
+- `ping` — replies with `{}`.
+
+Single requests and JSON-RPC batches are both supported. The wire
+content type is `application/json` — no SSE / streamable-HTTP, no
+session ids, no Durable Objects. Stateless reads were the assumption
+all along; this just makes that assumption explicit in the transport.
+
+`api/src/mcp/tools.ts` keeps the same tool catalogue + handler
+implementations as the SDK-based draft. The only structural change is
+that `inputSchema` is emitted via `z.toJSONSchema(schema, { target:
+'draft-2020-12', io: 'input', unrepresentable: 'any' })` at registry
+build time and stored alongside the descriptor.
+
+## Removed dependencies
+
+- `@hono/mcp@^0.2.5`
+- `@modelcontextprotocol/sdk@^1.29.0`
+
+(They remain available for the demo client in Unit 15, where they run
+under Node and don't hit the workerd issue.)
+
+## Trade-offs vs the SDK path
+
+- ✅ No transitive Ajv → no workerd CJS issue → tests run cleanly.
+- ✅ Smaller bundle (the SDK + Ajv are heavy).
+- ✅ Stateless and fully visible: every request is one POST, one
+  response.
+- ❌ No automatic compliance with future MCP spec features
+  (resources, prompts, sampling). When/if we add any of those, we
+  re-evaluate adopting the SDK or extending the fallback.
+- ❌ No streamable-HTTP or SSE. The current MCP read surface doesn't
+  need it; if we later add long-running validate or per-session OAuth
+  we'll revisit.
+
+## Reverting to the SDK
+
+If a future workerd / vitest-pool-workers release fixes the Ajv issue,
+or if we move tests to a different harness, reverting is mechanical:
+
+1. Re-add `@hono/mcp` and `@modelcontextprotocol/sdk` to dependencies.
+2. Replace `api/src/mcp/server.ts` with the SDK-based handler (kept in
+   the git history of this commit).
+3. Replace `api/src/mcp/tools.ts` with the `McpServer.registerTool(...)`
+   form (also in git history).
+4. Run the existing `api/test/api/mcp.test.ts` suite — the JSON-RPC
+   client it uses talks to the wire format, so no test changes needed.

--- a/api/docs/waf-rules.md
+++ b/api/docs/waf-rules.md
@@ -1,0 +1,99 @@
+# WAF rate-limit rules
+
+These rules sit at the Cloudflare WAF layer and fire before the Worker
+runs. They are the coarse, per-IP absolute caps referenced in the plan
+(R29). The Workers Rate Limit API bindings (`RL_READ`, `RL_VALIDATE`)
+are the second tier — tighter, per-`(IP, DTPR-Client)` tuple, applied
+inside the Worker. Both must be in place for the full protection.
+
+Source of truth: this document. Changes made directly in the
+Cloudflare dashboard must be mirrored here; the dashboard is audited
+quarterly against what's written down.
+
+## Rules
+
+All three rules use `action = block` with a typed 429 response —
+agents cannot solve `managed_challenge`, and silent lock-out is worse
+than a clear error.
+
+### Rule 1: GET /api/v2/*
+
+- **Zone**: `dtpr.io`
+- **Hostname filter**: `api.dtpr.io` (and `api-preview.dtpr.io` for preview)
+- **Expression**: `(http.request.method eq "GET" and starts_with(http.request.uri.path, "/api/v2/"))`
+- **Counting**: per `ip.src`
+- **Period**: 60 seconds
+- **Requests per period**: 1000
+- **Action**: block
+
+Rationale: covers the entire public read surface. 1000/min/IP
+accommodates mobile-carrier CGNAT and the Worcester app's burstier
+sessions without opening a path for an abusive client to soak the
+Worker-tier quota by themselves.
+
+### Rule 2: POST /api/v2/*/validate
+
+- **Zone**: `dtpr.io`
+- **Hostname filter**: `api.dtpr.io` (and `api-preview.dtpr.io` for preview)
+- **Expression**: `(http.request.method eq "POST" and ends_with(http.request.uri.path, "/validate"))`
+- **Counting**: per `ip.src`
+- **Period**: 60 seconds
+- **Requests per period**: 30
+- **Action**: block
+
+Rationale: validate is the expensive write-ish path — it reads several
+R2 objects and runs the full semantic rule set. 30/min/IP is well
+above demo traffic but low enough that an abusive client can't drive
+Worker CPU on this path alone.
+
+### Rule 3: /mcp
+
+- **Zone**: `dtpr.io`
+- **Hostname filter**: `api.dtpr.io` (and `api-preview.dtpr.io` for preview)
+- **Expression**: `(http.request.uri.path eq "/mcp")`
+- **Counting**: per `ip.src`
+- **Period**: 60 seconds
+- **Requests per period**: 300
+- **Action**: block
+
+Rationale: a single MCP session can easily emit 20–30 tool calls. 300
+per minute per IP lets a few concurrent sessions run without tripping
+the absolute cap while still ring-fencing an abusive client to one
+order of magnitude above baseline. The Worker-tier binding does the
+finer `(IP, DTPR-Client)` tuple limiting that defeats shared-egress
+pools.
+
+## 429 body contract
+
+When WAF blocks a request, Cloudflare returns its default 429 page.
+That's acceptable for this MVP — we explicitly document in
+`api/docs/api-usage.md` that a raw Cloudflare 429 at the edge means
+"you exceeded the WAF cap; back off for 60 s." The typed envelope
+only appears for Worker-tier 429s (`Retry-After` + `rate_limited` code
++ `DTPR-Client` fix_hint). This split is intentional: the WAF tier
+can't format envelopes cheaply, and at its fire rate the delta
+doesn't matter for diagnosis.
+
+## Provisioning checklist
+
+One-time manual steps before the first stable promotion. Owner:
+whoever provisions the Cloudflare-side infrastructure.
+
+- [ ] Create each rule above in Cloudflare dashboard
+      (Security → WAF → Rate limiting rules).
+- [ ] Apply identical rules to both `api.dtpr.io` and
+      `api-preview.dtpr.io` (adjust the hostname filter).
+- [ ] Confirm actions are all `block`, not `managed_challenge`.
+- [ ] Record rule IDs in the team runbook for audit.
+- [ ] Schedule a quarterly sync against this document.
+
+## Tuning signals
+
+Revisit when any of the following happens:
+
+- The Worker-tier binding (`RL_READ` or `RL_VALIDATE`) fires ≥1% of
+  requests for legitimate clients.
+- Observability shows a legitimate `DTPR-Client` value consistently
+  near the WAF cap.
+- Traffic baseline (brainstorm: ~10 k req/day) triples or more.
+- A new consumer class (non-Worcester, non-demo) comes online.

--- a/api/package.json
+++ b/api/package.json
@@ -23,9 +23,7 @@
     "schema:promote": "tsx cli/bin.ts promote"
   },
   "dependencies": {
-    "@hono/mcp": "^0.2.5",
     "@hono/zod-validator": "^0.7.6",
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "hono": "^4.12.14",
     "hono-rate-limiter": "^0.4.0",
     "js-yaml": "^4.1.0",

--- a/api/src/app-types.ts
+++ b/api/src/app-types.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared Hono app environment type. Declared once here so middleware
+ * and routes agree on the shape of `c.var` and `c.env`.
+ */
+
+export interface AppVariables {
+  /** Populated by the request-id middleware (hono/request-id). */
+  requestId: string
+  /** Populated by the timeout middleware; loaders may honor it. */
+  abortSignal: AbortSignal
+}
+
+export interface AppEnv {
+  Bindings: Env
+  Variables: AppVariables
+}

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_VALIDATE_BUDGET_MS,
   timeout,
 } from './middleware/timeout.ts'
+import { createRestApp } from './rest/routes.ts'
 
 export type { AppEnv, AppVariables } from './app-types.ts'
 
@@ -42,13 +43,16 @@ export function createApp(options: CreateAppOptions = {}) {
   app.use('*', logging())
   app.use('*', payloadLimits(options.maxPayloadBytes))
 
-  // Read routes (everything except POST .../validate and MCP validate tool)
-  app.use(
-    '/healthz',
-    timeout({ budgetMs: options.readBudgetMs ?? DEFAULT_READ_BUDGET_MS }),
-  )
+  const readBudget = options.readBudgetMs ?? DEFAULT_READ_BUDGET_MS
+  const validateBudget = options.validateBudgetMs ?? DEFAULT_VALIDATE_BUDGET_MS
+
+  // POST .../validate gets the longer wall-clock budget; everything
+  // else (including the MCP read paths) uses the read budget.
+  app.use('/api/v2/schemas/:version/validate', timeout({ budgetMs: validateBudget }))
+  app.use('*', timeout({ budgetMs: readBudget }))
 
   app.get('/healthz', (c) => c.json({ ok: true, service: 'dtpr-api' }))
+  app.route('/api/v2', createRestApp())
 
   registerErrorHandler(app)
   return app

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,13 +1,55 @@
 import { Hono } from 'hono'
+import type { AppEnv } from './app-types.ts'
+import { configuredCors } from './middleware/cors.ts'
+import { registerErrorHandler } from './middleware/error-handler.ts'
+import { logging } from './middleware/logging.ts'
+import { payloadLimits } from './middleware/payload-limits.ts'
+import { configuredRequestId } from './middleware/request-id.ts'
+import {
+  DEFAULT_READ_BUDGET_MS,
+  DEFAULT_VALIDATE_BUDGET_MS,
+  timeout,
+} from './middleware/timeout.ts'
 
-export type AppEnv = {
-  Bindings: Env
+export type { AppEnv, AppVariables } from './app-types.ts'
+
+export interface CreateAppOptions {
+  /** Override the read-path wall-clock budget (defaults to 2 s). */
+  readBudgetMs?: number
+  /** Override the validate-path wall-clock budget (defaults to 5 s). */
+  validateBudgetMs?: number
+  /** Override the request-body byte cap (defaults to 64 KB). */
+  maxPayloadBytes?: number
 }
 
-export function createApp() {
+/**
+ * Build the Hono application with the standard middleware stack.
+ *
+ * Order (outermost first):
+ *   1. CORS — runs on every request, including preflight
+ *   2. request-id — so logs downstream include a correlation key
+ *   3. logging — emits a single JSON line per request
+ *   4. payload-limits — cheap content-length short-circuit
+ *   5. timeout — per-route wall-clock budget (route-scoped below)
+ *   6. route handlers
+ *   7. error handler — registered via `app.onError`
+ */
+export function createApp(options: CreateAppOptions = {}) {
   const app = new Hono<AppEnv>()
+
+  app.use('*', configuredCors())
+  app.use('*', configuredRequestId())
+  app.use('*', logging())
+  app.use('*', payloadLimits(options.maxPayloadBytes))
+
+  // Read routes (everything except POST .../validate and MCP validate tool)
+  app.use(
+    '/healthz',
+    timeout({ budgetMs: options.readBudgetMs ?? DEFAULT_READ_BUDGET_MS }),
+  )
 
   app.get('/healthz', (c) => c.json({ ok: true, service: 'dtpr-api' }))
 
+  registerErrorHandler(app)
   return app
 }

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -50,8 +50,23 @@ export function createApp(options: CreateAppOptions = {}) {
 
   // POST .../validate gets the longer wall-clock budget; everything
   // else (including the MCP read paths) uses the read budget.
+  //
+  // Important: the read-budget timeout is mounted on each non-validate
+  // route explicitly rather than on `'*'`. Hono runs middleware in
+  // mount order, and the two timeouts do not nest cleanly — both
+  // `Promise.race` timers run concurrently, so the shorter (read)
+  // budget would always fire first if it also matched validate,
+  // silently capping validate at 2 s instead of 5 s. A cold-cache
+  // validate request hitting several R2 reads could then trip a
+  // spurious 504 before its real budget expired.
   app.use('/api/v2/schemas/:version/validate', timeout({ budgetMs: validateBudget }))
-  app.use('*', timeout({ budgetMs: readBudget }))
+  app.use('/healthz', timeout({ budgetMs: readBudget }))
+  app.use('/api/v2/schemas', timeout({ budgetMs: readBudget }))
+  app.use('/api/v2/schemas/:version/manifest', timeout({ budgetMs: readBudget }))
+  app.use('/api/v2/schemas/:version/categories', timeout({ budgetMs: readBudget }))
+  app.use('/api/v2/schemas/:version/elements', timeout({ budgetMs: readBudget }))
+  app.use('/api/v2/schemas/:version/elements/:element_id', timeout({ budgetMs: readBudget }))
+  app.use('/mcp', timeout({ budgetMs: readBudget }))
 
   // Rate limits (two buckets — validate is tighter). Middleware is a
   // no-op when the bindings are absent, so dev / test / preview

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_VALIDATE_BUDGET_MS,
   timeout,
 } from './middleware/timeout.ts'
+import { handleMcpRequest } from './mcp/server.ts'
 import { createRestApp } from './rest/routes.ts'
 
 export type { AppEnv, AppVariables } from './app-types.ts'
@@ -53,6 +54,7 @@ export function createApp(options: CreateAppOptions = {}) {
 
   app.get('/healthz', (c) => c.json({ ok: true, service: 'dtpr-api' }))
   app.route('/api/v2', createRestApp())
+  app.all('/mcp', (c) => handleMcpRequest(c))
 
   registerErrorHandler(app)
   return app

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -4,6 +4,7 @@ import { configuredCors } from './middleware/cors.ts'
 import { registerErrorHandler } from './middleware/error-handler.ts'
 import { logging } from './middleware/logging.ts'
 import { payloadLimits } from './middleware/payload-limits.ts'
+import { rateLimit } from './middleware/rate-limit.ts'
 import { configuredRequestId } from './middleware/request-id.ts'
 import {
   DEFAULT_READ_BUDGET_MS,
@@ -51,6 +52,13 @@ export function createApp(options: CreateAppOptions = {}) {
   // else (including the MCP read paths) uses the read budget.
   app.use('/api/v2/schemas/:version/validate', timeout({ budgetMs: validateBudget }))
   app.use('*', timeout({ budgetMs: readBudget }))
+
+  // Rate limits (two buckets — validate is tighter). Middleware is a
+  // no-op when the bindings are absent, so dev / test / preview
+  // builds don't need to provision them.
+  app.use('/api/v2/schemas/:version/validate', rateLimit({ binding: 'RL_VALIDATE' }))
+  app.use('/api/v2/*', rateLimit({ binding: 'RL_READ' }))
+  app.use('/mcp', rateLimit({ binding: 'RL_READ' }))
 
   app.get('/healthz', (c) => c.json({ ok: true, service: 'dtpr-api' }))
   app.route('/api/v2', createRestApp())

--- a/api/src/mcp/delimiters.ts
+++ b/api/src/mcp/delimiters.ts
@@ -1,0 +1,60 @@
+/**
+ * Provenance tagging for element prose surfaced to LLMs.
+ *
+ * When an element's `description` or `citation` is rendered into the
+ * `text` content block of a tool response, wrap it in
+ * `<dtpr_element>` tags so the receiving LLM treats the content as
+ * data rather than instructions. The structured-content block is left
+ * untouched (it's data already).
+ *
+ * The wrapper attributes are sanitized — element ids and locale codes
+ * are already constrained at the schema layer to safe character sets.
+ */
+
+import type { Element } from '../schema/element.ts'
+import type { LocaleCode } from '../schema/locale.ts'
+
+const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/
+
+function safeAttr(value: string): string {
+  // Defense in depth: drop any character that could break out of the
+  // attribute even though `id` and `locale` are already restricted.
+  return value.replace(/[^a-zA-Z0-9_.-]/g, '')
+}
+
+export interface WrapElementOptions {
+  /** Schema version that produced the element (for traceability). */
+  version: string
+  /** Locale of the prose being wrapped. */
+  locale: LocaleCode
+}
+
+/**
+ * Wrap a single localized string in a provenance tag.
+ */
+export function wrapText(value: string, opts: { id: string; version: string; locale: LocaleCode }): string {
+  const id = SAFE_ID_RE.test(opts.id) ? opts.id : safeAttr(opts.id)
+  const version = safeAttr(opts.version)
+  const locale = safeAttr(opts.locale)
+  return `<dtpr_element id="${id}" locale="${locale}" version="${version}">${value}</dtpr_element>`
+}
+
+/**
+ * Build a single concatenated prose blob for an element across all
+ * locales it carries. Used when including the element's content as
+ * free-form text in a tool response (e.g., the agent rendering
+ * `get_element` for a user).
+ */
+export function wrapElementContent(element: Element, opts: WrapElementOptions): string {
+  const parts: string[] = []
+  for (const t of element.title) {
+    parts.push(wrapText(t.value, { id: element.id, version: opts.version, locale: t.locale as LocaleCode }))
+  }
+  for (const d of element.description) {
+    parts.push(wrapText(d.value, { id: element.id, version: opts.version, locale: d.locale as LocaleCode }))
+  }
+  for (const c of element.citation) {
+    parts.push(wrapText(c.value, { id: element.id, version: opts.version, locale: c.locale as LocaleCode }))
+  }
+  return parts.join('\n')
+}

--- a/api/src/mcp/envelope.ts
+++ b/api/src/mcp/envelope.ts
@@ -1,0 +1,72 @@
+import type { ApiErrorShape } from '../middleware/errors.ts'
+
+/**
+ * Tool response envelopes mirror the REST `{ok, errors?}` shape so
+ * agents see one consistent contract whether they call REST or MCP.
+ *
+ * Each envelope is emitted as both `structuredContent` (typed JSON for
+ * 2025-06-18 MCP clients) and a back-compat `content[].text` block
+ * carrying the same JSON serialized — older clients that don't yet
+ * read structuredContent still get the data.
+ */
+
+export interface OkEnvelope<T> {
+  ok: true
+  data: T
+  meta?: ResponseMeta
+}
+
+export interface ErrEnvelope {
+  ok: false
+  errors: ApiErrorShape[]
+  meta?: ResponseMeta
+}
+
+export interface ResponseMeta {
+  content_hash?: string
+  next_cursor?: string | null
+  warnings?: string[]
+  /** Convenience: mirror the schema version on every response. */
+  version?: string
+}
+
+export type Envelope<T> = OkEnvelope<T> | ErrEnvelope
+
+export function okEnvelope<T>(data: T, meta?: ResponseMeta): OkEnvelope<T> {
+  return meta ? { ok: true, data, meta } : { ok: true, data }
+}
+
+export function errEnvelope(errors: ApiErrorShape[], meta?: ResponseMeta): ErrEnvelope {
+  return meta ? { ok: false, errors, meta } : { ok: false, errors }
+}
+
+/**
+ * Shape an envelope into an MCP tool result. `isError` is set when the
+ * envelope is `ok:false` AND the failure represents an operational
+ * problem (unknown version, parse error, etc.). Semantic validation
+ * results from `validate_datachain` are `ok:false` but NOT `isError`,
+ * since the call itself ran successfully — the *result* is "invalid".
+ */
+export function toToolResult<T>(env: Envelope<T>, opts: { isError?: boolean } = {}) {
+  const isError = opts.isError ?? (env.ok === false)
+  return {
+    structuredContent: env as unknown as Record<string, unknown>,
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(env),
+      },
+    ],
+    ...(isError ? { isError: true as const } : {}),
+  }
+}
+
+/**
+ * Soft-failure variant: a tool ran fine, but the answer is "no" or
+ * "invalid". `validate_datachain` and per-id null entries from
+ * `get_elements` use this so the MCP client doesn't treat them as
+ * transport-level failures.
+ */
+export function toSoftFailureResult<T>(env: Envelope<T>) {
+  return toToolResult(env, { isError: false })
+}

--- a/api/src/mcp/server.ts
+++ b/api/src/mcp/server.ts
@@ -171,6 +171,12 @@ export async function handleMcpRequest(c: Context<AppEnv>): Promise<Response> {
       const resp = await dispatch(registry, entry as JsonRpcRequest)
       if (resp) responses.push(resp)
     }
+    // JSON-RPC 2.0 §6: when a batch contains only notifications, the
+    // server MUST NOT return an empty Array — it returns nothing.
+    // Mirror the single-notification branch below.
+    if (responses.length === 0) {
+      return new Response(null, { status: 204 })
+    }
     return c.json(responses as unknown as Record<string, unknown>)
   }
   const resp = await dispatch(registry, body as JsonRpcRequest)

--- a/api/src/mcp/server.ts
+++ b/api/src/mcp/server.ts
@@ -1,0 +1,177 @@
+import type { Context } from 'hono'
+import type { AppEnv } from '../app-types.ts'
+import { errEnvelope, toToolResult } from './envelope.ts'
+import { buildToolRegistry, type ToolRegistry, type ToolResult } from './tools.ts'
+
+/**
+ * Hand-rolled MCP-over-JSON-RPC handler (plan fallback per
+ * `api/docs/mcp-fallback.md` rationale).
+ *
+ * The official `@modelcontextprotocol/sdk` pulls in CJS-only Ajv via
+ * its server transport, which workerd's nodejs_compat v1 cannot load
+ * cleanly. Rather than fight the SDK runtime, we implement the
+ * read-only subset of the protocol that DTPR needs (`initialize`,
+ * `tools/list`, `tools/call`) directly. Streamable HTTP semantics are
+ * trivial when we don't need server-initiated notifications: a single
+ * POST returns a single JSON response.
+ *
+ * Wire format implemented (2025-06-18 spec):
+ *   request  : { jsonrpc:"2.0", id, method, params? }
+ *   response : { jsonrpc:"2.0", id, result | error }
+ */
+
+export const PROTOCOL_VERSION = '2025-06-18'
+
+export const SERVER_INFO = {
+  name: 'dtpr-api',
+  version: '0.1.0',
+}
+
+export const SERVER_CAPABILITIES = {
+  tools: {},
+}
+
+interface JsonRpcRequest {
+  jsonrpc?: string
+  id?: number | string
+  method?: string
+  params?: Record<string, unknown>
+}
+
+type JsonRpcResponse =
+  | { jsonrpc: '2.0'; id: number | string | null; result: unknown }
+  | { jsonrpc: '2.0'; id: number | string | null; error: { code: number; message: string; data?: unknown } }
+
+const ERR = {
+  PARSE: -32700,
+  INVALID_REQUEST: -32600,
+  METHOD_NOT_FOUND: -32601,
+  INVALID_PARAMS: -32602,
+  INTERNAL: -32603,
+}
+
+function rpcError(
+  id: number | string | null,
+  code: number,
+  message: string,
+  data?: unknown,
+): JsonRpcResponse {
+  return { jsonrpc: '2.0', id, ...(data !== undefined ? { error: { code, message, data } } : { error: { code, message } }) }
+}
+
+function rpcSuccess(id: number | string, result: unknown): JsonRpcResponse {
+  return { jsonrpc: '2.0', id, result }
+}
+
+async function dispatch(
+  registry: ToolRegistry,
+  body: JsonRpcRequest,
+): Promise<JsonRpcResponse | null> {
+  const { id, method, params } = body
+  if (typeof method !== 'string' || method.length === 0) {
+    return rpcError(id ?? null, ERR.INVALID_REQUEST, 'Missing method')
+  }
+  // Notifications (no id) get no response per JSON-RPC spec.
+  const reqId = id ?? null
+
+  switch (method) {
+    case 'initialize': {
+      if (reqId === null) return null
+      return rpcSuccess(reqId, {
+        protocolVersion: PROTOCOL_VERSION,
+        serverInfo: SERVER_INFO,
+        capabilities: SERVER_CAPABILITIES,
+      })
+    }
+    case 'notifications/initialized':
+    case 'initialized': {
+      // Client confirmation — no response.
+      return null
+    }
+    case 'tools/list': {
+      if (reqId === null) return null
+      const tools = registry.list()
+      return rpcSuccess(reqId, { tools })
+    }
+    case 'tools/call': {
+      if (reqId === null) return null
+      const name = params?.['name']
+      const args = params?.['arguments'] ?? {}
+      if (typeof name !== 'string') {
+        return rpcError(reqId, ERR.INVALID_PARAMS, '`name` is required')
+      }
+      const tool = registry.get(name)
+      if (!tool) {
+        return rpcError(reqId, ERR.METHOD_NOT_FOUND, `Tool not found: ${name}`)
+      }
+      let result: ToolResult
+      try {
+        result = await tool.handler(args as Record<string, unknown>)
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e)
+        result = toToolResult(
+          errEnvelope([{ code: 'internal_error', message: msg }]),
+          { isError: true },
+        )
+      }
+      return rpcSuccess(reqId, result)
+    }
+    case 'ping': {
+      if (reqId === null) return null
+      return rpcSuccess(reqId, {})
+    }
+    default: {
+      if (reqId === null) return null
+      return rpcError(reqId, ERR.METHOD_NOT_FOUND, `Method not implemented: ${method}`)
+    }
+  }
+}
+
+/**
+ * Hono handler for `/mcp`. Accepts a single JSON-RPC POST and
+ * returns the response as `application/json` (no SSE / streaming
+ * needed for our stateless read-only surface).
+ *
+ * GET requests return 405 — server-initiated streams are not
+ * supported here.
+ */
+export async function handleMcpRequest(c: Context<AppEnv>): Promise<Response> {
+  if (c.req.method === 'GET') {
+    return c.json(
+      {
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: ERR.INVALID_REQUEST, message: 'GET not supported on /mcp' },
+      },
+      405,
+    )
+  }
+  let body: unknown
+  try {
+    body = await c.req.json()
+  } catch {
+    const res = rpcError(null, ERR.PARSE, 'Invalid JSON')
+    return c.json(res as Record<string, unknown>, 400)
+  }
+
+  const registry = buildToolRegistry({
+    bucket: c.env.CONTENT,
+    ctx: c.executionCtx,
+  })
+
+  // Single request or batch.
+  if (Array.isArray(body)) {
+    const responses: JsonRpcResponse[] = []
+    for (const entry of body) {
+      const resp = await dispatch(registry, entry as JsonRpcRequest)
+      if (resp) responses.push(resp)
+    }
+    return c.json(responses as unknown as Record<string, unknown>)
+  }
+  const resp = await dispatch(registry, body as JsonRpcRequest)
+  if (!resp) {
+    // Notification with no response — 204 per JSON-RPC convention.
+    return new Response(null, { status: 204 })
+  }
+  return c.json(resp as unknown as Record<string, unknown>)
+}

--- a/api/src/mcp/server.ts
+++ b/api/src/mcp/server.ts
@@ -68,6 +68,11 @@ async function dispatch(
   body: JsonRpcRequest,
 ): Promise<JsonRpcResponse | null> {
   const { id, method, params } = body
+  // Per JSON-RPC 2.0 spec, the `jsonrpc` member MUST be exactly "2.0".
+  // Reject requests that omit it or send a different version (e.g. "1.0").
+  if (body.jsonrpc !== '2.0') {
+    return rpcError(id ?? null, ERR.INVALID_REQUEST, 'Invalid or missing `jsonrpc` version; must be "2.0"')
+  }
   if (typeof method !== 'string' || method.length === 0) {
     return rpcError(id ?? null, ERR.INVALID_REQUEST, 'Missing method')
   }

--- a/api/src/mcp/tools.ts
+++ b/api/src/mcp/tools.ts
@@ -1,0 +1,578 @@
+import { z, ZodError, type ZodType } from 'zod'
+import {
+  ApiError,
+  apiErrors,
+  type ApiErrorShape,
+} from '../middleware/errors.ts'
+import {
+  loadCategories,
+  loadDatachainType,
+  loadElement,
+  loadElements,
+  loadManifest,
+  loadSchemaIndex,
+  loadSchemaJson,
+  type LoadContext,
+} from '../store/index.ts'
+import {
+  decodeCursor,
+  paginate,
+  parseLimitParam,
+  MAX_LIMIT,
+} from '../rest/pagination.ts'
+import {
+  deepFilterLocales,
+  projectFields,
+} from '../rest/responses.ts'
+import { reorderByIds, searchElementIds } from '../rest/search.ts'
+import {
+  resolveKnownVersion,
+  normalizeVersionParam,
+} from '../rest/version-resolver.ts'
+import { DatachainInstanceSchema } from '../schema/datachain-instance.ts'
+import { LocaleCodeSchema, type LocaleCode } from '../schema/locale.ts'
+import { validateInstance } from '../validator/semantic.ts'
+import {
+  errEnvelope,
+  okEnvelope,
+  toSoftFailureResult,
+  toToolResult,
+} from './envelope.ts'
+
+/** Cap on bulk `get_elements` requests. Keeps the corpus shippable in one call. */
+export const GET_ELEMENTS_MAX = 100
+/** Per-id length cap inside `get_elements`. */
+export const ELEMENT_ID_MAX_LEN = 128
+
+const DEFAULT_LIST_FIELDS = ['id', 'title', 'category_ids'] as const
+
+/** Tool result envelope as serialized to MCP clients. */
+export interface ToolResult {
+  structuredContent?: Record<string, unknown>
+  content: Array<{ type: 'text'; text: string }>
+  isError?: true
+}
+
+/** Tool descriptor shipped in `tools/list` responses. */
+export interface ToolDescriptor {
+  name: string
+  description: string
+  inputSchema: Record<string, unknown>
+  outputSchema?: Record<string, unknown>
+}
+
+interface ToolDef {
+  descriptor: ToolDescriptor
+  handler: (args: Record<string, unknown>) => Promise<ToolResult>
+}
+
+export interface ToolRegistry {
+  list(): ToolDescriptor[]
+  get(name: string): ToolDef | undefined
+}
+
+function apiErrorToErrors(err: unknown): ApiErrorShape[] {
+  if (err instanceof ApiError) return err.errors
+  if (err instanceof Error) return [{ code: 'internal_error', message: err.message }]
+  return [{ code: 'internal_error', message: String(err) }]
+}
+
+const VersionString = z.string().min(1).describe(
+  'Schema version, e.g. "ai@2026-04-16". Use list_schema_versions to enumerate.',
+)
+const ElementId = z.string().min(1).describe('Element id (whitelisted to [a-zA-Z0-9_-]).')
+const FieldsParam = z.union([z.array(z.string()), z.literal('all')])
+
+/** Wrap a Zod schema as a draft-2020-12 input schema for tools/list. */
+function schemaToJson(schema: ZodType): Record<string, unknown> {
+  return z.toJSONSchema(schema, {
+    target: 'draft-2020-12',
+    io: 'input',
+    unrepresentable: 'any',
+  }) as Record<string, unknown>
+}
+
+/**
+ * Build a tool registry bound to a specific request context. Each
+ * call to `/mcp` builds one of these; tool handlers close over the
+ * provided `LoadContext` for R2 + caches.
+ */
+export function buildToolRegistry(ctx: LoadContext): ToolRegistry {
+  const tools: ToolDef[] = [
+    listSchemaVersionsTool(ctx),
+    getSchemaTool(ctx),
+    listCategoriesTool(ctx),
+    listElementsTool(ctx),
+    getElementTool(ctx),
+    getElementsTool(ctx),
+    validateDatachainTool(ctx),
+  ]
+  const byName = new Map(tools.map((t) => [t.descriptor.name, t]))
+  return {
+    list: () => tools.map((t) => t.descriptor),
+    get: (name) => byName.get(name),
+  }
+}
+
+// ------------------------------------------------------------------ list_schema_versions
+function listSchemaVersionsTool(ctx: LoadContext): ToolDef {
+  const inputSchema = z.object({
+    datachain_type: z
+      .string()
+      .optional()
+      .describe('Filter to one type, e.g. "ai". Omit to list every version.'),
+  })
+  return {
+    descriptor: {
+      name: 'list_schema_versions',
+      description: 'List all known DTPR schema versions and their stability status.',
+      inputSchema: schemaToJson(inputSchema),
+    },
+    handler: async (raw) => {
+      try {
+        const args = inputSchema.parse(raw)
+        const index = await loadSchemaIndex(ctx)
+        const versions = args.datachain_type
+          ? index.versions.filter((v) => v.id.startsWith(`${args.datachain_type}@`))
+          : index.versions
+        return toToolResult(okEnvelope({ versions }))
+      } catch (e) {
+        return toToolResult(errEnvelope(zodOrApiErrors(e)))
+      }
+    },
+  }
+}
+
+// ------------------------------------------------------------------ get_schema
+function getSchemaTool(ctx: LoadContext): ToolDef {
+  const inputSchema = z.object({
+    version: VersionString,
+    include: z
+      .enum(['manifest', 'full'])
+      .default('manifest')
+      .describe('"manifest" (default): manifest + categories. "full": also inline elements.'),
+  })
+  return {
+    descriptor: {
+      name: 'get_schema',
+      description:
+        'Fetch a schema version. By default returns manifest + categories + datachain-type; pass include="full" to also inline every element.',
+      inputSchema: schemaToJson(inputSchema),
+    },
+    handler: async (raw) => {
+      try {
+        const args = inputSchema.parse(raw)
+        const version = await resolveKnownVersion(ctx, args.version)
+        const manifest = await loadManifest(ctx, version)
+        if (!manifest) {
+          return toToolResult(
+            errEnvelope([
+              { code: 'unknown_version', message: `Manifest for ${version.canonical} missing.` },
+            ]),
+          )
+        }
+        const datachainType = await loadDatachainType(ctx, version)
+        const categories = (await loadCategories(ctx, version)) ?? []
+        const schemaJson = await loadSchemaJson(ctx, version)
+        const data: Record<string, unknown> = {
+          version: version.canonical,
+          manifest,
+          datachain_type: datachainType,
+          categories,
+          schema_json: schemaJson,
+        }
+        if (args.include === 'full') {
+          data.elements = (await loadElements(ctx, version)) ?? []
+        }
+        return toToolResult(
+          okEnvelope(data, { content_hash: manifest.content_hash, version: version.canonical }),
+        )
+      } catch (e) {
+        return toToolResult(errEnvelope(zodOrApiErrors(e)))
+      }
+    },
+  }
+}
+
+// ------------------------------------------------------------------ list_categories
+function listCategoriesTool(ctx: LoadContext): ToolDef {
+  const inputSchema = z.object({
+    version: VersionString,
+    locales: z
+      .array(LocaleCodeSchema)
+      .optional()
+      .describe('Locales to retain in localized strings. Omit for every locale.'),
+  })
+  return {
+    descriptor: {
+      name: 'list_categories',
+      description: 'List the categories defined in a schema version, with locale filtering.',
+      inputSchema: schemaToJson(inputSchema),
+    },
+    handler: async (raw) => {
+      try {
+        const args = inputSchema.parse(raw)
+        const version = await resolveKnownVersion(ctx, args.version)
+        const manifest = await loadManifest(ctx, version)
+        if (!manifest) {
+          return toToolResult(
+            errEnvelope([
+              { code: 'unknown_version', message: `Manifest for ${version.canonical} missing.` },
+            ]),
+          )
+        }
+        const categories = (await loadCategories(ctx, version)) ?? []
+        const allow = args.locales ? new Set<LocaleCode>(args.locales) : null
+        const filtered = categories.map((c) => deepFilterLocales(c, allow))
+        return toToolResult(
+          okEnvelope(
+            { version: version.canonical, categories: filtered },
+            { content_hash: manifest.content_hash, version: version.canonical },
+          ),
+        )
+      } catch (e) {
+        return toToolResult(errEnvelope(zodOrApiErrors(e)))
+      }
+    },
+  }
+}
+
+// ------------------------------------------------------------------ list_elements
+function listElementsTool(ctx: LoadContext): ToolDef {
+  const inputSchema = z.object({
+    version: VersionString,
+    category_id: z.string().optional().describe('Restrict to one category.'),
+    locale: LocaleCodeSchema.default('en').describe('Locale used for `query` search. Default "en".'),
+    locales: z.array(LocaleCodeSchema).optional(),
+    query: z.string().optional().describe('BM25 search across title (boost 3) + description.'),
+    fields: FieldsParam.optional().describe(
+      'Field projection. Default: ["id","title","category_ids"]. Pass "all" for full elements.',
+    ),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(MAX_LIMIT)
+      .default(50)
+      .describe(`Page size (1-${MAX_LIMIT}). Default 50.`),
+    cursor: z.string().optional().describe('Opaque pagination cursor from a previous call.'),
+  })
+  return {
+    descriptor: {
+      name: 'list_elements',
+      description:
+        'List elements in a schema version. Supports category_id filter, BM25 `query`, locale filtering, projection, and opaque-cursor pagination.',
+      inputSchema: schemaToJson(inputSchema),
+    },
+    handler: async (raw) => {
+      try {
+        const args = inputSchema.parse(raw)
+        const version = await resolveKnownVersion(ctx, args.version)
+        const manifest = await loadManifest(ctx, version)
+        if (!manifest) {
+          return toToolResult(
+            errEnvelope([
+              { code: 'unknown_version', message: `Manifest for ${version.canonical} missing.` },
+            ]),
+          )
+        }
+        let elements = (await loadElements(ctx, version)) ?? []
+        if (args.category_id) {
+          elements = elements.filter((e) => e.category_ids.includes(args.category_id!))
+        }
+        if (args.query && args.query.trim().length > 0) {
+          const ids = await searchElementIds({
+            ctx,
+            version,
+            locale: args.locale,
+            query: args.query,
+          })
+          elements = reorderByIds(elements, ids)
+        }
+        const offset = decodeCursor(args.cursor)
+        const limit = parseLimitParam(args.limit?.toString())
+        const { page, nextCursor } = paginate(elements, offset, limit)
+        const fields = args.fields ?? DEFAULT_LIST_FIELDS
+        const allow = args.locales ? new Set<LocaleCode>(args.locales) : null
+        const projected = page.map((el) => projectFields(el, fields))
+        const filtered = projected.map((el) => deepFilterLocales(el, allow))
+        return toToolResult(
+          okEnvelope(
+            {
+              version: version.canonical,
+              elements: filtered,
+              total: elements.length,
+              returned: filtered.length,
+            },
+            {
+              content_hash: manifest.content_hash,
+              next_cursor: nextCursor,
+              version: version.canonical,
+            },
+          ),
+        )
+      } catch (e) {
+        return toToolResult(errEnvelope(zodOrApiErrors(e)))
+      }
+    },
+  }
+}
+
+// ------------------------------------------------------------------ get_element
+function getElementTool(ctx: LoadContext): ToolDef {
+  const inputSchema = z.object({
+    version: VersionString,
+    element_id: ElementId,
+    locales: z.array(LocaleCodeSchema).optional(),
+    fields: FieldsParam.optional(),
+  })
+  return {
+    descriptor: {
+      name: 'get_element',
+      description: 'Point read for a single element by id.',
+      inputSchema: schemaToJson(inputSchema),
+    },
+    handler: async (raw) => {
+      try {
+        const args = inputSchema.parse(raw)
+        const version = await resolveKnownVersion(ctx, args.version)
+        const manifest = await loadManifest(ctx, version)
+        if (!manifest) {
+          return toToolResult(
+            errEnvelope([
+              { code: 'unknown_version', message: `Manifest for ${version.canonical} missing.` },
+            ]),
+          )
+        }
+        const element = await loadElement(ctx, version, args.element_id)
+        if (!element) {
+          return toToolResult(
+            errEnvelope([
+              {
+                code: 'element_not_found',
+                message: `Element '${args.element_id}' not found in ${version.canonical}.`,
+                fix_hint: 'Use list_elements to enumerate available elements.',
+              },
+            ]),
+          )
+        }
+        const fields = args.fields ?? 'all'
+        const allow = args.locales ? new Set<LocaleCode>(args.locales) : null
+        const projected = projectFields(element, fields)
+        const filtered = deepFilterLocales(projected, allow)
+        return toToolResult(
+          okEnvelope(
+            { version: version.canonical, element: filtered },
+            { content_hash: manifest.content_hash, version: version.canonical },
+          ),
+        )
+      } catch (e) {
+        return toToolResult(errEnvelope(zodOrApiErrors(e)))
+      }
+    },
+  }
+}
+
+// ------------------------------------------------------------------ get_elements (bulk)
+function getElementsTool(ctx: LoadContext): ToolDef {
+  const inputSchema = z.object({
+    version: VersionString,
+    element_ids: z
+      .array(z.string().min(1).max(ELEMENT_ID_MAX_LEN))
+      .min(1)
+      .describe(`Element ids to fetch. Cap: ${GET_ELEMENTS_MAX} after dedupe.`),
+    locales: z.array(LocaleCodeSchema).optional(),
+    fields: FieldsParam.optional(),
+  })
+  return {
+    descriptor: {
+      name: 'get_elements',
+      description: `Bulk point read for up to ${GET_ELEMENTS_MAX} elements in one call. Server-side dedupes repeated ids; per-id failures appear inline as null with an errors[] entry.`,
+      inputSchema: schemaToJson(inputSchema),
+    },
+    handler: async (raw) => {
+      try {
+        const args = inputSchema.parse(raw)
+        for (const id of args.element_ids) {
+          if (id.length > ELEMENT_ID_MAX_LEN) {
+            return toToolResult(
+              errEnvelope([
+                {
+                  code: 'element_id_too_long',
+                  message: `element_id '${id.slice(0, 32)}…' exceeds ${ELEMENT_ID_MAX_LEN} chars.`,
+                  fix_hint: `Provide ids ≤${ELEMENT_ID_MAX_LEN} chars.`,
+                },
+              ]),
+            )
+          }
+        }
+        const dedup = Array.from(new Set(args.element_ids))
+        if (dedup.length > GET_ELEMENTS_MAX) {
+          return toToolResult(
+            errEnvelope([
+              {
+                code: 'element_ids_too_many',
+                message: `Requested ${dedup.length} unique ids; cap is ${GET_ELEMENTS_MAX}.`,
+                fix_hint: `Split into batches of ≤${GET_ELEMENTS_MAX} or use list_elements.`,
+              },
+            ]),
+          )
+        }
+        const version = await resolveKnownVersion(ctx, args.version)
+        const manifest = await loadManifest(ctx, version)
+        if (!manifest) {
+          return toToolResult(
+            errEnvelope([
+              { code: 'unknown_version', message: `Manifest for ${version.canonical} missing.` },
+            ]),
+          )
+        }
+        const fields = args.fields ?? 'all'
+        const allow = args.locales ? new Set<LocaleCode>(args.locales) : null
+        const elements: Record<string, unknown> = {}
+        const errors: ApiErrorShape[] = []
+        const reads = await Promise.all(
+          dedup.map(async (id) => ({ id, element: await loadElement(ctx, version, id) })),
+        )
+        for (const { id, element } of reads) {
+          if (!element) {
+            elements[id] = null
+            errors.push({
+              code: 'element_not_found',
+              message: `Element '${id}' not found.`,
+              path: id,
+              fix_hint: 'Use list_elements to enumerate available elements.',
+            })
+            continue
+          }
+          const projected = projectFields(element, fields)
+          elements[id] = deepFilterLocales(projected, allow)
+        }
+        if (errors.length > 0) {
+          return toSoftFailureResult({
+            ok: false,
+            errors,
+            meta: { content_hash: manifest.content_hash, version: version.canonical },
+            data: { version: version.canonical, elements },
+          } as never)
+        }
+        return toToolResult(
+          okEnvelope(
+            { version: version.canonical, elements },
+            { content_hash: manifest.content_hash, version: version.canonical },
+          ),
+        )
+      } catch (e) {
+        return toToolResult(errEnvelope(zodOrApiErrors(e)))
+      }
+    },
+  }
+}
+
+// ------------------------------------------------------------------ validate_datachain
+function validateDatachainTool(ctx: LoadContext): ToolDef {
+  const inputSchema = z.object({
+    version: VersionString,
+    datachain: z.unknown().describe('Datachain instance JSON. See schema_json.DatachainInstance.'),
+  })
+  return {
+    descriptor: {
+      name: 'validate_datachain',
+      description:
+        'Validate a datachain instance against a schema version. Returns ok:true on success or ok:false with structured errors + fix_hints. Always isError:false — invalid is a successful answer.',
+      inputSchema: schemaToJson(inputSchema),
+    },
+    handler: async (raw) => {
+      let args
+      try {
+        args = inputSchema.parse(raw)
+      } catch (e) {
+        return toToolResult(errEnvelope(zodOrApiErrors(e)))
+      }
+      try {
+        normalizeVersionParam(args.version)
+      } catch (e) {
+        return toToolResult(errEnvelope(apiErrorToErrors(e)))
+      }
+      try {
+        const version = await resolveKnownVersion(ctx, args.version)
+        const manifest = await loadManifest(ctx, version)
+        if (!manifest) {
+          return toToolResult(
+            errEnvelope([
+              { code: 'unknown_version', message: `Manifest for ${version.canonical} missing.` },
+            ]),
+          )
+        }
+        let parsed
+        try {
+          parsed = DatachainInstanceSchema.parse(args.datachain)
+        } catch (e) {
+          if (e instanceof ZodError) {
+            const errors = e.issues.map((iss) => ({
+              code: 'parse_error',
+              message: iss.message,
+              path: iss.path.join('.'),
+              fix_hint: 'Fix the field shape and retry.',
+            }))
+            return toSoftFailureResult(
+              errEnvelope(errors, {
+                content_hash: manifest.content_hash,
+                version: version.canonical,
+              }),
+            )
+          }
+          throw e
+        }
+        const datachainType = await loadDatachainType(ctx, version)
+        const categories = (await loadCategories(ctx, version)) ?? []
+        const elements = (await loadElements(ctx, version)) ?? []
+        if (!datachainType) {
+          return toToolResult(
+            errEnvelope([
+              {
+                code: 'unknown_version',
+                message: `Datachain type for ${version.canonical} missing.`,
+              },
+            ]),
+          )
+        }
+        const result = validateInstance(
+          { manifest, datachainType, categories, elements },
+          parsed,
+        )
+        if (result.ok) {
+          return toSoftFailureResult(
+            okEnvelope(
+              { ok: true, warnings: result.warnings },
+              { content_hash: manifest.content_hash, version: version.canonical },
+            ),
+          )
+        }
+        return toSoftFailureResult(
+          errEnvelope(result.errors, {
+            content_hash: manifest.content_hash,
+            version: version.canonical,
+            warnings: result.warnings.map((w) => `${w.code}: ${w.message}`),
+          }),
+        )
+      } catch (e) {
+        return toToolResult(errEnvelope(apiErrorToErrors(e)))
+      }
+    },
+  }
+}
+
+function zodOrApiErrors(err: unknown): ApiErrorShape[] {
+  if (err instanceof ZodError) {
+    return err.issues.map((iss) => ({
+      code: 'invalid_arguments',
+      message: iss.message,
+      path: iss.path.join('.'),
+      fix_hint: 'Provide valid values for the tool arguments.',
+    }))
+  }
+  return apiErrorToErrors(err)
+}
+
+export { apiErrors }

--- a/api/src/mcp/tools.ts
+++ b/api/src/mcp/tools.ts
@@ -41,8 +41,8 @@ import {
 
 /** Cap on bulk `get_elements` requests. Keeps the corpus shippable in one call. */
 export const GET_ELEMENTS_MAX = 100
-/** Per-id length cap inside `get_elements`. */
-export const ELEMENT_ID_MAX_LEN = 128
+/** Per-id length cap inside `get_elements`. Enforced by the input schema. */
+const ELEMENT_ID_MAX_LEN = 128
 
 const DEFAULT_LIST_FIELDS = ['id', 'title', 'category_ids'] as const
 
@@ -393,19 +393,6 @@ function getElementsTool(ctx: LoadContext): ToolDef {
     handler: async (raw) => {
       try {
         const args = inputSchema.parse(raw)
-        for (const id of args.element_ids) {
-          if (id.length > ELEMENT_ID_MAX_LEN) {
-            return toToolResult(
-              errEnvelope([
-                {
-                  code: 'element_id_too_long',
-                  message: `element_id '${id.slice(0, 32)}…' exceeds ${ELEMENT_ID_MAX_LEN} chars.`,
-                  fix_hint: `Provide ids ≤${ELEMENT_ID_MAX_LEN} chars.`,
-                },
-              ]),
-            )
-          }
-        }
         const dedup = Array.from(new Set(args.element_ids))
         if (dedup.length > GET_ELEMENTS_MAX) {
           return toToolResult(

--- a/api/src/mcp/tools.ts
+++ b/api/src/mcp/tools.ts
@@ -287,7 +287,11 @@ function listElementsTool(ctx: LoadContext): ToolDef {
             locale: args.locale,
             query: args.query,
           })
-          elements = reorderByIds(elements, ids)
+          // `null` means no index for this locale — leave elements in
+          // natural order rather than zeroing them out.
+          if (ids !== null) {
+            elements = reorderByIds(elements, ids)
+          }
         }
         const offset = decodeCursor(args.cursor)
         const limit = parseLimitParam(args.limit?.toString())

--- a/api/src/middleware/cors.ts
+++ b/api/src/middleware/cors.ts
@@ -1,0 +1,44 @@
+import { cors } from 'hono/cors'
+import type { MiddlewareHandler } from 'hono'
+
+/**
+ * Static allow-list (R32). Wildcards are forbidden; every origin is
+ * explicitly enumerated plus a preview regex for ephemeral deploys.
+ */
+const ALLOW_LIST: readonly string[] = [
+  'https://dtpr.io',
+  'https://www.dtpr.io',
+  'https://docs.dtpr.io',
+  'https://studio.nuxt.com',
+]
+
+const PREVIEW_HOST_RE = /^https:\/\/[a-z0-9-]+-preview\.api\.dtpr\.io$/
+const LOCAL_HOST_RE = /^http:\/\/localhost(:\d+)?$/
+const LOCAL_127_RE = /^http:\/\/127\.0\.0\.1(:\d+)?$/
+
+function isAllowedOrigin(origin: string): boolean {
+  if (ALLOW_LIST.includes(origin)) return true
+  if (PREVIEW_HOST_RE.test(origin)) return true
+  if (LOCAL_HOST_RE.test(origin)) return true
+  if (LOCAL_127_RE.test(origin)) return true
+  return false
+}
+
+/**
+ * CORS policy:
+ *  - GET + POST only (no credentials, no cookies).
+ *  - Explicit allow-list; no wildcards.
+ *  - Preview hostnames matched by pattern so we don't have to enumerate
+ *    every PR-specific subdomain.
+ */
+export const configuredCors = (): MiddlewareHandler =>
+  cors({
+    origin: (origin) => (isAllowedOrigin(origin) ? origin : null),
+    allowMethods: ['GET', 'POST', 'OPTIONS'],
+    allowHeaders: ['Content-Type', 'DTPR-Client', 'Authorization'],
+    exposeHeaders: ['X-Request-Id', 'DTPR-Content-Hash', 'Retry-After'],
+    credentials: false,
+    maxAge: 86400,
+  })
+
+export const _test = { isAllowedOrigin }

--- a/api/src/middleware/error-handler.ts
+++ b/api/src/middleware/error-handler.ts
@@ -1,0 +1,69 @@
+import type { Hono } from 'hono'
+import type { AppEnv } from '../app-types.ts'
+import { R2LoadError } from '../store/r2-loader.ts'
+import { ApiError, apiErrors, errorEnvelope } from './errors.ts'
+
+/**
+ * Installs the global `onError` + `notFound` handlers. Every error
+ * path in the pipeline must funnel through here so clients see a
+ * uniform envelope shape (no raw stack traces escape).
+ *
+ * Mapping:
+ *  - `ApiError` → use its attached status + errors
+ *  - `R2LoadError` → 502 upstream
+ *  - anything else → 500 internal (message redacted)
+ *
+ * The request id from `c.var.requestId` is echoed in responses so
+ * callers can report issues with a correlation key. Unexpected errors
+ * are logged (with stack) so they're visible in Cloudflare logs.
+ */
+export function registerErrorHandler(app: Hono<AppEnv>): void {
+  app.onError((err, c) => {
+    const requestId = c.get('requestId')
+    if (err instanceof ApiError) {
+      return c.json(errorEnvelope(err.errors), err.status, {
+        ...(requestId ? { 'X-Request-Id': requestId } : {}),
+      })
+    }
+    if (err instanceof R2LoadError) {
+      logUnhandled(c, err, 'r2_load_error')
+      const e = apiErrors.upstreamError(err.key)
+      return c.json(errorEnvelope(e.errors), e.status, {
+        ...(requestId ? { 'X-Request-Id': requestId } : {}),
+      })
+    }
+    logUnhandled(c, err, 'unhandled')
+    const e = apiErrors.internal()
+    return c.json(errorEnvelope(e.errors), e.status, {
+      ...(requestId ? { 'X-Request-Id': requestId } : {}),
+    })
+  })
+
+  app.notFound((c) => {
+    const requestId = c.get('requestId')
+    const err = apiErrors.notFound('Route not found.')
+    return c.json(errorEnvelope(err.errors), err.status, {
+      ...(requestId ? { 'X-Request-Id': requestId } : {}),
+    })
+  })
+}
+
+function logUnhandled(
+  c: { req: { method: string; url: string }; get: (k: 'requestId') => string | undefined },
+  err: unknown,
+  tag: string,
+): void {
+  const message = err instanceof Error ? err.message : String(err)
+  const stack = err instanceof Error ? err.stack : undefined
+  console.error(
+    JSON.stringify({
+      level: 'error',
+      tag,
+      method: c.req.method,
+      url: c.req.url,
+      request_id: c.get('requestId'),
+      message,
+      stack,
+    }),
+  )
+}

--- a/api/src/middleware/errors.ts
+++ b/api/src/middleware/errors.ts
@@ -1,0 +1,97 @@
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
+
+/**
+ * Shape of a single error record in the public envelope. Contract is
+ * stable — adding new `code` values is additive; renaming/removing is
+ * a breaking change (guarded by snapshot fixtures in
+ * `api/test/fixtures/error-envelopes/`).
+ */
+export interface ApiErrorShape {
+  code: string
+  message: string
+  /** JSON path inside the caller's payload, e.g. `elements[3].category_ids[1]`. */
+  path?: string
+  /** Short actionable instruction for a caller (agent or human). */
+  fix_hint?: string
+}
+
+export interface ApiErrorEnvelope {
+  ok: false
+  errors: ApiErrorShape[]
+}
+
+/**
+ * Thrown anywhere in the request pipeline; caught by the global
+ * `onError` handler (see `registerErrorHandler`). Carries the HTTP
+ * status and one or more structured errors.
+ */
+export class ApiError extends Error {
+  constructor(
+    public readonly status: ContentfulStatusCode,
+    public readonly errors: ApiErrorShape[],
+  ) {
+    super(errors[0]?.message ?? 'api error')
+    this.name = 'ApiError'
+  }
+}
+
+export function errorEnvelope(errors: ApiErrorShape[]): ApiErrorEnvelope {
+  return { ok: false, errors }
+}
+
+/**
+ * Known error-shape factories. Centralizing these keeps `code` values
+ * consistent across REST + MCP surfaces and lets reviewers spot new
+ * codes introduced by a change.
+ */
+export const apiErrors = {
+  badRequest(message: string, path?: string, fix_hint?: string): ApiError {
+    return new ApiError(400, [{ code: 'bad_request', message, path, fix_hint }])
+  },
+  notFound(message: string, fix_hint?: string): ApiError {
+    return new ApiError(404, [{ code: 'not_found', message, fix_hint }])
+  },
+  payloadTooLarge(maxBytes: number): ApiError {
+    return new ApiError(413, [
+      {
+        code: 'payload_too_large',
+        message: `Request body exceeds ${maxBytes}-byte limit.`,
+        fix_hint: 'Shrink the request or break it into smaller batches.',
+      },
+    ])
+  },
+  timeout(budgetMs: number): ApiError {
+    return new ApiError(504, [
+      {
+        code: 'timeout',
+        message: `Request exceeded ${budgetMs}-ms wall-clock budget.`,
+        fix_hint: 'Retry; if persistent, reduce payload size or open an issue.',
+      },
+    ])
+  },
+  rateLimited(retryAfterSeconds: number): ApiError {
+    return new ApiError(429, [
+      {
+        code: 'rate_limited',
+        message: 'Rate limit exceeded.',
+        fix_hint: `Wait ${retryAfterSeconds} seconds or set \`DTPR-Client\` for a dedicated bucket.`,
+      },
+    ])
+  },
+  upstreamError(key?: string): ApiError {
+    return new ApiError(502, [
+      {
+        code: 'upstream_error',
+        message: key
+          ? `Schema store read failed for ${key}.`
+          : 'Schema store unreachable.',
+        fix_hint: 'Retry; if persistent, the content store may be degraded.',
+      },
+    ])
+  },
+  internal(): ApiError {
+    return new ApiError(500, [
+      { code: 'internal_error', message: 'Unexpected server error.' },
+    ])
+  },
+}

--- a/api/src/middleware/logging.ts
+++ b/api/src/middleware/logging.ts
@@ -1,0 +1,41 @@
+import type { MiddlewareHandler } from 'hono'
+
+/**
+ * Emits one structured log line per request with method, path, status,
+ * duration, and request id. The line is JSON so it's filterable in
+ * Cloudflare's workers observability UI.
+ *
+ * Failures still log — the error handler formats the response body;
+ * we want the request trace regardless of status.
+ */
+export const logging = (): MiddlewareHandler => async (c, next) => {
+  const start = Date.now()
+  let error: unknown = undefined
+  try {
+    await next()
+  } catch (e) {
+    error = e
+    throw e
+  } finally {
+    const duration = Date.now() - start
+    const status = c.res?.status ?? (error ? 500 : 0)
+    const urlPath = safePath(c.req.url)
+    const line = {
+      level: error ? 'error' : 'info',
+      method: c.req.method,
+      path: urlPath,
+      status,
+      duration_ms: duration,
+      request_id: c.get('requestId'),
+    }
+    console.log(JSON.stringify(line))
+  }
+}
+
+function safePath(raw: string): string {
+  try {
+    return new URL(raw).pathname
+  } catch {
+    return raw
+  }
+}

--- a/api/src/middleware/payload-limits.ts
+++ b/api/src/middleware/payload-limits.ts
@@ -5,12 +5,22 @@ import { apiErrors } from './errors.ts'
 export const MAX_PAYLOAD_BYTES = 64 * 1024
 
 /**
- * Rejects requests whose `Content-Length` exceeds the limit.
+ * Rejects requests whose body exceeds the limit.
+ *
+ * If `Content-Length` is present we trust it as a cheap pre-parse
+ * short-circuit. If it's absent (e.g. HTTP/1.1 chunked transfer
+ * encoding from an Edge client), we drain the body stream ourselves,
+ * counting bytes incrementally and aborting as soon as we cross the
+ * cap — this prevents an attacker from forcing us to buffer a
+ * gigabyte of chunked input before Zod ever gets a look.
+ *
+ * The drained bytes are seeded into Hono's `bodyCache` so the route
+ * handler can still call `c.req.json()` / `c.req.text()` without
+ * re-reading the (now-consumed) underlying `ReadableStream`.
  *
  * Depth (32) and array (1000) caps are enforced by Zod at parse time
  * rather than here — Zod sees the actual structure and can emit a
- * precise path. This middleware is a cheap, pre-parse short-circuit
- * for obviously-too-large bodies.
+ * precise path.
  */
 export const payloadLimits = (maxBytes = MAX_PAYLOAD_BYTES): MiddlewareHandler =>
   async (c, next) => {
@@ -27,6 +37,62 @@ export const payloadLimits = (maxBytes = MAX_PAYLOAD_BYTES): MiddlewareHandler =
       if (len > maxBytes) {
         throw apiErrors.payloadTooLarge(maxBytes)
       }
+      await next()
+      return
     }
+
+    // No declared length: we have to count bytes as they arrive.
+    const stream = c.req.raw.body
+    if (stream === null) {
+      await next()
+      return
+    }
+
+    const reader = stream.getReader()
+    const chunks: Uint8Array[] = []
+    let total = 0
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        if (value === undefined) continue
+        total += value.byteLength
+        if (total > maxBytes) {
+          // Stop pulling more bytes from the wire and reject.
+          await reader.cancel().catch(() => {})
+          throw apiErrors.payloadTooLarge(maxBytes)
+        }
+        chunks.push(value)
+      }
+    } finally {
+      reader.releaseLock()
+    }
+
+    // Re-attach the consumed body via Hono's bodyCache so downstream
+    // c.req.json()/text()/arrayBuffer() reuse the buffered bytes.
+    // (Hono types `bodyCache` as Partial<Body>, but at runtime each
+    // slot holds the resolved promise rather than a method — so we
+    // cast through unknown to assign the buffered ArrayBuffer.)
+    const buffer = concatChunks(chunks, total)
+    const arrayBuffer = buffer.buffer.slice(
+      buffer.byteOffset,
+      buffer.byteOffset + buffer.byteLength,
+    ) as ArrayBuffer
+    const cache = c.req.bodyCache as unknown as {
+      arrayBuffer?: Promise<ArrayBuffer>
+    }
+    cache.arrayBuffer = Promise.resolve(arrayBuffer)
+
     await next()
   }
+
+function concatChunks(chunks: Uint8Array[], total: number): Uint8Array {
+  if (chunks.length === 1) return chunks[0]!
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return out
+}

--- a/api/src/middleware/payload-limits.ts
+++ b/api/src/middleware/payload-limits.ts
@@ -1,0 +1,32 @@
+import type { MiddlewareHandler } from 'hono'
+import { apiErrors } from './errors.ts'
+
+/** Plan R30: 64 KB payload cap on every request. */
+export const MAX_PAYLOAD_BYTES = 64 * 1024
+
+/**
+ * Rejects requests whose `Content-Length` exceeds the limit.
+ *
+ * Depth (32) and array (1000) caps are enforced by Zod at parse time
+ * rather than here — Zod sees the actual structure and can emit a
+ * precise path. This middleware is a cheap, pre-parse short-circuit
+ * for obviously-too-large bodies.
+ */
+export const payloadLimits = (maxBytes = MAX_PAYLOAD_BYTES): MiddlewareHandler =>
+  async (c, next) => {
+    const lenHeader = c.req.header('content-length')
+    if (lenHeader !== undefined) {
+      const len = Number(lenHeader)
+      if (!Number.isFinite(len) || len < 0) {
+        throw apiErrors.badRequest(
+          `Invalid Content-Length header: ${lenHeader}`,
+          undefined,
+          'Send a valid Content-Length or omit it.',
+        )
+      }
+      if (len > maxBytes) {
+        throw apiErrors.payloadTooLarge(maxBytes)
+      }
+    }
+    await next()
+  }

--- a/api/src/middleware/rate-limit.ts
+++ b/api/src/middleware/rate-limit.ts
@@ -1,0 +1,70 @@
+import type { MiddlewareHandler } from 'hono'
+import type { AppEnv } from '../app-types.ts'
+import { apiErrors } from './errors.ts'
+
+/** Window used for the synthetic Retry-After hint. Matches the WAF rule period. */
+const RETRY_AFTER_SECONDS = 60
+const ANONYMOUS_CLIENT = 'anonymous'
+const CLIENT_HEADER = 'DTPR-Client'
+
+/**
+ * Extract the caller's stable rate-limit identity. IP + the
+ * (voluntary) `DTPR-Client: name/version` header. Anonymous callers
+ * all share one bucket; identified clients get their own, which lets
+ * a legitimate shared-egress tool (Claude Desktop, worcester-app)
+ * escape the anonymous-pool noise.
+ */
+export function composeRateKey(req: { header: (name: string) => string | undefined }): string {
+  const ip = req.header('cf-connecting-ip') ?? req.header('x-forwarded-for') ?? 'unknown'
+  const client = req.header(CLIENT_HEADER)?.trim()
+  return `${ip}:${client && client.length > 0 ? client : ANONYMOUS_CLIENT}`
+}
+
+/**
+ * Resolve a rate-limit binding by name. Returns `null` when the
+ * binding is not configured (dev, unit tests, preview bootstrap) so
+ * the middleware can skip quietly instead of 500'ing.
+ */
+function getBinding(env: Env, name: string): RateLimit | null {
+  const candidate = (env as unknown as Record<string, unknown>)[name]
+  if (candidate && typeof (candidate as RateLimit).limit === 'function') {
+    return candidate as RateLimit
+  }
+  return null
+}
+
+export interface RateLimitMiddlewareOptions {
+  /**
+   * Env binding name for the rate-limit bucket to consume from.
+   * Typically `RL_READ` or `RL_VALIDATE`.
+   */
+  binding: string
+}
+
+/**
+ * Middleware that consumes one token from the named rate-limit
+ * binding (Workers Rate Limit API) per request. Over-limit responses
+ * get a typed 429 envelope with a `Retry-After` header and a
+ * fix_hint that points clients at the `DTPR-Client` convention.
+ *
+ * No-op when the binding is missing so the middleware is safe to
+ * include in test and preview builds without extra gating.
+ */
+export const rateLimit = (
+  options: RateLimitMiddlewareOptions,
+): MiddlewareHandler<AppEnv> => async (c, next) => {
+  const binding = getBinding(c.env, options.binding)
+  if (!binding) {
+    await next()
+    return
+  }
+  const key = composeRateKey(c.req)
+  const { success } = await binding.limit({ key })
+  if (!success) {
+    c.header('Retry-After', String(RETRY_AFTER_SECONDS))
+    throw apiErrors.rateLimited(RETRY_AFTER_SECONDS)
+  }
+  await next()
+}
+
+export const _test = { composeRateKey, getBinding, CLIENT_HEADER }

--- a/api/src/middleware/request-id.ts
+++ b/api/src/middleware/request-id.ts
@@ -1,0 +1,15 @@
+import { requestId as honoRequestId } from 'hono/request-id'
+import type { MiddlewareHandler } from 'hono'
+
+/**
+ * Stamps every request with an `X-Request-Id` header. Reuses Hono's
+ * built-in middleware so incoming IDs are respected (subject to safe
+ * character/length limits) and generates a UUID when absent.
+ *
+ * `c.var.requestId` is typed via `hono/request-id`'s module augmentation.
+ */
+export const configuredRequestId = (): MiddlewareHandler =>
+  honoRequestId({
+    headerName: 'X-Request-Id',
+    // Keep defaults for generator + length limit.
+  })

--- a/api/src/middleware/timeout.ts
+++ b/api/src/middleware/timeout.ts
@@ -1,0 +1,51 @@
+import type { MiddlewareHandler } from 'hono'
+import { apiErrors } from './errors.ts'
+
+/**
+ * Default wall-clock budgets. The plan targets tighter numbers (50 ms
+ * reads / 500 ms validate) — those are the production SLOs. The
+ * defaults here are generous enough that genuine cold-cache R2 reads
+ * won't trip the guard in local / test environments; route-specific
+ * budgets can be passed when mounting the middleware per route.
+ *
+ * CPU budget is enforced separately by Wrangler `limits.cpu_ms`.
+ */
+export const DEFAULT_READ_BUDGET_MS = 2_000
+export const DEFAULT_VALIDATE_BUDGET_MS = 5_000
+
+export interface TimeoutOptions {
+  /** Budget in milliseconds for this mount's handler. */
+  budgetMs: number
+}
+
+/**
+ * Wall-clock timeout via AbortController + `setTimeout`. Race pattern:
+ * the handler runs as normal; an AbortSignal is exposed on
+ * `c.var.abortSignal` so loaders can abort their own inner work; when
+ * the timer fires, we reject with a typed 504 envelope.
+ *
+ * Note: JavaScript cannot actually stop a running handler, so a
+ * CPU-bound handler past its budget keeps burning until it yields.
+ * The signal-based opt-in is the cooperative half; `limits.cpu_ms`
+ * is the coercive one.
+ */
+export const timeout = (options: TimeoutOptions): MiddlewareHandler =>
+  async (c, next) => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), options.budgetMs)
+    c.set('abortSignal', controller.signal)
+    try {
+      await Promise.race([
+        next(),
+        new Promise<never>((_, reject) => {
+          controller.signal.addEventListener(
+            'abort',
+            () => reject(apiErrors.timeout(options.budgetMs)),
+            { once: true },
+          )
+        }),
+      ])
+    } finally {
+      clearTimeout(timer)
+    }
+  }

--- a/api/src/rest/pagination.ts
+++ b/api/src/rest/pagination.ts
@@ -1,0 +1,93 @@
+import { apiErrors } from '../middleware/errors.ts'
+
+/**
+ * Opaque cursor pagination (MCP spec, base64-encoded `{offset}`).
+ *
+ * Clients MUST treat cursors as opaque tokens — discard on schema
+ * version change, never decode/manipulate. Validity is bounded by
+ * the version because offset positions depend on the sorted element
+ * list for a given snapshot.
+ */
+
+export const DEFAULT_LIMIT = 50
+export const MAX_LIMIT = 200
+
+interface CursorPayload {
+  offset: number
+}
+
+export function encodeCursor(offset: number): string {
+  const json = JSON.stringify({ offset } satisfies CursorPayload)
+  return btoa(json)
+}
+
+export function decodeCursor(raw: string | null | undefined): number {
+  if (!raw) return 0
+  let decoded: string
+  try {
+    decoded = atob(raw)
+  } catch {
+    throw apiErrors.badRequest(
+      'Invalid pagination cursor.',
+      undefined,
+      'Discard the cursor and re-issue the request without one, or pass a value previously returned by the API.',
+    )
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(decoded)
+  } catch {
+    throw apiErrors.badRequest('Invalid pagination cursor.', undefined, 'Discard the cursor.')
+  }
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    typeof (parsed as { offset?: unknown }).offset !== 'number' ||
+    !Number.isInteger((parsed as { offset: number }).offset) ||
+    (parsed as { offset: number }).offset < 0
+  ) {
+    throw apiErrors.badRequest('Invalid pagination cursor.', undefined, 'Discard the cursor.')
+  }
+  return (parsed as { offset: number }).offset
+}
+
+/**
+ * Resolve a `?limit=` value to an integer in `[1, MAX_LIMIT]`. Rejects
+ * non-integers and out-of-range values with a typed 400.
+ */
+export function parseLimitParam(raw?: string | null, fallback = DEFAULT_LIMIT): number {
+  if (raw === undefined || raw === null || raw === '') return fallback
+  const n = Number(raw)
+  if (!Number.isInteger(n) || n <= 0) {
+    throw apiErrors.badRequest(
+      `Invalid limit '${raw}'`,
+      undefined,
+      `Use a positive integer up to ${MAX_LIMIT}.`,
+    )
+  }
+  if (n > MAX_LIMIT) {
+    throw apiErrors.badRequest(
+      `Limit ${n} exceeds maximum (${MAX_LIMIT}).`,
+      undefined,
+      `Reduce the limit to ${MAX_LIMIT} or less.`,
+    )
+  }
+  return n
+}
+
+/**
+ * Slice `items` for a single page. Returns the page + the cursor for
+ * the next page (or null when there is none).
+ */
+export function paginate<T>(
+  items: T[],
+  offset: number,
+  limit: number,
+): { page: T[]; nextCursor: string | null } {
+  const page = items.slice(offset, offset + limit)
+  const next = offset + limit
+  return {
+    page,
+    nextCursor: next < items.length ? encodeCursor(next) : null,
+  }
+}

--- a/api/src/rest/responses.ts
+++ b/api/src/rest/responses.ts
@@ -1,0 +1,120 @@
+import type { Context } from 'hono'
+import type { LocaleCode, LocaleValue } from '../schema/locale.ts'
+import type { SchemaManifest } from '../schema/manifest.ts'
+
+/**
+ * Parse a `?locales=en,fr` query param into a Set. Returns `null` when
+ * the param is absent — callers interpret null as "no filter".
+ *
+ * Unknown locale codes (e.g. `?locales=zz`) are tolerated here; the
+ * filter just removes nothing for them. The schema's locale allow-list
+ * lives on the manifest, not the response shape.
+ */
+export function parseLocalesParam(raw?: string | null): Set<LocaleCode> | null {
+  if (!raw) return null
+  const parts = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean) as LocaleCode[]
+  return parts.length === 0 ? null : new Set(parts)
+}
+
+function isLocaleValue(v: unknown): v is LocaleValue {
+  return (
+    !!v &&
+    typeof v === 'object' &&
+    'locale' in (v as object) &&
+    'value' in (v as object) &&
+    typeof (v as { locale: unknown }).locale === 'string' &&
+    typeof (v as { value: unknown }).value === 'string'
+  )
+}
+
+/**
+ * Recursively walk a value and filter every `LocaleValue[]` it
+ * contains down to the requested locales. Leaves non-localized data
+ * untouched. Pure — does not mutate inputs.
+ *
+ * The shape detection is deliberately simple: an array whose first
+ * element matches `{ locale: string, value: string }`. This mirrors
+ * the heuristic in the v1 API's `filterLocaleValues` and keeps the
+ * filter independent of any specific Zod schema.
+ */
+export function deepFilterLocales<T>(value: T, allow: Set<LocaleCode> | null): T {
+  if (!allow) return value
+  if (Array.isArray(value)) {
+    if (value.length > 0 && isLocaleValue(value[0])) {
+      return value.filter((entry) =>
+        isLocaleValue(entry) ? allow.has(entry.locale as LocaleCode) : true,
+      ) as unknown as T
+    }
+    return value.map((entry) => deepFilterLocales(entry, allow)) as unknown as T
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = deepFilterLocales(v, allow)
+    }
+    return out as T
+  }
+  return value
+}
+
+/**
+ * Cache-Control directive for a version.
+ *  - stable → safe to cache for 24h, immutable
+ *  - beta   → never cache; agents/devs must always see fresh bytes
+ */
+export function cacheControlFor(manifest: SchemaManifest): string {
+  return manifest.status === 'stable'
+    ? 'public, max-age=86400, immutable'
+    : 'no-store'
+}
+
+/**
+ * Stamp the standard pair of response headers — content hash for
+ * pinning + cache-control matching the version's mutability.
+ */
+export function setVersionHeaders(c: Context, manifest: SchemaManifest): void {
+  c.header('DTPR-Content-Hash', manifest.content_hash)
+  c.header('Cache-Control', cacheControlFor(manifest))
+}
+
+/**
+ * Project an object down to a subset of its top-level fields. `id` is
+ * always retained so callers can correlate compact rows with the full
+ * record.
+ *
+ * The `'all'` sentinel returns the input unchanged. Unknown field
+ * names are silently ignored (no error) so callers can write feature-
+ * detected projection lists.
+ */
+export function projectFields<T extends { id: string }>(
+  obj: T,
+  fields: readonly string[] | 'all',
+): Partial<T> & Pick<T, 'id'> {
+  if (fields === 'all') return obj
+  const out: Record<string, unknown> = { id: obj.id }
+  for (const field of fields) {
+    if (field === 'id') continue
+    if (field in obj) out[field] = (obj as Record<string, unknown>)[field]
+  }
+  return out as Partial<T> & Pick<T, 'id'>
+}
+
+/**
+ * Parse a `?fields=a,b,c` query param. Returns `'all'` when the param
+ * value is the literal `'all'`. Returns null for missing — the caller
+ * picks an endpoint-appropriate default (e.g. `['id', 'title',
+ * 'category_ids']` for `/elements`).
+ */
+export function parseFieldsParam(raw?: string | null): readonly string[] | 'all' | null {
+  if (raw === undefined || raw === null) return null
+  const trimmed = raw.trim()
+  if (trimmed === '') return null
+  if (trimmed === 'all') return 'all'
+  return trimmed
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}

--- a/api/src/rest/routes.ts
+++ b/api/src/rest/routes.ts
@@ -1,0 +1,192 @@
+import { Hono } from 'hono'
+import { ZodError } from 'zod'
+import type { AppEnv } from '../app-types.ts'
+import { apiErrors } from '../middleware/errors.ts'
+import { DatachainInstanceSchema } from '../schema/datachain-instance.ts'
+import {
+  loadCategories,
+  loadDatachainType,
+  loadElement,
+  loadElements,
+  loadManifest,
+  loadSchemaIndex,
+  type LoadContext,
+} from '../store/index.ts'
+import { validateInstance } from '../validator/semantic.ts'
+import {
+  decodeCursor,
+  paginate,
+  parseLimitParam,
+} from './pagination.ts'
+import {
+  deepFilterLocales,
+  parseFieldsParam,
+  parseLocalesParam,
+  projectFields,
+  setVersionHeaders,
+} from './responses.ts'
+import { reorderByIds, searchElementIds } from './search.ts'
+import { resolveKnownVersion } from './version-resolver.ts'
+
+const DEFAULT_ELEMENT_FIELDS = ['id', 'title', 'category_ids'] as const
+
+function loadCtx(c: { env: Env; executionCtx?: { waitUntil(p: Promise<unknown>): void } }): LoadContext {
+  return { bucket: c.env.CONTENT, ctx: c.executionCtx }
+}
+
+/**
+ * Mount the REST surface at `/api/v2`. Returns a Hono sub-app the
+ * caller can `app.route('/api/v2', restApp())`.
+ *
+ * Routes:
+ *   GET  /schemas
+ *   GET  /schemas/:version/manifest
+ *   GET  /schemas/:version/categories
+ *   GET  /schemas/:version/elements
+ *   GET  /schemas/:version/elements/:element_id
+ *   POST /schemas/:version/validate
+ */
+export function createRestApp() {
+  const app = new Hono<AppEnv>()
+
+  app.get('/schemas', async (c) => {
+    const ctx = loadCtx(c)
+    const index = await loadSchemaIndex(ctx)
+    return c.json({ ok: true, versions: index.versions })
+  })
+
+  app.get('/schemas/:version/manifest', async (c) => {
+    const ctx = loadCtx(c)
+    const version = await resolveKnownVersion(ctx, c.req.param('version'))
+    const manifest = await loadManifest(ctx, version)
+    if (!manifest) throw apiErrors.notFound(`Manifest for ${version.canonical} missing.`)
+    setVersionHeaders(c, manifest)
+    return c.json({ ok: true, manifest })
+  })
+
+  app.get('/schemas/:version/categories', async (c) => {
+    const ctx = loadCtx(c)
+    const version = await resolveKnownVersion(ctx, c.req.param('version'))
+    const manifest = await loadManifest(ctx, version)
+    if (!manifest) throw apiErrors.notFound(`Manifest for ${version.canonical} missing.`)
+    const allow = parseLocalesParam(c.req.query('locales'))
+    const categories = (await loadCategories(ctx, version)) ?? []
+    const filtered = categories.map((cat) => deepFilterLocales(cat, allow))
+    setVersionHeaders(c, manifest)
+    return c.json({ ok: true, version: version.canonical, categories: filtered })
+  })
+
+  app.get('/schemas/:version/elements', async (c) => {
+    const ctx = loadCtx(c)
+    const version = await resolveKnownVersion(ctx, c.req.param('version'))
+    const manifest = await loadManifest(ctx, version)
+    if (!manifest) throw apiErrors.notFound(`Manifest for ${version.canonical} missing.`)
+
+    const allow = parseLocalesParam(c.req.query('locales'))
+    const fields = parseFieldsParam(c.req.query('fields')) ?? DEFAULT_ELEMENT_FIELDS
+    const limit = parseLimitParam(c.req.query('limit'))
+    const offset = decodeCursor(c.req.query('cursor'))
+    const categoryFilter = c.req.query('category_id')
+    const query = c.req.query('query')
+
+    let elements = (await loadElements(ctx, version)) ?? []
+    if (categoryFilter) {
+      elements = elements.filter((el) => el.category_ids.includes(categoryFilter))
+    }
+
+    if (query && query.trim().length > 0) {
+      const searchLocale = (c.req.query('locale') ?? 'en') as 'en'
+      const ids = await searchElementIds({ ctx, version, locale: searchLocale, query })
+      elements = reorderByIds(elements, ids)
+    }
+
+    const { page, nextCursor } = paginate(elements, offset, limit)
+    const projected = page.map((el) => projectFields(el, fields))
+    const filtered = projected.map((el) => deepFilterLocales(el, allow))
+
+    setVersionHeaders(c, manifest)
+    return c.json({
+      ok: true,
+      version: version.canonical,
+      elements: filtered,
+      meta: {
+        total: elements.length,
+        returned: filtered.length,
+        next_cursor: nextCursor,
+      },
+    })
+  })
+
+  app.get('/schemas/:version/elements/:element_id', async (c) => {
+    const ctx = loadCtx(c)
+    const version = await resolveKnownVersion(ctx, c.req.param('version'))
+    const manifest = await loadManifest(ctx, version)
+    if (!manifest) throw apiErrors.notFound(`Manifest for ${version.canonical} missing.`)
+    const elementId = c.req.param('element_id')
+    const element = await loadElement(ctx, version, elementId)
+    if (!element) {
+      throw apiErrors.notFound(
+        `Element '${elementId}' not found in ${version.canonical}.`,
+        'Use GET /api/v2/schemas/:version/elements to enumerate available element ids.',
+      )
+    }
+    const allow = parseLocalesParam(c.req.query('locales'))
+    const fields = parseFieldsParam(c.req.query('fields')) ?? 'all'
+    const projected = projectFields(element, fields)
+    const filtered = deepFilterLocales(projected, allow)
+    setVersionHeaders(c, manifest)
+    return c.json({ ok: true, version: version.canonical, element: filtered })
+  })
+
+  app.post('/schemas/:version/validate', async (c) => {
+    const ctx = loadCtx(c)
+    const version = await resolveKnownVersion(ctx, c.req.param('version'))
+    const manifest = await loadManifest(ctx, version)
+    if (!manifest) throw apiErrors.notFound(`Manifest for ${version.canonical} missing.`)
+
+    let raw: unknown
+    try {
+      raw = await c.req.json()
+    } catch {
+      throw apiErrors.badRequest(
+        'Invalid JSON body.',
+        undefined,
+        'Send a valid JSON datachain-instance payload.',
+      )
+    }
+
+    let parsed
+    try {
+      parsed = DatachainInstanceSchema.parse(raw)
+    } catch (e) {
+      if (e instanceof ZodError) {
+        const errors = e.issues.map((iss) => ({
+          code: 'parse_error',
+          message: iss.message,
+          path: iss.path.join('.'),
+          fix_hint: 'Fix the field shape and retry.',
+        }))
+        return c.json({ ok: false, errors }, 200)
+      }
+      throw e
+    }
+
+    const datachainType = await loadDatachainType(ctx, version)
+    const categories = (await loadCategories(ctx, version)) ?? []
+    const elements = (await loadElements(ctx, version)) ?? []
+    if (!datachainType) {
+      throw apiErrors.notFound(`Datachain type for ${version.canonical} missing.`)
+    }
+    const result = validateInstance(
+      { manifest, datachainType, categories, elements },
+      parsed,
+    )
+    setVersionHeaders(c, manifest)
+    if (result.ok) {
+      return c.json({ ok: true, warnings: result.warnings }, 200)
+    }
+    return c.json({ ok: false, errors: result.errors, warnings: result.warnings }, 200)
+  })
+
+  return app
+}

--- a/api/src/rest/routes.ts
+++ b/api/src/rest/routes.ts
@@ -97,7 +97,11 @@ export function createRestApp() {
     if (query && query.trim().length > 0) {
       const searchLocale = (c.req.query('locale') ?? 'en') as 'en'
       const ids = await searchElementIds({ ctx, version, locale: searchLocale, query })
-      elements = reorderByIds(elements, ids)
+      // `null` means no index for this locale — leave elements in
+      // natural order rather than zeroing them out.
+      if (ids !== null) {
+        elements = reorderByIds(elements, ids)
+      }
     }
 
     const { page, nextCursor } = paginate(elements, offset, limit)

--- a/api/src/rest/search.ts
+++ b/api/src/rest/search.ts
@@ -1,0 +1,58 @@
+import MiniSearch from 'minisearch'
+import type { Element } from '../schema/element.ts'
+import type { LocaleCode } from '../schema/locale.ts'
+import type { ParsedVersion } from '../../cli/lib/version-parser.ts'
+import { loadSearchIndex, type LoadContext } from '../store/index.ts'
+
+/**
+ * Match the option shape that `cli/lib/search-index-builder.ts` used
+ * when building the index. The serialized index does not record its
+ * options, so the loader must pass them back in for `loadJSON` to
+ * rehydrate correctly.
+ */
+const REHYDRATE_OPTIONS = {
+  fields: ['title', 'description'],
+  storeFields: ['id', 'title', 'category_ids'],
+  searchOptions: {
+    boost: { title: 3 },
+    fuzzy: 0.2,
+    prefix: true,
+  },
+}
+
+/**
+ * Run the BM25 query against the version's per-locale index and return
+ * the matching element ids in rank order. Returns the input order if
+ * no index has been built for that locale (degraded but working).
+ *
+ * The full elements list is passed in as the source of truth: the
+ * search index only stores the projection fields; the route still
+ * needs the full record to apply the `fields=` projection.
+ */
+export async function searchElementIds(opts: {
+  ctx: LoadContext
+  version: ParsedVersion
+  locale: LocaleCode
+  query: string
+}): Promise<string[]> {
+  const { ctx, version, locale, query } = opts
+  const serialized = await loadSearchIndex(ctx, version, locale)
+  if (!serialized) return []
+  const index = MiniSearch.loadJSON(serialized, REHYDRATE_OPTIONS)
+  return index.search(query).map((hit) => hit.id as string)
+}
+
+/**
+ * Filter an `Element[]` to ids in `order`, preserving the order. Used
+ * after `searchElementIds` returns ranked ids — the caller has the
+ * full element list and just needs to project the relevant ones.
+ */
+export function reorderByIds(elements: Element[], order: string[]): Element[] {
+  const byId = new Map(elements.map((e) => [e.id, e] as const))
+  const out: Element[] = []
+  for (const id of order) {
+    const el = byId.get(id)
+    if (el) out.push(el)
+  }
+  return out
+}

--- a/api/src/rest/search.ts
+++ b/api/src/rest/search.ts
@@ -22,8 +22,12 @@ const REHYDRATE_OPTIONS = {
 
 /**
  * Run the BM25 query against the version's per-locale index and return
- * the matching element ids in rank order. Returns the input order if
- * no index has been built for that locale (degraded but working).
+ * the matching element ids in rank order.
+ *
+ * Returns `null` when no index exists for the requested locale —
+ * callers treat this as "no search available, fall back to the
+ * unfiltered natural order" rather than as "zero matches". An empty
+ * `string[]` (vs `null`) means the index ran and returned no hits.
  *
  * The full elements list is passed in as the source of truth: the
  * search index only stores the projection fields; the route still
@@ -34,10 +38,10 @@ export async function searchElementIds(opts: {
   version: ParsedVersion
   locale: LocaleCode
   query: string
-}): Promise<string[]> {
+}): Promise<string[] | null> {
   const { ctx, version, locale, query } = opts
   const serialized = await loadSearchIndex(ctx, version, locale)
-  if (!serialized) return []
+  if (!serialized) return null
   const index = MiniSearch.loadJSON(serialized, REHYDRATE_OPTIONS)
   return index.search(query).map((hit) => hit.id as string)
 }

--- a/api/src/rest/version-resolver.ts
+++ b/api/src/rest/version-resolver.ts
@@ -1,0 +1,63 @@
+import {
+  InvalidVersionError,
+  parseVersion,
+  type ParsedVersion,
+} from '../../cli/lib/version-parser.ts'
+import { apiErrors } from '../middleware/errors.ts'
+import { loadSchemaIndex, type LoadContext } from '../store/index.ts'
+
+/**
+ * Parse a `:version` path param.
+ *
+ * Handles both the canonical `ai@2026-04-16-beta` and the
+ * URL-encoded `ai%402026-04-16-beta` forms. Hono already decodes
+ * single-pass, but we defensively decode again so a double-encoded
+ * value (rare) still works. Malformed input throws 400 with the
+ * specific parser error.
+ */
+export function normalizeVersionParam(raw: string): ParsedVersion {
+  let decoded = raw
+  try {
+    decoded = decodeURIComponent(raw)
+  } catch {
+    throw apiErrors.badRequest(
+      `Malformed version parameter: ${raw}`,
+      undefined,
+      "Use the canonical 'type@YYYY-MM-DD[-beta]' form.",
+    )
+  }
+  try {
+    return parseVersion(decoded)
+  } catch (e) {
+    if (e instanceof InvalidVersionError) {
+      throw apiErrors.badRequest(
+        e.message,
+        undefined,
+        "Use the canonical 'type@YYYY-MM-DD[-beta]' form.",
+      )
+    }
+    throw e
+  }
+}
+
+/**
+ * Parse the param and confirm the version is registered in
+ * `schemas/index.json`. This is the path every read route takes so
+ * unknown versions 404 with a helpful fix_hint before any other R2
+ * reads are attempted.
+ */
+export async function resolveKnownVersion(
+  ctx: LoadContext,
+  raw: string,
+): Promise<ParsedVersion> {
+  const version = normalizeVersionParam(raw)
+  const index = await loadSchemaIndex(ctx)
+  const known = index.versions.some((entry) => entry.id === version.canonical)
+  if (!known) {
+    throw apiErrors.notFound(
+      `Schema version '${version.canonical}' is not registered.`,
+      'List available versions via GET /api/v2/schemas.',
+    )
+  }
+  return version
+}

--- a/api/src/store/cache-wrapper.ts
+++ b/api/src/store/cache-wrapper.ts
@@ -1,0 +1,114 @@
+/**
+ * Cache API wrapper for typed loaders.
+ *
+ * Wraps an arbitrary `loader: () => Promise<T | null>` so that the
+ * loader's positive results are cached in `caches.default` keyed by
+ * an internal URL. On cache hit the wrapper deserializes the stored
+ * JSON and returns it without invoking the loader. `null` results are
+ * never cached so a freshly-uploaded version becomes visible on the
+ * next request rather than waiting out a TTL.
+ *
+ * Caveats:
+ *  - `caches.default` is only persisted on Cloudflare custom domains.
+ *    Local `wrangler dev --local` skips writes silently. The
+ *    `vitest-pool-workers` runner exposes a working Cache API, so
+ *    integration tests can assert hit/miss behavior.
+ *  - Cache invalidation on schema promotion is handled implicitly:
+ *    cache keys include the version directory, so a promoted
+ *    `<type>/<date>/` directory has a different key than its
+ *    `<type>/<date>-beta/` predecessor.
+ */
+
+export interface CacheOptions {
+  /** Cache TTL in seconds. Used in the synthesized Cache-Control. */
+  ttl: number
+  /** When false, bypass cache entirely (read + write). */
+  enabled: boolean
+  /** Worker execution context for non-blocking cache writes. */
+  ctx?: ExecutionContext
+}
+
+const CACHE_BASE = 'https://cache.internal.dtpr-api/'
+
+/** Build a unique cache key from an arbitrary R2-style path. */
+export function cacheKeyFor(path: string): string {
+  // Cache API requires absolute URLs. Strip leading slashes so a path
+  // like `schemas/ai/2026-04-16/elements.json` becomes a deterministic
+  // URL under our internal namespace.
+  const normalized = path.replace(/^\/+/, '')
+  return `${CACHE_BASE}${normalized}`
+}
+
+/**
+ * Memoize a JSON loader through `caches.default`.
+ *
+ * @param key Stable cache identifier (turned into an internal URL).
+ * @param loader Source-of-truth fetcher; returns `null` for missing data.
+ * @param options TTL + enabled flag + optional execution context.
+ */
+export async function cached<T>(
+  key: string,
+  loader: () => Promise<T | null>,
+  options: CacheOptions,
+): Promise<T | null> {
+  if (!options.enabled) return loader()
+
+  const cache = caches.default
+  const req = new Request(cacheKeyFor(key))
+
+  const hit = await cache.match(req)
+  if (hit) {
+    return (await hit.json()) as T
+  }
+
+  const value = await loader()
+  if (value === null) return null
+
+  const response = new Response(JSON.stringify(value), {
+    headers: {
+      'content-type': 'application/json',
+      'cache-control': `public, max-age=${options.ttl}`,
+    },
+  })
+  if (options.ctx) {
+    options.ctx.waitUntil(cache.put(req, response.clone()))
+  } else {
+    await cache.put(req, response.clone())
+  }
+  return value
+}
+
+/**
+ * Variant of {@link cached} for callers that need text rather than JSON
+ * (used by the MiniSearch index loader, which deserializes via
+ * `MiniSearch.loadJSON`).
+ */
+export async function cachedText(
+  key: string,
+  loader: () => Promise<string | null>,
+  options: CacheOptions,
+): Promise<string | null> {
+  if (!options.enabled) return loader()
+
+  const cache = caches.default
+  const req = new Request(cacheKeyFor(key))
+
+  const hit = await cache.match(req)
+  if (hit) return hit.text()
+
+  const value = await loader()
+  if (value === null) return null
+
+  const response = new Response(value, {
+    headers: {
+      'content-type': 'application/json',
+      'cache-control': `public, max-age=${options.ttl}`,
+    },
+  })
+  if (options.ctx) {
+    options.ctx.waitUntil(cache.put(req, response.clone()))
+  } else {
+    await cache.put(req, response.clone())
+  }
+  return value
+}

--- a/api/src/store/cache-wrapper.ts
+++ b/api/src/store/cache-wrapper.ts
@@ -19,13 +19,18 @@
  *    `<type>/<date>-beta/` predecessor.
  */
 
+/** Subset of ExecutionContext we use; see `LoadContext` rationale. */
+interface ExecutionLike {
+  waitUntil(promise: Promise<unknown>): void
+}
+
 export interface CacheOptions {
   /** Cache TTL in seconds. Used in the synthesized Cache-Control. */
   ttl: number
   /** When false, bypass cache entirely (read + write). */
   enabled: boolean
   /** Worker execution context for non-blocking cache writes. */
-  ctx?: ExecutionContext
+  ctx?: ExecutionLike
 }
 
 const CACHE_BASE = 'https://cache.internal.dtpr-api/'

--- a/api/src/store/index-loader.ts
+++ b/api/src/store/index-loader.ts
@@ -1,0 +1,61 @@
+import { cached } from './cache-wrapper.ts'
+import { INDEX_KEY } from './keys.ts'
+import { R2LoadError, type LoadContext } from './r2-loader.ts'
+
+/**
+ * One entry in `schemas/index.json`. Mirrors the shape produced by
+ * `api/scripts/r2-upload.ts`. Kept structural here (rather than a Zod
+ * schema) because the index is server-authored and read-only — clients
+ * receive a re-shaped envelope.
+ */
+export interface SchemaIndexEntry {
+  id: string
+  status: 'beta' | 'stable'
+  created_at: string
+  content_hash: string
+}
+
+export interface SchemaIndex {
+  versions: SchemaIndexEntry[]
+}
+
+/**
+ * Index TTL is short (60 s) because promotions rewrite this single
+ * object and we want the new version visible across the edge fleet
+ * within a minute. Per-version manifest reads still cache for 24 h.
+ */
+const INDEX_TTL_SECONDS = 60
+
+/**
+ * Load `schemas/index.json`. Missing index treated as an empty
+ * `{ versions: [] }` so a freshly-provisioned bucket doesn't 500.
+ */
+export async function loadSchemaIndex(ctx: LoadContext): Promise<SchemaIndex> {
+  const result = await cached<SchemaIndex>(
+    INDEX_KEY,
+    async () => {
+      let obj: R2ObjectBody | null
+      try {
+        obj = await ctx.bucket.get(INDEX_KEY)
+      } catch (e) {
+        throw new R2LoadError(
+          `R2 read failed for ${INDEX_KEY}: ${(e as Error).message}`,
+          INDEX_KEY,
+          e,
+        )
+      }
+      if (!obj) return null
+      try {
+        return (await obj.json()) as SchemaIndex
+      } catch (e) {
+        throw new R2LoadError(
+          `R2 object ${INDEX_KEY} is not valid JSON: ${(e as Error).message}`,
+          INDEX_KEY,
+          e,
+        )
+      }
+    },
+    { enabled: true, ttl: INDEX_TTL_SECONDS, ctx: ctx.ctx },
+  )
+  return result ?? { versions: [] }
+}

--- a/api/src/store/index.ts
+++ b/api/src/store/index.ts
@@ -1,0 +1,89 @@
+/**
+ * Store module: composes inline-bundle fallback (R10b) on top of the
+ * R2 loader. Routes import from this barrel so they don't need to
+ * re-implement the routing rule.
+ */
+
+import type { Category } from '../schema/category.ts'
+import type { DatachainType } from '../schema/datachain-type.ts'
+import type { Element } from '../schema/element.ts'
+import type { LocaleCode } from '../schema/locale.ts'
+import type { SchemaManifest } from '../schema/manifest.ts'
+import type { ParsedVersion } from '../../cli/lib/version-parser.ts'
+import { getInlineBundle } from './inline-bundles.ts'
+import * as r2 from './r2-loader.ts'
+
+export type { LoadContext } from './r2-loader.ts'
+export { R2LoadError } from './r2-loader.ts'
+export { loadSchemaIndex, type SchemaIndex, type SchemaIndexEntry } from './index-loader.ts'
+export {
+  registerInlineBundle,
+  getInlineBundle,
+  _resetInlineBundles,
+  type InlineBundle,
+} from './inline-bundles.ts'
+
+export async function loadManifest(
+  ctx: r2.LoadContext,
+  version: ParsedVersion,
+): Promise<SchemaManifest | null> {
+  const inline = getInlineBundle(version.canonical)
+  if (inline) return inline.manifest
+  return r2.loadManifest(ctx, version)
+}
+
+export async function loadDatachainType(
+  ctx: r2.LoadContext,
+  version: ParsedVersion,
+): Promise<DatachainType | null> {
+  const inline = getInlineBundle(version.canonical)
+  if (inline) return inline.datachainType
+  return r2.loadDatachainType(ctx, version)
+}
+
+export async function loadCategories(
+  ctx: r2.LoadContext,
+  version: ParsedVersion,
+): Promise<Category[] | null> {
+  const inline = getInlineBundle(version.canonical)
+  if (inline) return inline.categories
+  return r2.loadCategories(ctx, version)
+}
+
+export async function loadElements(
+  ctx: r2.LoadContext,
+  version: ParsedVersion,
+): Promise<Element[] | null> {
+  const inline = getInlineBundle(version.canonical)
+  if (inline) return inline.elements
+  return r2.loadElements(ctx, version)
+}
+
+export async function loadElement(
+  ctx: r2.LoadContext,
+  version: ParsedVersion,
+  elementId: string,
+): Promise<Element | null> {
+  const inline = getInlineBundle(version.canonical)
+  if (inline) return inline.elements.find((e) => e.id === elementId) ?? null
+  return r2.loadElement(ctx, version, elementId)
+}
+
+export async function loadSearchIndex(
+  ctx: r2.LoadContext,
+  version: ParsedVersion,
+  locale: LocaleCode,
+): Promise<string | null> {
+  const inline = getInlineBundle(version.canonical)
+  if (inline) return inline.searchIndexesByLocale[locale] ?? null
+  return r2.loadSearchIndex(ctx, version, locale)
+}
+
+export async function loadSchemaJson(
+  ctx: r2.LoadContext,
+  version: ParsedVersion,
+): Promise<Record<string, unknown> | null> {
+  const inline = getInlineBundle(version.canonical)
+  if (inline) return inline.schemaJson
+  return r2.loadSchemaJson(ctx, version)
+}

--- a/api/src/store/inline-bundles.ts
+++ b/api/src/store/inline-bundles.ts
@@ -1,0 +1,48 @@
+/**
+ * Inline-bundle fallback (R10b).
+ *
+ * P1 ships R2-only — `schema:build` does not currently emit an
+ * `inline.ts` module, so this registry is empty. The hook exists so
+ * the loader composition in `composed-loader.ts` can short-circuit to
+ * inline data without a code change once the build step starts
+ * emitting it. Adding an inline bundle is then a one-line registration:
+ *
+ *   import inline_ai_2026_04_16 from '../../dist/schemas/ai/2026-04-16/inline.ts'
+ *   register('ai@2026-04-16', inline_ai_2026_04_16)
+ *
+ * Until then, `getInlineBundle` always returns `null` and routes fall
+ * through to R2.
+ */
+
+import type { Category } from '../schema/category.ts'
+import type { DatachainType } from '../schema/datachain-type.ts'
+import type { Element } from '../schema/element.ts'
+import type { LocaleCode } from '../schema/locale.ts'
+import type { SchemaManifest } from '../schema/manifest.ts'
+
+export interface InlineBundle {
+  manifest: SchemaManifest
+  datachainType: DatachainType
+  categories: Category[]
+  elements: Element[]
+  schemaJson: Record<string, unknown>
+  /** Serialized MiniSearch index per locale (raw JSON strings). */
+  searchIndexesByLocale: Partial<Record<LocaleCode, string>>
+}
+
+const REGISTRY = new Map<string, InlineBundle>()
+
+/** Register an inline bundle keyed by canonical version string. */
+export function registerInlineBundle(canonicalVersion: string, bundle: InlineBundle): void {
+  REGISTRY.set(canonicalVersion, bundle)
+}
+
+/** Retrieve a registered inline bundle, or `null` if none. */
+export function getInlineBundle(canonicalVersion: string): InlineBundle | null {
+  return REGISTRY.get(canonicalVersion) ?? null
+}
+
+/** Test-only: clear all registered inline bundles. */
+export function _resetInlineBundles(): void {
+  REGISTRY.clear()
+}

--- a/api/src/store/keys.ts
+++ b/api/src/store/keys.ts
@@ -1,0 +1,39 @@
+import type { LocaleCode } from '../schema/locale.ts'
+import type { ParsedVersion } from '../../cli/lib/version-parser.ts'
+
+/**
+ * Object key conventions in R2. Mirrors the layout written by
+ * `api/scripts/r2-upload.ts`. Every helper here returns an R2 key
+ * (no leading slash). The single source of truth so the upload
+ * script and Worker reads stay in lockstep.
+ */
+
+export const INDEX_KEY = 'schemas/index.json'
+
+export function manifestKey(version: ParsedVersion): string {
+  return `schemas/${version.dir}/manifest.json`
+}
+
+export function datachainTypeKey(version: ParsedVersion): string {
+  return `schemas/${version.dir}/datachain-type.json`
+}
+
+export function categoriesKey(version: ParsedVersion): string {
+  return `schemas/${version.dir}/categories.json`
+}
+
+export function elementsKey(version: ParsedVersion): string {
+  return `schemas/${version.dir}/elements.json`
+}
+
+export function elementKey(version: ParsedVersion, elementId: string): string {
+  return `schemas/${version.dir}/elements/${elementId}.json`
+}
+
+export function searchIndexKey(version: ParsedVersion, locale: LocaleCode): string {
+  return `schemas/${version.dir}/search-index.${locale}.json`
+}
+
+export function schemaJsonKey(version: ParsedVersion): string {
+  return `schemas/${version.dir}/schema.json`
+}

--- a/api/src/store/r2-loader.ts
+++ b/api/src/store/r2-loader.ts
@@ -1,0 +1,158 @@
+import type { Category } from '../schema/category.ts'
+import type { DatachainType } from '../schema/datachain-type.ts'
+import type { Element } from '../schema/element.ts'
+import type { LocaleCode } from '../schema/locale.ts'
+import type { SchemaManifest } from '../schema/manifest.ts'
+import type { ParsedVersion } from '../../cli/lib/version-parser.ts'
+import { cached, cachedText, type CacheOptions } from './cache-wrapper.ts'
+import {
+  categoriesKey,
+  datachainTypeKey,
+  elementKey,
+  elementsKey,
+  manifestKey,
+  schemaJsonKey,
+  searchIndexKey,
+} from './keys.ts'
+
+/** Default per-version cache TTL for stable versions. 24 hours. */
+const STABLE_TTL_SECONDS = 86_400
+
+/**
+ * Thrown when an R2 read fails for a non-404 reason. Routes map this
+ * to a 502 envelope (upstream failure) so clients can distinguish
+ * "not found" from "the store is unhealthy".
+ */
+export class R2LoadError extends Error {
+  constructor(
+    message: string,
+    public readonly key: string,
+    public override readonly cause?: unknown,
+  ) {
+    super(message)
+    this.name = 'R2LoadError'
+  }
+}
+
+/**
+ * Per-call context for the loaders. Bundling the bucket + execution
+ * context here means routes pass one object instead of three positional
+ * arguments to every loader call.
+ */
+export interface LoadContext {
+  bucket: R2Bucket
+  ctx?: ExecutionContext
+}
+
+function cacheOptionsFor(version: ParsedVersion, ctx?: ExecutionContext): CacheOptions {
+  // Beta versions are never cached — content is mutable and we want
+  // consumers to see fresh bytes on every fetch. Stable versions are
+  // immutable, so cache for the full TTL.
+  return { enabled: !version.beta, ttl: STABLE_TTL_SECONDS, ctx }
+}
+
+async function getJson<T>(bucket: R2Bucket, key: string): Promise<T | null> {
+  let obj: R2ObjectBody | null
+  try {
+    obj = await bucket.get(key)
+  } catch (e) {
+    throw new R2LoadError(`R2 read failed for ${key}: ${(e as Error).message}`, key, e)
+  }
+  if (!obj) return null
+  try {
+    return (await obj.json()) as T
+  } catch (e) {
+    throw new R2LoadError(`R2 object ${key} is not valid JSON: ${(e as Error).message}`, key, e)
+  }
+}
+
+async function getText(bucket: R2Bucket, key: string): Promise<string | null> {
+  let obj: R2ObjectBody | null
+  try {
+    obj = await bucket.get(key)
+  } catch (e) {
+    throw new R2LoadError(`R2 read failed for ${key}: ${(e as Error).message}`, key, e)
+  }
+  if (!obj) return null
+  return obj.text()
+}
+
+/** Load the version manifest. Returns `null` if the version is unknown. */
+export function loadManifest(
+  ctx: LoadContext,
+  version: ParsedVersion,
+): Promise<SchemaManifest | null> {
+  const key = manifestKey(version)
+  return cached(key, () => getJson<SchemaManifest>(ctx.bucket, key), cacheOptionsFor(version, ctx.ctx))
+}
+
+/** Load the datachain-type definition. */
+export function loadDatachainType(
+  ctx: LoadContext,
+  version: ParsedVersion,
+): Promise<DatachainType | null> {
+  const key = datachainTypeKey(version)
+  return cached(
+    key,
+    () => getJson<DatachainType>(ctx.bucket, key),
+    cacheOptionsFor(version, ctx.ctx),
+  )
+}
+
+/** Load all categories for a version (already ordered by the build step). */
+export function loadCategories(
+  ctx: LoadContext,
+  version: ParsedVersion,
+): Promise<Category[] | null> {
+  const key = categoriesKey(version)
+  return cached(key, () => getJson<Category[]>(ctx.bucket, key), cacheOptionsFor(version, ctx.ctx))
+}
+
+/** Load the full elements list (variables already materialized). */
+export function loadElements(
+  ctx: LoadContext,
+  version: ParsedVersion,
+): Promise<Element[] | null> {
+  const key = elementsKey(version)
+  return cached(key, () => getJson<Element[]>(ctx.bucket, key), cacheOptionsFor(version, ctx.ctx))
+}
+
+/** Point read for a single element by id. Optimized via per-element JSON. */
+export function loadElement(
+  ctx: LoadContext,
+  version: ParsedVersion,
+  elementId: string,
+): Promise<Element | null> {
+  const key = elementKey(version, elementId)
+  return cached(key, () => getJson<Element>(ctx.bucket, key), cacheOptionsFor(version, ctx.ctx))
+}
+
+/**
+ * Load the serialized MiniSearch index for a locale. Returned as the
+ * raw JSON string so callers can pass it straight to
+ * `MiniSearch.loadJSON` without a round-trip through the JS parser.
+ */
+export function loadSearchIndex(
+  ctx: LoadContext,
+  version: ParsedVersion,
+  locale: LocaleCode,
+): Promise<string | null> {
+  const key = searchIndexKey(version, locale)
+  return cachedText(key, () => getText(ctx.bucket, key), cacheOptionsFor(version, ctx.ctx))
+}
+
+/**
+ * Load the per-version JSON Schema bundle (used by tools/list output
+ * and by clients wanting to validate datachain payloads themselves).
+ */
+export function loadSchemaJson(
+  ctx: LoadContext,
+  version: ParsedVersion,
+): Promise<Record<string, unknown> | null> {
+  const key = schemaJsonKey(version)
+  return cached(
+    key,
+    () => getJson<Record<string, unknown>>(ctx.bucket, key),
+    cacheOptionsFor(version, ctx.ctx),
+  )
+}

--- a/api/src/store/r2-loader.ts
+++ b/api/src/store/r2-loader.ts
@@ -35,16 +35,26 @@ export class R2LoadError extends Error {
 }
 
 /**
+ * Subset of `ExecutionContext` that the cache wrapper actually uses.
+ * Declared structurally so callers can pass the value Hono exposes on
+ * its Context (`c.executionCtx`) without a type cast — Hono's type and
+ * the Cloudflare-generated type differ on optional fields.
+ */
+export interface ExecutionLike {
+  waitUntil(promise: Promise<unknown>): void
+}
+
+/**
  * Per-call context for the loaders. Bundling the bucket + execution
  * context here means routes pass one object instead of three positional
  * arguments to every loader call.
  */
 export interface LoadContext {
   bucket: R2Bucket
-  ctx?: ExecutionContext
+  ctx?: ExecutionLike
 }
 
-function cacheOptionsFor(version: ParsedVersion, ctx?: ExecutionContext): CacheOptions {
+function cacheOptionsFor(version: ParsedVersion, ctx?: ExecutionLike): CacheOptions {
   // Beta versions are never cached — content is mutable and we want
   // consumers to see fresh bytes on every fetch. Stable versions are
   // immutable, so cache for the full TTL.

--- a/api/test/api/harness-parity.test.ts
+++ b/api/test/api/harness-parity.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { SELF } from 'cloudflare:test'
+import {
+  categoriesFingerprint,
+  elementsFingerprint,
+} from './helpers.ts'
+import {
+  CategoriesResponseSchema,
+  ElementsResponseSchema,
+  ManifestResponseSchema,
+  SchemaIndexResponseSchema,
+  SingleElementResponseSchema,
+} from './schemas.ts'
+import { SAMPLE_VERSION, seedVersion } from './seed.ts'
+import { createMcpClient, structured, type ToolCallResult } from './mcp-client.ts'
+
+/**
+ * Harness-parity coverage — mirrors the `app/test/api/*` pattern.
+ * Each response shape is re-validated with a separately-maintained
+ * Zod schema (catches accidental wire breakage) and distilled to a
+ * structural fingerprint for snapshot-based regression detection.
+ */
+
+beforeAll(async () => {
+  await seedVersion()
+})
+
+describe('harness parity: response shape + fingerprint', () => {
+  it('GET /schemas conforms to the index response schema', async () => {
+    const res = await SELF.fetch('https://example.com/api/v2/schemas')
+    const json = await res.json()
+    expect(() => SchemaIndexResponseSchema.parse(json)).not.toThrow()
+  })
+
+  it('GET /manifest conforms to the manifest response schema', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/manifest`,
+    )
+    const json = await res.json()
+    expect(() => ManifestResponseSchema.parse(json)).not.toThrow()
+  })
+
+  it('GET /categories matches snapshot fingerprint (ignores prose)', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/categories`,
+    )
+    const parsed = CategoriesResponseSchema.parse(await res.json())
+    expect(categoriesFingerprint(parsed)).toMatchInlineSnapshot(`
+      [
+        {
+          "context_value_ids": [],
+          "datachain_type": "ai",
+          "has_context": false,
+          "id": "ai__decision",
+          "locales": [
+            "en",
+            "fr",
+          ],
+          "order": 1,
+          "required": true,
+          "variable_ids": [],
+        },
+      ]
+    `)
+  })
+
+  it('GET /elements?fields=all matches snapshot fingerprint', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements?fields=all`,
+    )
+    const parsed = ElementsResponseSchema.parse(await res.json())
+    expect(elementsFingerprint(parsed)).toMatchInlineSnapshot(`
+      [
+        {
+          "category_ids": [
+            "ai__decision",
+          ],
+          "id": "accept_deny",
+          "locales": [
+            "en",
+            "fr",
+          ],
+          "variable_ids": [],
+        },
+        {
+          "category_ids": [
+            "ai__decision",
+          ],
+          "id": "anomaly_detection",
+          "locales": [
+            "en",
+            "fr",
+          ],
+          "variable_ids": [],
+        },
+        {
+          "category_ids": [
+            "ai__decision",
+          ],
+          "id": "identifiable_video",
+          "locales": [
+            "en",
+            "fr",
+          ],
+          "variable_ids": [],
+        },
+      ]
+    `)
+  })
+
+  it('GET /elements/:id conforms to the single-element response schema', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements/accept_deny`,
+    )
+    const json = await res.json()
+    expect(() => SingleElementResponseSchema.parse(json)).not.toThrow()
+  })
+})
+
+describe('harness parity: full agent-like MCP flow', () => {
+  it('initialize → tools/list → list_schema_versions → get_schema → list_elements(query) → get_elements → validate_datachain', async () => {
+    const start = Date.now()
+
+    const client = createMcpClient()
+    const init = await client.initialize()
+    expect(init.error).toBeUndefined()
+
+    const tools = await client.listTools()
+    expect(tools.error).toBeUndefined()
+
+    const versionsCall = await client.callTool<
+      ToolCallResult<{ data: { versions: Array<{ id: string }> } }>
+    >('list_schema_versions', {})
+    const versions = structured(versionsCall)
+    const versionId = versions.data.versions[0]!.id
+
+    const schemaCall = await client.callTool<ToolCallResult<{ data: { manifest: unknown } }>>(
+      'get_schema',
+      { version: versionId },
+    )
+    structured(schemaCall)
+
+    const listCall = await client.callTool<
+      ToolCallResult<{ data: { elements: Array<{ id: string }> } }>
+    >('list_elements', { version: versionId, query: 'video', limit: 5 })
+    const list = structured(listCall)
+    const topId = list.data.elements[0]!.id
+
+    const bulkCall = await client.callTool<
+      ToolCallResult<{ data: { elements: Record<string, unknown> } }>
+    >('get_elements', {
+      version: versionId,
+      element_ids: [topId, 'accept_deny'],
+    })
+    const bulk = structured(bulkCall)
+    expect(Object.keys(bulk.data.elements).sort()).toEqual([topId, 'accept_deny'].sort())
+
+    const validateCall = await client.callTool<
+      ToolCallResult<{ ok: boolean; data?: { ok: boolean } }>
+    >('validate_datachain', {
+      version: versionId,
+      datachain: {
+        id: 'harness-1',
+        schema_version: versionId,
+        created_at: '2026-04-16T00:00:00.000Z',
+        elements: [{ element_id: topId }, { element_id: 'accept_deny' }],
+      },
+    })
+    const validate = structured(validateCall)
+    expect(validate.ok).toBe(true)
+
+    // Session timing canary (regression signal only — not asserted as
+    // a p95 SLO because Miniflare's single-process simulation doesn't
+    // produce a meaningful distribution).
+    const elapsed = Date.now() - start
+    console.info(
+      `harness-parity: full MCP flow elapsed=${elapsed}ms (log-only canary, no SLO)`,
+    )
+    expect(elapsed).toBeLessThan(30_000)
+  })
+})

--- a/api/test/api/helpers.ts
+++ b/api/test/api/helpers.ts
@@ -1,0 +1,51 @@
+import type { z } from 'zod'
+import type {
+  CategoriesResponseSchema,
+  ElementsResponseSchema,
+} from './schemas.ts'
+
+/**
+ * Structural fingerprint helpers. Ported from `app/test/api/helpers.ts`
+ * and adapted to the v2 response shape.
+ *
+ * Fingerprints intentionally strip prose and URLs so editorial or
+ * translation changes don't require snapshot updates. Structural
+ * regressions (missing categories, fields, locales, variables) still
+ * surface as snapshot diffs.
+ */
+
+type CategoriesResponse = z.infer<typeof CategoriesResponseSchema>
+type ElementsResponse = z.infer<typeof ElementsResponseSchema>
+
+export function categoriesFingerprint(data: CategoriesResponse) {
+  return data.categories
+    .map((category) => ({
+      id: category.id,
+      datachain_type: category.datachain_type,
+      has_context: !!category.context,
+      order: category.order ?? null,
+      required: category.required ?? false,
+      locales: [...new Set(category.name.map((n) => n.locale))].sort(),
+      variable_ids: category.element_variables.map((v) => v.id).sort(),
+      context_value_ids: category.context
+        ? category.context.values.map((v) => v.id).sort()
+        : [],
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id))
+}
+
+export function elementsFingerprint(data: ElementsResponse) {
+  return data.elements
+    .map((element) => {
+      const title = element.title ?? []
+      const categoryIds = element.category_ids ?? []
+      const variables = element.variables ?? []
+      return {
+        id: element.id,
+        category_ids: [...categoryIds].sort(),
+        locales: [...new Set(title.map((t) => t.locale))].sort(),
+        variable_ids: variables.map((v) => v.id).sort(),
+      }
+    })
+    .sort((a, b) => a.id.localeCompare(b.id))
+}

--- a/api/test/api/locale-filtering.test.ts
+++ b/api/test/api/locale-filtering.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { SELF } from 'cloudflare:test'
+import { SAMPLE_VERSION, seedVersion } from './seed.ts'
+import { deepFilterLocales, parseLocalesParam } from '../../src/rest/responses.ts'
+
+beforeAll(async () => {
+  await seedVersion()
+})
+
+describe('locale filtering: parseLocalesParam', () => {
+  it('returns null when missing', () => {
+    expect(parseLocalesParam(undefined)).toBeNull()
+    expect(parseLocalesParam(null)).toBeNull()
+    expect(parseLocalesParam('')).toBeNull()
+  })
+
+  it('parses comma-separated values into a Set', () => {
+    const set = parseLocalesParam('en,fr')
+    expect(set?.has('en')).toBe(true)
+    expect(set?.has('fr')).toBe(true)
+    expect(set?.size).toBe(2)
+  })
+
+  it('trims whitespace and skips empties', () => {
+    const set = parseLocalesParam(' en , , fr ')
+    expect(set?.size).toBe(2)
+    expect(set?.has('en')).toBe(true)
+    expect(set?.has('fr')).toBe(true)
+  })
+})
+
+describe('locale filtering: deepFilterLocales', () => {
+  const sample = {
+    title: [
+      { locale: 'en', value: 'Hi' },
+      { locale: 'fr', value: 'Salut' },
+    ],
+    nested: {
+      description: [
+        { locale: 'en', value: 'long' },
+        { locale: 'fr', value: 'longue' },
+      ],
+    },
+    untouched: ['stays', 'as', 'is'],
+    scalar: 42,
+  }
+
+  it('returns input unchanged when allow=null', () => {
+    expect(deepFilterLocales(sample, null)).toEqual(sample)
+  })
+
+  it('filters LocaleValue arrays at any depth', () => {
+    const result = deepFilterLocales(sample, new Set(['en']))
+    expect(result.title).toEqual([{ locale: 'en', value: 'Hi' }])
+    expect(result.nested.description).toEqual([{ locale: 'en', value: 'long' }])
+  })
+
+  it('does not touch non-LocaleValue arrays or scalars', () => {
+    const result = deepFilterLocales(sample, new Set(['en']))
+    expect(result.untouched).toEqual(['stays', 'as', 'is'])
+    expect(result.scalar).toBe(42)
+  })
+})
+
+describe('locale filtering: end-to-end through REST', () => {
+  it('?locales=fr filters all category-level localized strings', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/categories?locales=fr`,
+    )
+    const body = (await res.json()) as {
+      categories: Array<{
+        name: { locale: string }[]
+        description: { locale: string }[]
+      }>
+    }
+    expect(body.categories[0]?.name.map((n) => n.locale)).toEqual(['fr'])
+    expect(body.categories[0]?.description.map((n) => n.locale)).toEqual(['fr'])
+  })
+
+  it('?locales=en,fr keeps both', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/categories?locales=en,fr`,
+    )
+    const body = (await res.json()) as {
+      categories: Array<{ name: { locale: string }[] }>
+    }
+    expect(body.categories[0]?.name.map((n) => n.locale).sort()).toEqual(['en', 'fr'])
+  })
+
+  it('?locales filters element title and description through nested icon alt_text', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements/accept_deny?locales=en`,
+    )
+    const body = (await res.json()) as {
+      element: {
+        title: { locale: string }[]
+        description: { locale: string }[]
+        icon: { alt_text: { locale: string }[] }
+      }
+    }
+    expect(body.element.title.map((t) => t.locale)).toEqual(['en'])
+    expect(body.element.description.map((t) => t.locale)).toEqual(['en'])
+    expect(body.element.icon.alt_text.map((t) => t.locale)).toEqual(['en'])
+  })
+})

--- a/api/test/api/mcp-client.ts
+++ b/api/test/api/mcp-client.ts
@@ -1,0 +1,123 @@
+/**
+ * Lightweight test-only JSON-RPC client for the `/mcp` endpoint.
+ *
+ * `@modelcontextprotocol/sdk`'s real client wires up an
+ * `EventSource`-style transport that workerd doesn't expose in tests,
+ * so the simplest path is to drive the streamable-HTTP endpoint
+ * directly and parse its responses ourselves. The shape we need is
+ * tiny: an initialize handshake, tools/list, and tools/call.
+ */
+
+import { SELF } from 'cloudflare:test'
+
+const ORIGIN = 'https://example.com'
+const ACCEPT = 'application/json, text/event-stream'
+
+let nextId = 1
+
+export interface McpClientOptions {
+  origin?: string
+  /** Optional override for the path. */
+  path?: string
+}
+
+export interface McpResponse<T = unknown> {
+  jsonrpc: '2.0'
+  id: number
+  result?: T
+  error?: { code: number; message: string; data?: unknown }
+}
+
+export interface McpClient {
+  initialize: () => Promise<McpResponse>
+  listTools: () => Promise<McpResponse<{ tools: Array<{ name: string; description?: string }> }>>
+  callTool: <T = unknown>(name: string, args: Record<string, unknown>) => Promise<McpResponse<T>>
+  /** The session id surfaced after `initialize` (transport-managed). */
+  sessionId: () => string | null
+}
+
+function parseBody(text: string, contentType: string | null): unknown {
+  if (contentType?.includes('text/event-stream')) {
+    // SSE frames look like:  event: message\ndata: {...}\n\n
+    const lines = text.split('\n')
+    for (const line of lines) {
+      if (line.startsWith('data:')) {
+        const payload = line.slice('data:'.length).trim()
+        if (payload && payload !== '[DONE]') return JSON.parse(payload)
+      }
+    }
+    throw new Error(`SSE response had no data frame: ${text.slice(0, 200)}`)
+  }
+  return JSON.parse(text)
+}
+
+export function createMcpClient(opts: McpClientOptions = {}): McpClient {
+  const origin = opts.origin ?? ORIGIN
+  const path = opts.path ?? '/mcp'
+  let sessionId: string | null = null
+
+  async function send(payload: object): Promise<McpResponse> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Accept: ACCEPT,
+    }
+    if (sessionId) headers['mcp-session-id'] = sessionId
+    const res = await SELF.fetch(`${origin}${path}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    })
+    const sid = res.headers.get('mcp-session-id')
+    if (sid) sessionId = sid
+    const text = await res.text()
+    const body = parseBody(text, res.headers.get('content-type'))
+    return body as McpResponse
+  }
+
+  return {
+    sessionId: () => sessionId,
+    async initialize() {
+      const id = nextId++
+      return send({
+        jsonrpc: '2.0',
+        id,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '0.0.0' },
+        },
+      })
+    },
+    async listTools() {
+      const id = nextId++
+      return (await send({ jsonrpc: '2.0', id, method: 'tools/list' })) as McpResponse<{
+        tools: Array<{ name: string; description?: string }>
+      }>
+    },
+    async callTool<T = unknown>(name: string, args: Record<string, unknown>) {
+      const id = nextId++
+      return (await send({
+        jsonrpc: '2.0',
+        id,
+        method: 'tools/call',
+        params: { name, arguments: args },
+      })) as McpResponse<T>
+    },
+  }
+}
+
+export interface ToolCallResult<T = unknown> {
+  structuredContent?: T
+  content?: Array<{ type: string; text: string }>
+  isError?: boolean
+}
+
+/** Pull the structuredContent off a tools/call result, asserting present. */
+export function structured<T>(res: McpResponse<ToolCallResult<T>>): T {
+  if (res.error) throw new Error(`MCP error: ${res.error.message}`)
+  if (!res.result?.structuredContent) {
+    throw new Error(`tools/call result missing structuredContent: ${JSON.stringify(res.result)}`)
+  }
+  return res.result.structuredContent
+}

--- a/api/test/api/mcp.test.ts
+++ b/api/test/api/mcp.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest'
+import { SELF } from 'cloudflare:test'
 import { SAMPLE_VERSION, seedVersion } from './seed.ts'
 import { createMcpClient, structured, type ToolCallResult } from './mcp-client.ts'
 
@@ -46,6 +47,50 @@ interface BulkPayload {
 
 beforeAll(async () => {
   await seedVersion()
+})
+
+describe('MCP: jsonrpc version validation', () => {
+  async function postRaw(payload: unknown): Promise<{ status: number; body: Record<string, unknown> }> {
+    const res = await SELF.fetch('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify(payload),
+    })
+    const body = (await res.json()) as Record<string, unknown>
+    return { status: res.status, body }
+  }
+
+  it('rejects jsonrpc:"1.0" with INVALID_REQUEST', async () => {
+    const { body } = await postRaw({ jsonrpc: '1.0', id: 1, method: 'initialize' })
+    const err = body.error as { code: number; message: string } | undefined
+    expect(err?.code).toBe(-32600)
+    expect(err?.message).toMatch(/jsonrpc/i)
+    expect(body.id).toBe(1)
+  })
+
+  it('rejects requests missing the jsonrpc field with INVALID_REQUEST', async () => {
+    const { body } = await postRaw({ id: 2, method: 'initialize' })
+    const err = body.error as { code: number; message: string } | undefined
+    expect(err?.code).toBe(-32600)
+    expect(err?.message).toMatch(/jsonrpc/i)
+    expect(body.id).toBe(2)
+  })
+
+  it('rejects per-entry in batch requests', async () => {
+    const { body } = await postRaw([
+      { jsonrpc: '2.0', id: 10, method: 'ping' },
+      { jsonrpc: '1.0', id: 11, method: 'ping' },
+    ])
+    const arr = body as unknown as Array<Record<string, unknown>>
+    expect(Array.isArray(arr)).toBe(true)
+    const ok = arr.find((r) => r.id === 10)
+    const bad = arr.find((r) => r.id === 11)
+    expect(ok?.result).toBeDefined()
+    expect((bad?.error as { code: number } | undefined)?.code).toBe(-32600)
+  })
 })
 
 describe('MCP: handshake + tools/list', () => {

--- a/api/test/api/mcp.test.ts
+++ b/api/test/api/mcp.test.ts
@@ -91,6 +91,22 @@ describe('MCP: jsonrpc version validation', () => {
     expect(ok?.result).toBeDefined()
     expect((bad?.error as { code: number } | undefined)?.code).toBe(-32600)
   })
+
+  it('all-notification batch returns 204, not an empty array (JSON-RPC §6)', async () => {
+    const res = await SELF.fetch('https://example.com/mcp', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify([
+        { jsonrpc: '2.0', method: 'notifications/initialized' },
+        { jsonrpc: '2.0', method: 'initialized' },
+      ]),
+    })
+    expect(res.status).toBe(204)
+    expect(await res.text()).toBe('')
+  })
 })
 
 describe('MCP: handshake + tools/list', () => {

--- a/api/test/api/mcp.test.ts
+++ b/api/test/api/mcp.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { SAMPLE_VERSION, seedVersion } from './seed.ts'
+import { createMcpClient, structured, type ToolCallResult } from './mcp-client.ts'
+
+interface ToolListResult {
+  tools: Array<{
+    name: string
+    description?: string
+    inputSchema?: { properties?: Record<string, unknown> }
+  }>
+}
+
+interface VersionsPayload {
+  ok: boolean
+  data: { versions: Array<{ id: string; status: string }> }
+}
+
+interface ListElementsPayload {
+  ok: boolean
+  data: {
+    version: string
+    elements: Array<Record<string, unknown>>
+    total: number
+    returned: number
+  }
+  meta?: { next_cursor?: string | null; content_hash?: string }
+}
+
+interface SingleElementPayload {
+  ok: boolean
+  data?: { element: Record<string, unknown> }
+  errors?: Array<{ code: string; fix_hint?: string }>
+}
+
+interface ValidatePayload {
+  ok: boolean
+  data?: { ok: boolean }
+  errors?: Array<{ code: string; fix_hint?: string }>
+}
+
+interface BulkPayload {
+  ok: boolean
+  data?: { elements: Record<string, unknown> }
+  errors?: Array<{ code: string; path?: string; fix_hint?: string }>
+}
+
+beforeAll(async () => {
+  await seedVersion()
+})
+
+describe('MCP: handshake + tools/list', () => {
+  it('initialize returns server info', async () => {
+    const client = createMcpClient()
+    const res = await client.initialize()
+    expect(res.error).toBeUndefined()
+    expect((res.result as { serverInfo: { name: string } }).serverInfo.name).toBe('dtpr-api')
+  })
+
+  it('tools/list returns the seven read-side tools', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.listTools()
+    expect(res.error).toBeUndefined()
+    const names = (res.result as ToolListResult).tools.map((t) => t.name).sort()
+    expect(names).toEqual(
+      [
+        'get_element',
+        'get_elements',
+        'get_schema',
+        'list_categories',
+        'list_elements',
+        'list_schema_versions',
+        'validate_datachain',
+      ].sort(),
+    )
+  })
+
+  it('every tool carries a non-empty description', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.listTools()
+    for (const tool of (res.result as ToolListResult).tools) {
+      expect(tool.description?.length ?? 0).toBeGreaterThan(0)
+    }
+  })
+
+  it('tool inputSchema includes the documented parameters', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.listTools()
+    const listElements = (res.result as ToolListResult).tools.find(
+      (t) => t.name === 'list_elements',
+    )
+    const props = listElements?.inputSchema?.properties ?? {}
+    expect(Object.keys(props)).toEqual(
+      expect.arrayContaining(['version', 'category_id', 'locale', 'query', 'limit', 'cursor']),
+    )
+  })
+})
+
+describe('MCP: list_schema_versions', () => {
+  it('returns the seeded versions', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.callTool<ToolCallResult<VersionsPayload>>(
+      'list_schema_versions',
+      {},
+    )
+    const env = structured(res)
+    expect(env.ok).toBe(true)
+    expect(env.data.versions[0]?.id).toBe(SAMPLE_VERSION.canonical)
+  })
+
+  it('filters by datachain_type', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.callTool<ToolCallResult<VersionsPayload>>('list_schema_versions', {
+      datachain_type: 'device',
+    })
+    const env = structured(res)
+    expect(env.data.versions).toEqual([])
+  })
+})
+
+describe('MCP: get_schema', () => {
+  it('manifest mode does not inline elements', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.callTool<ToolCallResult<{ ok: true; data: Record<string, unknown> }>>(
+      'get_schema',
+      { version: SAMPLE_VERSION.canonical },
+    )
+    const env = structured(res)
+    expect((env.data as Record<string, unknown>).manifest).toBeDefined()
+    expect((env.data as Record<string, unknown>).elements).toBeUndefined()
+  })
+
+  it('full mode inlines elements', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.callTool<ToolCallResult<{ ok: true; data: { elements: unknown[] } }>>(
+      'get_schema',
+      { version: SAMPLE_VERSION.canonical, include: 'full' },
+    )
+    const env = structured(res)
+    expect(env.data.elements.length).toBeGreaterThan(0)
+  })
+})
+
+describe('MCP: list_elements', () => {
+  it('default projection returns id, title, category_ids', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.callTool<ToolCallResult<ListElementsPayload>>('list_elements', {
+      version: SAMPLE_VERSION.canonical,
+    })
+    const env = structured(res)
+    const fields = Object.keys(env.data.elements[0] ?? {}).sort()
+    expect(fields).toEqual(['category_ids', 'id', 'title'])
+  })
+
+  it('search ranks identifiable_video first for "video"', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.callTool<ToolCallResult<ListElementsPayload>>('list_elements', {
+      version: SAMPLE_VERSION.canonical,
+      query: 'video',
+    })
+    const env = structured(res)
+    expect((env.data.elements[0] as { id: string }).id).toBe('identifiable_video')
+  })
+
+  it('paginates with opaque cursor', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res1 = await client.callTool<ToolCallResult<ListElementsPayload>>('list_elements', {
+      version: SAMPLE_VERSION.canonical,
+      limit: 1,
+    })
+    const env1 = structured(res1)
+    expect(env1.data.returned).toBe(1)
+    expect(env1.meta?.next_cursor).toBeTruthy()
+
+    const res2 = await client.callTool<ToolCallResult<ListElementsPayload>>('list_elements', {
+      version: SAMPLE_VERSION.canonical,
+      limit: 1,
+      cursor: env1.meta!.next_cursor!,
+    })
+    const env2 = structured(res2)
+    expect(env2.data.returned).toBe(1)
+  })
+
+  it('content_hash returned in meta', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.callTool<ToolCallResult<ListElementsPayload>>('list_elements', {
+      version: SAMPLE_VERSION.canonical,
+    })
+    const env = structured(res)
+    expect(env.meta?.content_hash).toMatch(/^sha256-/)
+  })
+})
+
+describe('MCP: get_element', () => {
+  it('returns the element', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.callTool<ToolCallResult<SingleElementPayload>>('get_element', {
+      version: SAMPLE_VERSION.canonical,
+      element_id: 'accept_deny',
+    })
+    const env = structured(res)
+    expect((env.data?.element as { id: string }).id).toBe('accept_deny')
+  })
+
+  it('unknown id returns isError with element_not_found', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.callTool<ToolCallResult<SingleElementPayload>>('get_element', {
+      version: SAMPLE_VERSION.canonical,
+      element_id: 'nope',
+    })
+    const env = structured(res)
+    expect(env.ok).toBe(false)
+    expect(env.errors?.[0]?.code).toBe('element_not_found')
+    expect(env.errors?.[0]?.fix_hint).toContain('list_elements')
+    expect(res.result?.isError).toBe(true)
+  })
+
+  it('unknown version returns isError with unknown_version', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.callTool<ToolCallResult<SingleElementPayload>>('get_element', {
+      version: 'ai@2099-12-31',
+      element_id: 'accept_deny',
+    })
+    const env = structured(res)
+    expect(env.ok).toBe(false)
+    expect(env.errors?.[0]?.code).toBe('not_found')
+  })
+})
+
+describe('MCP: get_elements (bulk)', () => {
+  it('returns multiple elements keyed by id', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.callTool<ToolCallResult<BulkPayload>>('get_elements', {
+      version: SAMPLE_VERSION.canonical,
+      element_ids: ['accept_deny', 'identifiable_video'],
+    })
+    const env = structured(res)
+    expect(Object.keys(env.data?.elements ?? {}).sort()).toEqual([
+      'accept_deny',
+      'identifiable_video',
+    ])
+  })
+
+  it('deduplicates repeated ids', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.callTool<ToolCallResult<BulkPayload>>('get_elements', {
+      version: SAMPLE_VERSION.canonical,
+      element_ids: ['accept_deny', 'accept_deny', 'accept_deny'],
+    })
+    const env = structured(res)
+    expect(Object.keys(env.data?.elements ?? {})).toEqual(['accept_deny'])
+  })
+
+  it('per-id miss returns null + an inline error entry, not a hard failure', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.callTool<ToolCallResult<BulkPayload>>('get_elements', {
+      version: SAMPLE_VERSION.canonical,
+      element_ids: ['accept_deny', 'nope'],
+    })
+    const env = structured(res)
+    expect(env.data?.elements?.accept_deny).toBeTruthy()
+    expect(env.data?.elements?.nope).toBeNull()
+    expect(env.errors?.find((e) => e.path === 'nope')?.code).toBe('element_not_found')
+    // Soft failure — call succeeded.
+    expect(res.result?.isError).toBeUndefined()
+  })
+
+  it('rejects when too many ids are sent', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const ids = Array.from({ length: 101 }, (_, i) => `id_${i}`)
+    const res = await client.callTool<ToolCallResult<BulkPayload>>('get_elements', {
+      version: SAMPLE_VERSION.canonical,
+      element_ids: ids,
+    })
+    const env = structured(res)
+    expect(env.errors?.[0]?.code).toBe('element_ids_too_many')
+  })
+})
+
+describe('MCP: validate_datachain', () => {
+  it('valid datachain returns ok:true (soft success)', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const datachain = {
+      id: 'i1',
+      schema_version: SAMPLE_VERSION.canonical,
+      created_at: '2026-04-16T00:00:00.000Z',
+      elements: [{ element_id: 'accept_deny' }],
+    }
+    const res = await client.callTool<ToolCallResult<ValidatePayload>>('validate_datachain', {
+      version: SAMPLE_VERSION.canonical,
+      datachain,
+    })
+    const env = structured(res)
+    expect(env.ok).toBe(true)
+    expect(env.data?.ok).toBe(true)
+    expect(res.result?.isError).toBeUndefined()
+  })
+
+  it('invalid datachain returns ok:false but isError:false (semantic failure)', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const datachain = {
+      id: 'i2',
+      schema_version: SAMPLE_VERSION.canonical,
+      created_at: '2026-04-16T00:00:00.000Z',
+      elements: [{ element_id: 'accept_deny' }, { element_id: 'unknown_one' }],
+    }
+    const res = await client.callTool<ToolCallResult<ValidatePayload>>('validate_datachain', {
+      version: SAMPLE_VERSION.canonical,
+      datachain,
+    })
+    const env = structured(res)
+    expect(env.ok).toBe(false)
+    expect(env.errors && env.errors.length).toBeGreaterThan(0)
+    expect(res.result?.isError).toBeUndefined()
+  })
+
+  it('malformed datachain shape returns parse_error envelope', async () => {
+    const client = createMcpClient()
+    await client.initialize()
+    const res = await client.callTool<ToolCallResult<ValidatePayload>>('validate_datachain', {
+      version: SAMPLE_VERSION.canonical,
+      datachain: { wrong: 'shape' },
+    })
+    const env = structured(res)
+    expect(env.ok).toBe(false)
+    expect(env.errors?.every((e) => e.code === 'parse_error')).toBe(true)
+  })
+})

--- a/api/test/api/rate-limit.test.ts
+++ b/api/test/api/rate-limit.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { SELF } from 'cloudflare:test'
+import { Hono } from 'hono'
+import type { AppEnv } from '../../src/app-types.ts'
+import { rateLimit, _test } from '../../src/middleware/rate-limit.ts'
+import { registerErrorHandler } from '../../src/middleware/error-handler.ts'
+import { configuredRequestId } from '../../src/middleware/request-id.ts'
+import { SAMPLE_VERSION, seedVersion } from './seed.ts'
+
+describe('rate-limit: composeRateKey', () => {
+  it('uses cf-connecting-ip + DTPR-Client header', () => {
+    const req = headerBag({ 'cf-connecting-ip': '1.2.3.4', 'DTPR-Client': 'worcester/1.0' })
+    expect(_test.composeRateKey(req)).toBe('1.2.3.4:worcester/1.0')
+  })
+
+  it('falls back to x-forwarded-for when cf-connecting-ip is absent', () => {
+    const req = headerBag({ 'x-forwarded-for': '5.6.7.8' })
+    expect(_test.composeRateKey(req)).toBe('5.6.7.8:anonymous')
+  })
+
+  it('collapses missing client header into the anonymous bucket', () => {
+    const req = headerBag({ 'cf-connecting-ip': '9.9.9.9' })
+    expect(_test.composeRateKey(req)).toBe('9.9.9.9:anonymous')
+  })
+})
+
+describe('rate-limit: middleware', () => {
+  it('no-ops when the binding is absent (preview/dev/tests)', async () => {
+    const app = buildMiniApp()
+    const res = await app.request('/hit', {}, { CONTENT: null as never })
+    expect(res.status).toBe(200)
+  })
+
+  it('passes through on success and 429s on failure', async () => {
+    const app = buildMiniApp()
+    const fakeBinding = makeFakeRateLimit(['success', 'fail'])
+    const bound = { RL_READ: fakeBinding } as unknown as Env
+    const okRes = await app.request('/hit', { headers: { 'cf-connecting-ip': '1.1.1.1' } }, bound)
+    expect(okRes.status).toBe(200)
+    const blockedRes = await app.request(
+      '/hit',
+      { headers: { 'cf-connecting-ip': '1.1.1.1' } },
+      bound,
+    )
+    expect(blockedRes.status).toBe(429)
+    expect(blockedRes.headers.get('Retry-After')).toBe('60')
+    const body = (await blockedRes.json()) as { ok: false; errors: { fix_hint?: string }[] }
+    expect(body.errors[0]?.fix_hint).toContain('DTPR-Client')
+  })
+
+  it('isolates buckets by (IP, DTPR-Client) tuple', async () => {
+    const app = buildMiniApp()
+    const hits: string[] = []
+    const binding = {
+      limit(opts: { key: string }) {
+        hits.push(opts.key)
+        return Promise.resolve({ success: true })
+      },
+    }
+    const bound = { RL_READ: binding } as unknown as Env
+
+    await app.request(
+      '/hit',
+      { headers: { 'cf-connecting-ip': '1.1.1.1', 'DTPR-Client': 'worcester/1.0' } },
+      bound,
+    )
+    await app.request(
+      '/hit',
+      { headers: { 'cf-connecting-ip': '1.1.1.1' } },
+      bound,
+    )
+    expect(hits).toEqual(['1.1.1.1:worcester/1.0', '1.1.1.1:anonymous'])
+  })
+})
+
+describe('rate-limit: E2E (production app, binding absent)', () => {
+  beforeAll(async () => {
+    await seedVersion()
+  })
+
+  it('responds 200 even without a real rate-limit binding in tests', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/manifest`,
+    )
+    expect(res.status).toBe(200)
+  })
+})
+
+// ----------------------------------------------------------- helpers
+
+function headerBag(headers: Record<string, string>) {
+  return {
+    header: (name: string) => {
+      const k = Object.keys(headers).find((h) => h.toLowerCase() === name.toLowerCase())
+      return k ? headers[k] : undefined
+    },
+  }
+}
+
+function makeFakeRateLimit(outcomes: Array<'success' | 'fail'>): RateLimit {
+  let i = 0
+  return {
+    limit() {
+      const next = outcomes[Math.min(i, outcomes.length - 1)]
+      i++
+      return Promise.resolve({ success: next === 'success' })
+    },
+  }
+}
+
+function buildMiniApp() {
+  const app = new Hono<AppEnv>()
+  app.use('*', configuredRequestId())
+  app.use('/hit', rateLimit({ binding: 'RL_READ' }))
+  app.get('/hit', (c) => c.json({ ok: true }))
+  registerErrorHandler(app)
+  return app
+}

--- a/api/test/api/rest.test.ts
+++ b/api/test/api/rest.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { env, SELF } from 'cloudflare:test'
+import {
+  SAMPLE_BETA_VERSION,
+  SAMPLE_VERSION,
+  clearBucket,
+  makeElements,
+  makeManifest,
+  seedVersion,
+} from './seed.ts'
+import { INDEX_KEY } from '../../src/store/keys.ts'
+import { _resetInlineBundles } from '../../src/store/inline-bundles.ts'
+
+beforeEach(() => {
+  _resetInlineBundles()
+})
+
+describe('REST: GET /api/v2/schemas', () => {
+  beforeAll(async () => {
+    await seedVersion()
+  })
+
+  it('returns the registered versions', async () => {
+    const res = await SELF.fetch('https://example.com/api/v2/schemas')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: true; versions: Array<{ id: string; status: string }> }
+    expect(body.ok).toBe(true)
+    expect(body.versions[0]?.id).toBe(SAMPLE_VERSION.canonical)
+    expect(body.versions[0]?.status).toBe('stable')
+  })
+
+  it('returns an empty list when index is absent', async () => {
+    await clearBucket()
+    const res = await SELF.fetch('https://example.com/api/v2/schemas')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: true; versions: unknown[] }
+    expect(body.versions).toEqual([])
+  })
+})
+
+describe('REST: version normalization + 404 paths', () => {
+  beforeAll(async () => {
+    await seedVersion()
+  })
+
+  it('@-form returns the manifest', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/manifest`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { manifest: { version: string } }
+    expect(body.manifest.version).toBe(SAMPLE_VERSION.canonical)
+  })
+
+  it('%40-encoded version is treated identically to @ form', async () => {
+    const encoded = SAMPLE_VERSION.canonical.replace('@', '%40')
+    const res = await SELF.fetch(`https://example.com/api/v2/schemas/${encoded}/manifest`)
+    expect(res.status).toBe(200)
+  })
+
+  it('unknown version returns 404 envelope with fix_hint', async () => {
+    const res = await SELF.fetch('https://example.com/api/v2/schemas/ai@2099-12-31/manifest')
+    expect(res.status).toBe(404)
+    const body = (await res.json()) as { ok: false; errors: { code: string; fix_hint?: string }[] }
+    expect(body.ok).toBe(false)
+    expect(body.errors[0]?.code).toBe('not_found')
+    expect(body.errors[0]?.fix_hint).toContain('GET /api/v2/schemas')
+  })
+
+  it('malformed version returns 400', async () => {
+    const res = await SELF.fetch('https://example.com/api/v2/schemas/ai@2026-04/manifest')
+    expect(res.status).toBe(400)
+  })
+
+  it('missing route returns 404 envelope', async () => {
+    const res = await SELF.fetch('https://example.com/api/v2/nope')
+    expect(res.status).toBe(404)
+    const body = (await res.json()) as { ok: false; errors: { code: string }[] }
+    expect(body.errors[0]?.code).toBe('not_found')
+  })
+})
+
+describe('REST: GET .../categories', () => {
+  beforeAll(async () => {
+    await seedVersion()
+  })
+
+  it('returns categories with all locales', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/categories`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      categories: Array<{ name: { locale: string }[] }>
+    }
+    const locales = body.categories[0]?.name.map((n) => n.locale).sort()
+    expect(locales).toEqual(['en', 'fr'])
+  })
+
+  it('?locales=en filters to a single locale', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/categories?locales=en`,
+    )
+    const body = (await res.json()) as {
+      categories: Array<{ name: { locale: string }[] }>
+    }
+    expect(body.categories[0]?.name.map((n) => n.locale)).toEqual(['en'])
+  })
+
+  it('stamps DTPR-Content-Hash and immutable Cache-Control on stable', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/categories`,
+    )
+    expect(res.headers.get('DTPR-Content-Hash')).toMatch(/^sha256-[0-9a-f]{64}$/)
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=86400, immutable')
+  })
+})
+
+describe('REST: GET .../elements', () => {
+  beforeAll(async () => {
+    await seedVersion()
+  })
+
+  it('default projection returns id, title, category_ids only', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      elements: Array<Record<string, unknown>>
+      meta: { total: number; returned: number }
+    }
+    expect(body.meta.total).toBe(3)
+    expect(body.meta.returned).toBe(3)
+    const fields = Object.keys(body.elements[0] ?? {}).sort()
+    expect(fields).toEqual(['category_ids', 'id', 'title'])
+  })
+
+  it('?fields=id,description returns only those fields (id always included)', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements?fields=description`,
+    )
+    const body = (await res.json()) as { elements: Array<Record<string, unknown>> }
+    const fields = Object.keys(body.elements[0] ?? {}).sort()
+    expect(fields).toEqual(['description', 'id'])
+  })
+
+  it('?fields=all returns full elements', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements?fields=all`,
+    )
+    const body = (await res.json()) as { elements: Array<Record<string, unknown>> }
+    expect(Object.keys(body.elements[0] ?? {})).toEqual(
+      expect.arrayContaining(['id', 'title', 'description', 'icon', 'category_ids', 'variables']),
+    )
+  })
+
+  it('?category_id filters elements', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements?category_id=ai__decision`,
+    )
+    const body = (await res.json()) as { meta: { total: number } }
+    expect(body.meta.total).toBe(3)
+  })
+
+  it('?category_id=missing returns empty array (not 404)', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements?category_id=ai__nope`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { elements: unknown[]; meta: { total: number } }
+    expect(body.meta.total).toBe(0)
+    expect(body.elements).toEqual([])
+  })
+
+  it('?limit=1 paginates with a next_cursor', async () => {
+    const res1 = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements?limit=1`,
+    )
+    const body1 = (await res1.json()) as {
+      meta: { next_cursor: string | null; returned: number }
+    }
+    expect(body1.meta.returned).toBe(1)
+    expect(body1.meta.next_cursor).toBeTruthy()
+
+    const res2 = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements?limit=1&cursor=${encodeURIComponent(body1.meta.next_cursor!)}`,
+    )
+    const body2 = (await res2.json()) as {
+      meta: { next_cursor: string | null; returned: number }
+    }
+    expect(body2.meta.returned).toBe(1)
+  })
+
+  it('?limit beyond max → 400', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements?limit=999`,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('malformed cursor → 400', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements?cursor=junk`,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('?query=video matches identifiable_video first', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements?query=video&fields=id`,
+    )
+    const body = (await res.json()) as { elements: Array<{ id: string }> }
+    expect(body.elements[0]?.id).toBe('identifiable_video')
+  })
+})
+
+describe('REST: GET .../elements/:id', () => {
+  beforeAll(async () => {
+    await seedVersion()
+  })
+
+  it('returns the full element by default', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements/accept_deny`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { element: { id: string; description: { locale: string }[] } }
+    expect(body.element.id).toBe('accept_deny')
+    expect(body.element.description.length).toBeGreaterThan(0)
+  })
+
+  it('unknown id returns 404 with fix_hint pointing to /elements', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements/nonexistent`,
+    )
+    expect(res.status).toBe(404)
+    const body = (await res.json()) as { ok: false; errors: { fix_hint?: string }[] }
+    expect(body.errors[0]?.fix_hint).toContain('/elements')
+  })
+
+  it('?locales=fr filters', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements/accept_deny?locales=fr`,
+    )
+    const body = (await res.json()) as { element: { title: { locale: string }[] } }
+    expect(body.element.title.map((t) => t.locale)).toEqual(['fr'])
+  })
+})
+
+describe('REST: POST .../validate', () => {
+  beforeAll(async () => {
+    await seedVersion()
+  })
+
+  it('valid datachain returns ok:true', async () => {
+    const body = {
+      id: 'test-1',
+      schema_version: SAMPLE_VERSION.canonical,
+      created_at: '2026-04-16T00:00:00.000Z',
+      elements: [{ element_id: 'accept_deny' }],
+    }
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/validate`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    )
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { ok: boolean }
+    expect(json.ok).toBe(true)
+  })
+
+  it('invalid datachain returns ok:false with errors', async () => {
+    const body = {
+      id: 'test-2',
+      schema_version: SAMPLE_VERSION.canonical,
+      created_at: '2026-04-16T00:00:00.000Z',
+      elements: [{ element_id: 'nonexistent' }],
+    }
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/validate`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    )
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as {
+      ok: false
+      errors: { code: string; fix_hint?: string }[]
+    }
+    expect(json.ok).toBe(false)
+    expect(json.errors.length).toBeGreaterThan(0)
+  })
+
+  it('malformed JSON body returns 400', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/validate`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{not json',
+      },
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('non-instance body shape returns ok:false with parse_error codes', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/validate`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ wrong: 'shape' }),
+      },
+    )
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { ok: false; errors: { code: string }[] }
+    expect(json.ok).toBe(false)
+    expect(json.errors.every((e) => e.code === 'parse_error')).toBe(true)
+  })
+})
+
+describe('REST: cache control on beta', () => {
+  beforeAll(async () => {
+    await seedVersion({ version: SAMPLE_BETA_VERSION, manifest: makeManifest(SAMPLE_BETA_VERSION) })
+  })
+
+  it('beta returns Cache-Control: no-store', async () => {
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_BETA_VERSION.canonical}/categories`,
+    )
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+  })
+})

--- a/api/test/api/rest.test.ts
+++ b/api/test/api/rest.test.ts
@@ -8,7 +8,7 @@ import {
   makeManifest,
   seedVersion,
 } from './seed.ts'
-import { INDEX_KEY } from '../../src/store/keys.ts'
+import { INDEX_KEY, searchIndexKey } from '../../src/store/keys.ts'
 import { _resetInlineBundles } from '../../src/store/inline-bundles.ts'
 
 beforeEach(() => {
@@ -212,6 +212,19 @@ describe('REST: GET .../elements', () => {
     )
     const body = (await res.json()) as { elements: Array<{ id: string }> }
     expect(body.elements[0]?.id).toBe('identifiable_video')
+  })
+
+  it('?query without a built index for the requested locale falls back to natural order, not zero results', async () => {
+    // Re-seed and remove the search index for the queried locale so
+    // we can exercise the no-index path.
+    await seedVersion()
+    await env.CONTENT.delete(searchIndexKey(SAMPLE_VERSION, 'fr'))
+    const res = await SELF.fetch(
+      `https://example.com/api/v2/schemas/${SAMPLE_VERSION.canonical}/elements?query=video&locale=fr&fields=id`,
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { elements: unknown[]; meta: { returned: number } }
+    expect(body.meta.returned).toBeGreaterThan(0)
   })
 })
 

--- a/api/test/api/schemas.ts
+++ b/api/test/api/schemas.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod'
+
+/**
+ * Zod schemas mirroring the API's public response shapes. These are
+ * test-only; the Worker uses the Zod sources in `src/schema/` for
+ * content validation. Keeping a separate set here forces us to think
+ * about the wire contract — accidental shape changes must be
+ * expressed in both places.
+ *
+ * Ported from `app/test/api/schemas.ts` and adapted to the v2
+ * envelope (`{ ok, ... }` rather than the v1 `{ schema, item }[]`).
+ */
+
+export const LocaleValueSchema = z.object({
+  locale: z.string(),
+  value: z.string(),
+})
+
+export const IconSchema = z.object({
+  url: z.string(),
+  format: z.string(),
+  alt_text: z.array(LocaleValueSchema),
+})
+
+export const VariableSchema = z.object({
+  id: z.string(),
+  label: z.array(LocaleValueSchema),
+  required: z.boolean(),
+})
+
+export const ContextValueSchema = z.object({
+  id: z.string(),
+  name: z.array(LocaleValueSchema),
+  description: z.array(LocaleValueSchema),
+  color: z.string(),
+})
+
+export const ContextSchema = z.object({
+  id: z.string(),
+  name: z.array(LocaleValueSchema),
+  description: z.array(LocaleValueSchema),
+  values: z.array(ContextValueSchema),
+})
+
+export const CategorySchema = z.object({
+  id: z.string(),
+  order: z.number().optional(),
+  required: z.boolean().optional(),
+  datachain_type: z.string(),
+  name: z.array(LocaleValueSchema),
+  description: z.array(LocaleValueSchema),
+  prompt: z.array(LocaleValueSchema),
+  element_variables: z.array(VariableSchema),
+  context: ContextSchema.optional(),
+})
+
+export const ElementSchema = z.object({
+  id: z.string(),
+  category_ids: z.array(z.string()),
+  title: z.array(LocaleValueSchema),
+  description: z.array(LocaleValueSchema),
+  citation: z.array(LocaleValueSchema),
+  icon: IconSchema,
+  variables: z.array(VariableSchema),
+})
+
+// Response envelopes (v2 shape)
+
+export const SchemaIndexEntrySchema = z.object({
+  id: z.string(),
+  status: z.enum(['beta', 'stable']),
+  created_at: z.string(),
+  content_hash: z.string(),
+})
+
+export const SchemaIndexResponseSchema = z.object({
+  ok: z.literal(true),
+  versions: z.array(SchemaIndexEntrySchema),
+})
+
+export const ManifestResponseSchema = z.object({
+  ok: z.literal(true),
+  manifest: z.object({
+    version: z.string(),
+    status: z.enum(['beta', 'stable']),
+    created_at: z.string(),
+    notes: z.string(),
+    content_hash: z.string(),
+    locales: z.array(z.string()),
+  }),
+})
+
+export const CategoriesResponseSchema = z.object({
+  ok: z.literal(true),
+  version: z.string(),
+  categories: z.array(CategorySchema),
+})
+
+export const ElementsResponseSchema = z.object({
+  ok: z.literal(true),
+  version: z.string(),
+  elements: z.array(ElementSchema.partial().required({ id: true })),
+  meta: z.object({
+    total: z.number(),
+    returned: z.number(),
+    next_cursor: z.string().nullable(),
+  }),
+})
+
+export const SingleElementResponseSchema = z.object({
+  ok: z.literal(true),
+  version: z.string(),
+  element: ElementSchema.partial().required({ id: true }),
+})

--- a/api/test/api/seed.ts
+++ b/api/test/api/seed.ts
@@ -1,0 +1,206 @@
+/**
+ * Helpers for seeding Miniflare's R2 binding from a vitest test file.
+ * Used by REST + MCP API tests so each suite can stand up a small,
+ * focused schema version inside one beforeAll.
+ */
+
+import { env } from 'cloudflare:test'
+import type { Category } from '../../src/schema/category.ts'
+import type { DatachainType } from '../../src/schema/datachain-type.ts'
+import type { Element } from '../../src/schema/element.ts'
+import type { LocaleCode } from '../../src/schema/locale.ts'
+import type { SchemaManifest } from '../../src/schema/manifest.ts'
+import type { ParsedVersion } from '../../cli/lib/version-parser.ts'
+import {
+  categoriesKey,
+  datachainTypeKey,
+  elementKey,
+  elementsKey,
+  manifestKey,
+  schemaJsonKey,
+  searchIndexKey,
+  INDEX_KEY,
+} from '../../src/store/keys.ts'
+import { buildSearchIndexesByLocale } from '../../cli/lib/search-index-builder.ts'
+import type { SchemaIndex } from '../../src/store/index.ts'
+
+const loc = (locale: LocaleCode, value: string) => ({ locale, value })
+
+export const SAMPLE_VERSION: ParsedVersion = {
+  type: 'ai',
+  date: '2026-04-16',
+  beta: false,
+  canonical: 'ai@2026-04-16',
+  dir: 'ai/2026-04-16',
+}
+
+export const SAMPLE_BETA_VERSION: ParsedVersion = {
+  type: 'ai',
+  date: '2026-04-16',
+  beta: true,
+  canonical: 'ai@2026-04-16-beta',
+  dir: 'ai/2026-04-16-beta',
+}
+
+export function makeManifest(version: ParsedVersion): SchemaManifest {
+  return {
+    version: version.canonical,
+    status: version.beta ? 'beta' : 'stable',
+    created_at: '2026-04-16T00:00:00.000Z',
+    notes: '',
+    content_hash: `sha256-${'a'.repeat(64)}`,
+    locales: ['en', 'fr'],
+  }
+}
+
+export function makeDatachainType(): DatachainType {
+  return {
+    id: 'ai',
+    name: [loc('en', 'AI'), loc('fr', 'IA')],
+    description: [loc('en', 'AI datachain'), loc('fr', 'Chaîne IA')],
+    categories: ['ai__decision'],
+    locales: ['en', 'fr'],
+  }
+}
+
+export function makeCategories(): Category[] {
+  return [
+    {
+      id: 'ai__decision',
+      name: [loc('en', 'Decision'), loc('fr', 'Décision')],
+      description: [
+        loc('en', 'How decisions get made.'),
+        loc('fr', 'Comment les décisions sont prises.'),
+      ],
+      prompt: [],
+      required: true,
+      order: 1,
+      datachain_type: 'ai',
+      element_variables: [],
+    },
+  ]
+}
+
+export function makeElements(): Element[] {
+  return [
+    {
+      id: 'accept_deny',
+      category_ids: ['ai__decision'],
+      title: [loc('en', 'Accept / Deny'), loc('fr', 'Accepter / Refuser')],
+      description: [
+        loc('en', 'Binary outcome: yes or no.'),
+        loc('fr', 'Résultat binaire: oui ou non.'),
+      ],
+      citation: [],
+      icon: {
+        url: '/dtpr-icons/accept_deny.svg',
+        format: 'svg',
+        alt_text: [loc('en', 'Accept / Deny icon'), loc('fr', 'Icône Accepter / Refuser')],
+      },
+      variables: [],
+    },
+    {
+      id: 'identifiable_video',
+      category_ids: ['ai__decision'],
+      title: [loc('en', 'Identifiable video'), loc('fr', 'Vidéo identifiable')],
+      description: [
+        loc('en', 'Video that can identify a person.'),
+        loc('fr', 'Vidéo qui peut identifier une personne.'),
+      ],
+      citation: [],
+      icon: {
+        url: '/dtpr-icons/identifiable_video.svg',
+        format: 'svg',
+        alt_text: [loc('en', 'video icon'), loc('fr', 'icône vidéo')],
+      },
+      variables: [],
+    },
+    {
+      id: 'anomaly_detection',
+      category_ids: ['ai__decision'],
+      title: [loc('en', 'Anomaly detection'), loc('fr', 'Détection d\'anomalies')],
+      description: [
+        loc('en', 'Flagging unusual patterns.'),
+        loc('fr', 'Signaler des modèles inhabituels.'),
+      ],
+      citation: [],
+      icon: {
+        url: '/dtpr-icons/anomaly.svg',
+        format: 'svg',
+        alt_text: [loc('en', 'anomaly icon'), loc('fr', 'icône anomalie')],
+      },
+      variables: [],
+    },
+  ]
+}
+
+async function putJson(key: string, value: unknown): Promise<void> {
+  await env.CONTENT.put(key, JSON.stringify(value))
+}
+
+async function clearBucket(): Promise<void> {
+  let cursor: string | undefined
+  do {
+    const list = await env.CONTENT.list({ cursor, limit: 1000 })
+    if (list.objects.length > 0) {
+      await env.CONTENT.delete(list.objects.map((o) => o.key))
+    }
+    cursor = list.truncated ? list.cursor : undefined
+  } while (cursor)
+}
+
+export interface SeedOptions {
+  version?: ParsedVersion
+  manifest?: SchemaManifest
+  datachainType?: DatachainType
+  categories?: Category[]
+  elements?: Element[]
+  /** When true, also write `schemas/index.json` so the version is discoverable. */
+  registerInIndex?: boolean
+}
+
+/**
+ * Wipe the bucket and seed a single version's worth of objects.
+ * Returns the seed payload so tests can assert against the exact
+ * shapes that landed in R2.
+ */
+export async function seedVersion(opts: SeedOptions = {}) {
+  await clearBucket()
+  const version = opts.version ?? SAMPLE_VERSION
+  const manifest = opts.manifest ?? makeManifest(version)
+  const datachainType = opts.datachainType ?? makeDatachainType()
+  const categories = opts.categories ?? makeCategories()
+  const elements = opts.elements ?? makeElements()
+
+  await putJson(manifestKey(version), manifest)
+  await putJson(datachainTypeKey(version), datachainType)
+  await putJson(categoriesKey(version), categories)
+  await putJson(elementsKey(version), elements)
+  await putJson(schemaJsonKey(version), { Element: { type: 'object' } })
+  for (const el of elements) {
+    await putJson(elementKey(version, el.id), el)
+  }
+
+  const indexes = buildSearchIndexesByLocale(elements, manifest.locales)
+  for (const [locale, serialized] of Object.entries(indexes)) {
+    await env.CONTENT.put(searchIndexKey(version, locale as LocaleCode), serialized)
+  }
+
+  if (opts.registerInIndex !== false) {
+    const idx: SchemaIndex = {
+      versions: [
+        {
+          id: manifest.version,
+          status: manifest.status,
+          created_at: manifest.created_at,
+          content_hash: manifest.content_hash,
+        },
+      ],
+    }
+    await putJson(INDEX_KEY, idx)
+  }
+
+  return { version, manifest, datachainType, categories, elements }
+}
+
+export { clearBucket }

--- a/api/test/types.d.ts
+++ b/api/test/types.d.ts
@@ -1,5 +1,19 @@
 /// <reference types="@cloudflare/vitest-pool-workers" />
 
+// Augment the generated Env with the rate-limit bindings declared in
+// wrangler.jsonc's `unsafe.bindings`. `wrangler types` does not emit
+// types for `unsafe.bindings`, so we declare them here by hand.
+declare global {
+  namespace Cloudflare {
+    interface Env {
+      RL_READ?: RateLimit
+      RL_VALIDATE?: RateLimit
+    }
+  }
+}
+
 declare module 'cloudflare:test' {
   interface ProvidedEnv extends Env {}
 }
+
+export {}

--- a/api/test/types.d.ts
+++ b/api/test/types.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="@cloudflare/vitest-pool-workers" />
+
+declare module 'cloudflare:test' {
+  interface ProvidedEnv extends Env {}
+}

--- a/api/test/unit/cache-wrapper.test.ts
+++ b/api/test/unit/cache-wrapper.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { cached, cachedText, cacheKeyFor } from '../../src/store/cache-wrapper.ts'
+
+/**
+ * caches.default in vitest-pool-workers is a real Miniflare cache,
+ * so hits/misses behave like production. Each test uses a unique key
+ * to keep ordering between cases independent.
+ */
+
+let counter = 0
+const uniqueKey = (label: string) => `test/${label}/${Date.now()}-${counter++}`
+
+describe('cache-wrapper: cached', () => {
+  beforeEach(() => {
+    counter++
+  })
+
+  it('first call invokes loader; second call serves from cache', async () => {
+    const key = uniqueKey('basic-hit')
+    let calls = 0
+    const loader = async () => {
+      calls++
+      return { foo: 'bar', n: calls }
+    }
+    const r1 = await cached<{ foo: string; n: number }>(key, loader, { enabled: true, ttl: 60 })
+    const r2 = await cached<{ foo: string; n: number }>(key, loader, { enabled: true, ttl: 60 })
+    expect(r1).toEqual({ foo: 'bar', n: 1 })
+    expect(r2).toEqual({ foo: 'bar', n: 1 })
+    expect(calls).toBe(1)
+  })
+
+  it('does not cache null results so missing data becomes visible immediately', async () => {
+    const key = uniqueKey('null-not-cached')
+    let calls = 0
+    let value: { x: number } | null = null
+    const loader = async () => {
+      calls++
+      return value
+    }
+    expect(await cached<{ x: number }>(key, loader, { enabled: true, ttl: 60 })).toBeNull()
+    value = { x: 42 }
+    expect(await cached<{ x: number }>(key, loader, { enabled: true, ttl: 60 })).toEqual({ x: 42 })
+    expect(calls).toBe(2)
+  })
+
+  it('bypasses cache when enabled=false', async () => {
+    const key = uniqueKey('disabled')
+    let calls = 0
+    const loader = async () => {
+      calls++
+      return { tick: calls }
+    }
+    await cached<{ tick: number }>(key, loader, { enabled: false, ttl: 60 })
+    await cached<{ tick: number }>(key, loader, { enabled: false, ttl: 60 })
+    expect(calls).toBe(2)
+  })
+
+  it('different keys do not share cache entries', async () => {
+    const a = uniqueKey('isolated-a')
+    const b = uniqueKey('isolated-b')
+    const ra = await cached<string>(a, async () => 'A', { enabled: true, ttl: 60 })
+    const rb = await cached<string>(b, async () => 'B', { enabled: true, ttl: 60 })
+    expect(ra).toBe('A')
+    expect(rb).toBe('B')
+  })
+
+  it('uses ctx.waitUntil for background cache writes when provided', async () => {
+    const key = uniqueKey('waituntil')
+    const ctx = createCtx()
+    let calls = 0
+    const loader = async () => {
+      calls++
+      return { v: calls }
+    }
+    const r1 = await cached(key, loader, { enabled: true, ttl: 60, ctx })
+    expect(r1).toEqual({ v: 1 })
+    expect(ctx.queue.length).toBe(1)
+    await Promise.all(ctx.queue)
+    const r2 = await cached(key, loader, { enabled: true, ttl: 60, ctx })
+    expect(r2).toEqual({ v: 1 })
+    expect(calls).toBe(1)
+  })
+})
+
+describe('cache-wrapper: cachedText', () => {
+  it('round-trips text without parsing it', async () => {
+    const key = uniqueKey('text')
+    const payload = '{"a":1,"b":[true,null,"xx"]}'
+    let calls = 0
+    const loader = async () => {
+      calls++
+      return payload
+    }
+    const r1 = await cachedText(key, loader, { enabled: true, ttl: 60 })
+    const r2 = await cachedText(key, loader, { enabled: true, ttl: 60 })
+    expect(r1).toBe(payload)
+    expect(r2).toBe(payload)
+    expect(calls).toBe(1)
+  })
+})
+
+describe('cache-wrapper: cacheKeyFor', () => {
+  it('strips leading slashes and produces an absolute URL', () => {
+    expect(cacheKeyFor('schemas/ai/2026-04-16/manifest.json')).toBe(
+      'https://cache.internal.dtpr-api/schemas/ai/2026-04-16/manifest.json',
+    )
+    expect(cacheKeyFor('/schemas/index.json')).toBe(
+      'https://cache.internal.dtpr-api/schemas/index.json',
+    )
+  })
+})
+
+function createCtx(): { queue: Promise<unknown>[] } & ExecutionContext {
+  const queue: Promise<unknown>[] = []
+  const ctx = {
+    waitUntil(p: Promise<unknown>) {
+      queue.push(p)
+    },
+    passThroughOnException() {},
+    props: {} as never,
+    exports: {} as never,
+    queue,
+  }
+  return ctx as { queue: Promise<unknown>[] } & ExecutionContext
+}

--- a/api/test/unit/middleware/cors.test.ts
+++ b/api/test/unit/middleware/cors.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { createApp } from '../../../src/app.ts'
+import { _test as corsTest } from '../../../src/middleware/cors.ts'
+
+describe('middleware: cors', () => {
+  it('allows explicit allow-list origins', () => {
+    expect(corsTest.isAllowedOrigin('https://dtpr.io')).toBe(true)
+    expect(corsTest.isAllowedOrigin('https://docs.dtpr.io')).toBe(true)
+  })
+
+  it('allows preview subdomains by pattern', () => {
+    expect(corsTest.isAllowedOrigin('https://pr-42-preview.api.dtpr.io')).toBe(true)
+  })
+
+  it('allows localhost for development', () => {
+    expect(corsTest.isAllowedOrigin('http://localhost:3000')).toBe(true)
+    expect(corsTest.isAllowedOrigin('http://127.0.0.1:8787')).toBe(true)
+  })
+
+  it('rejects arbitrary origins', () => {
+    expect(corsTest.isAllowedOrigin('https://evil.com')).toBe(false)
+    expect(corsTest.isAllowedOrigin('https://dtpr.io.evil.com')).toBe(false)
+  })
+
+  it('preflight returns matching Access-Control-Allow-Origin for allowed origin', async () => {
+    const app = createApp()
+    const res = await app.request('/healthz', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://dtpr.io',
+        'Access-Control-Request-Method': 'GET',
+      },
+    })
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://dtpr.io')
+  })
+
+  it('preflight does not set allow-origin for a disallowed origin', async () => {
+    const app = createApp()
+    const res = await app.request('/healthz', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://evil.com',
+        'Access-Control-Request-Method': 'GET',
+      },
+    })
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+})

--- a/api/test/unit/middleware/error-handler.test.ts
+++ b/api/test/unit/middleware/error-handler.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { Hono } from 'hono'
+import type { AppEnv } from '../../../src/app-types.ts'
+import { configuredRequestId } from '../../../src/middleware/request-id.ts'
+import { registerErrorHandler } from '../../../src/middleware/error-handler.ts'
+import { ApiError, apiErrors } from '../../../src/middleware/errors.ts'
+import { R2LoadError } from '../../../src/store/r2-loader.ts'
+
+function buildApp() {
+  const app = new Hono<AppEnv>()
+  app.use('*', configuredRequestId())
+  app.get('/boom', () => {
+    throw new Error('kaboom')
+  })
+  app.get('/not-found', () => {
+    throw apiErrors.notFound('No such element.', 'Use list_elements to enumerate.')
+  })
+  app.get('/rate-limited', () => {
+    throw apiErrors.rateLimited(42)
+  })
+  app.get('/upstream', () => {
+    throw new R2LoadError('connection reset', 'schemas/ai/2026-04-16/manifest.json')
+  })
+  app.get('/validation', () => {
+    throw new ApiError(400, [
+      { code: 'bad_field', message: 'foo is invalid', path: 'datachain.foo' },
+    ])
+  })
+  registerErrorHandler(app)
+  return app
+}
+
+describe('middleware: error-handler', () => {
+  it('translates ApiError to its declared status + envelope', async () => {
+    const app = buildApp()
+    const res = await app.request('/not-found')
+    expect(res.status).toBe(404)
+    const body = (await res.json()) as {
+      ok: false
+      errors: { code: string; fix_hint?: string }[]
+    }
+    expect(body.ok).toBe(false)
+    expect(body.errors[0]?.code).toBe('not_found')
+    expect(body.errors[0]?.fix_hint).toContain('list_elements')
+  })
+
+  it('emits rate-limited envelope with fix_hint referencing DTPR-Client', async () => {
+    const app = buildApp()
+    const res = await app.request('/rate-limited')
+    expect(res.status).toBe(429)
+    const body = (await res.json()) as { errors: { fix_hint?: string }[] }
+    expect(body.errors[0]?.fix_hint).toContain('DTPR-Client')
+  })
+
+  it('maps R2LoadError to 502 upstream envelope', async () => {
+    const app = buildApp()
+    const res = await app.request('/upstream')
+    expect(res.status).toBe(502)
+    const body = (await res.json()) as { errors: { code: string }[] }
+    expect(body.errors[0]?.code).toBe('upstream_error')
+  })
+
+  it('swallows unexpected errors and returns 500 without leaking the message', async () => {
+    const app = buildApp()
+    const res = await app.request('/boom')
+    expect(res.status).toBe(500)
+    const body = (await res.json()) as { errors: { code: string; message: string }[] }
+    expect(body.errors[0]?.code).toBe('internal_error')
+    expect(body.errors[0]?.message).not.toContain('kaboom')
+  })
+
+  it('echoes X-Request-Id on every error response', async () => {
+    const app = buildApp()
+    const res = await app.request('/boom', { headers: { 'X-Request-Id': 'test-42' } })
+    expect(res.headers.get('X-Request-Id')).toBe('test-42')
+  })
+
+  it('preserves per-field path metadata in validation errors', async () => {
+    const app = buildApp()
+    const res = await app.request('/validation')
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { errors: { path?: string }[] }
+    expect(body.errors[0]?.path).toBe('datachain.foo')
+  })
+
+  it('unmatched routes return 404 envelope', async () => {
+    const app = buildApp()
+    const res = await app.request('/nope')
+    expect(res.status).toBe(404)
+    const body = (await res.json()) as { ok: false; errors: { code: string }[] }
+    expect(body.errors[0]?.code).toBe('not_found')
+  })
+})

--- a/api/test/unit/middleware/payload-limits.test.ts
+++ b/api/test/unit/middleware/payload-limits.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { Hono } from 'hono'
+import type { AppEnv } from '../../../src/app-types.ts'
+import { payloadLimits, MAX_PAYLOAD_BYTES } from '../../../src/middleware/payload-limits.ts'
+import { registerErrorHandler } from '../../../src/middleware/error-handler.ts'
+
+function buildApp(maxBytes?: number) {
+  const app = new Hono<AppEnv>()
+  app.use('*', payloadLimits(maxBytes))
+  app.post('/echo', async (c) => c.json({ ok: true }))
+  registerErrorHandler(app)
+  return app
+}
+
+describe('middleware: payload-limits', () => {
+  it('allows requests under the limit', async () => {
+    const app = buildApp(1000)
+    const body = 'a'.repeat(500)
+    const res = await app.request('/echo', {
+      method: 'POST',
+      headers: { 'Content-Length': String(body.length), 'Content-Type': 'application/octet-stream' },
+      body,
+    })
+    expect(res.status).toBe(200)
+  })
+
+  it('rejects requests exceeding the limit with 413 envelope', async () => {
+    const app = buildApp(100)
+    const res = await app.request('/echo', {
+      method: 'POST',
+      headers: { 'Content-Length': '200', 'Content-Type': 'application/octet-stream' },
+      body: 'a'.repeat(200),
+    })
+    expect(res.status).toBe(413)
+    const json = (await res.json()) as { ok: false; errors: { code: string }[] }
+    expect(json.ok).toBe(false)
+    expect(json.errors[0]?.code).toBe('payload_too_large')
+  })
+
+  it('rejects malformed Content-Length as 400', async () => {
+    const app = buildApp()
+    const res = await app.request('/echo', {
+      method: 'POST',
+      headers: { 'Content-Length': 'not-a-number' },
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('defaults to 64 KB when no limit is supplied', () => {
+    expect(MAX_PAYLOAD_BYTES).toBe(64 * 1024)
+  })
+})

--- a/api/test/unit/middleware/payload-limits.test.ts
+++ b/api/test/unit/middleware/payload-limits.test.ts
@@ -8,8 +8,29 @@ function buildApp(maxBytes?: number) {
   const app = new Hono<AppEnv>()
   app.use('*', payloadLimits(maxBytes))
   app.post('/echo', async (c) => c.json({ ok: true }))
+  app.post('/parse', async (c) => {
+    // Forces the body to be read after the middleware has consumed it,
+    // so we can verify that bodyCache re-attachment works.
+    const json = await c.req.json()
+    return c.json({ ok: true, got: json })
+  })
   registerErrorHandler(app)
   return app
+}
+
+function streamOf(bytes: Uint8Array, chunkSize = 1024): ReadableStream<Uint8Array> {
+  let offset = 0
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (offset >= bytes.byteLength) {
+        controller.close()
+        return
+      }
+      const end = Math.min(offset + chunkSize, bytes.byteLength)
+      controller.enqueue(bytes.slice(offset, end))
+      offset = end
+    },
+  })
 }
 
 describe('middleware: payload-limits', () => {
@@ -48,5 +69,44 @@ describe('middleware: payload-limits', () => {
 
   it('defaults to 64 KB when no limit is supplied', () => {
     expect(MAX_PAYLOAD_BYTES).toBe(64 * 1024)
+  })
+
+  it('rejects oversize streamed (chunked) bodies with no Content-Length', async () => {
+    const app = buildApp(1024)
+    const payload = new Uint8Array(4096) // 4 KB > 1 KB cap
+    const res = await app.request(
+      '/echo',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: streamOf(payload),
+        // Required when sending a ReadableStream body.
+        // @ts-expect-error duplex is part of the fetch spec but not all libdom typings include it.
+        duplex: 'half',
+      },
+    )
+    expect(res.status).toBe(413)
+    const json = (await res.json()) as { ok: false; errors: { code: string }[] }
+    expect(json.ok).toBe(false)
+    expect(json.errors[0]?.code).toBe('payload_too_large')
+  })
+
+  it('allows under-cap streamed bodies and re-exposes them to the route', async () => {
+    const app = buildApp(1024)
+    const payload = new TextEncoder().encode(JSON.stringify({ hello: 'world' }))
+    const res = await app.request(
+      '/parse',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: streamOf(payload),
+        // @ts-expect-error duplex is part of the fetch spec but not all libdom typings include it.
+        duplex: 'half',
+      },
+    )
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { ok: true; got: { hello: string } }
+    expect(json.ok).toBe(true)
+    expect(json.got).toEqual({ hello: 'world' })
   })
 })

--- a/api/test/unit/middleware/request-id.test.ts
+++ b/api/test/unit/middleware/request-id.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { createApp } from '../../../src/app.ts'
+
+describe('middleware: request-id', () => {
+  it('generates a UUID when no header is sent', async () => {
+    const app = createApp()
+    const res = await app.request('/healthz')
+    const id = res.headers.get('X-Request-Id')
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+  })
+
+  it('echoes a safe caller-provided id', async () => {
+    const app = createApp()
+    const res = await app.request('/healthz', {
+      headers: { 'X-Request-Id': 'abc-123' },
+    })
+    expect(res.headers.get('X-Request-Id')).toBe('abc-123')
+  })
+
+  it('regenerates when caller sends an unsafe id', async () => {
+    const app = createApp()
+    const res = await app.request('/healthz', {
+      headers: { 'X-Request-Id': 'has spaces and !?' },
+    })
+    const id = res.headers.get('X-Request-Id') ?? ''
+    expect(id).not.toBe('has spaces and !?')
+    expect(id.length).toBeGreaterThan(0)
+  })
+})

--- a/api/test/unit/middleware/timeout.test.ts
+++ b/api/test/unit/middleware/timeout.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { Hono } from 'hono'
+import type { AppEnv } from '../../../src/app-types.ts'
+import { timeout } from '../../../src/middleware/timeout.ts'
+import { registerErrorHandler } from '../../../src/middleware/error-handler.ts'
+
+function buildApp(budgetMs: number) {
+  const app = new Hono<AppEnv>()
+  app.use('*', timeout({ budgetMs }))
+  app.get('/fast', (c) => c.json({ ok: true }))
+  app.get('/slow/:delay', async (c) => {
+    const delay = Number(c.req.param('delay'))
+    await new Promise((r) => setTimeout(r, delay))
+    return c.json({ ok: true })
+  })
+  app.get('/abort-aware', async (c) => {
+    const signal = c.get('abortSignal')
+    await new Promise((resolve, reject) => {
+      const t = setTimeout(resolve, 500)
+      signal?.addEventListener('abort', () => {
+        clearTimeout(t)
+        reject(new Error('aborted-by-signal'))
+      })
+    })
+    return c.json({ ok: true })
+  })
+  registerErrorHandler(app)
+  return app
+}
+
+describe('middleware: timeout', () => {
+  it('passes through when handler completes inside budget', async () => {
+    const app = buildApp(200)
+    const res = await app.request('/fast')
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 504 envelope when handler overruns budget', async () => {
+    const app = buildApp(30)
+    const res = await app.request('/slow/150')
+    expect(res.status).toBe(504)
+    const json = (await res.json()) as { ok: false; errors: { code: string }[] }
+    expect(json.errors[0]?.code).toBe('timeout')
+  })
+
+  it('exposes the AbortSignal on c.var so cooperative handlers can bail early', async () => {
+    const app = buildApp(30)
+    const res = await app.request('/abort-aware')
+    // Either we get the typed 504 from timeout losing the race, or
+    // the handler's rejection bubbles as a 500. Both confirm the
+    // signal fired — we only assert it did not succeed.
+    expect([504, 500]).toContain(res.status)
+  })
+})

--- a/api/test/unit/r2-loader.test.ts
+++ b/api/test/unit/r2-loader.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { env } from 'cloudflare:test'
+import { parseVersion } from '../../cli/lib/version-parser.ts'
+import {
+  loadCategories,
+  loadDatachainType,
+  loadElement,
+  loadElements,
+  loadManifest,
+  loadSchemaJson,
+  loadSearchIndex,
+  loadSchemaIndex,
+  registerInlineBundle,
+  _resetInlineBundles,
+  type SchemaIndex,
+} from '../../src/store/index.ts'
+import {
+  categoriesKey,
+  datachainTypeKey,
+  elementKey,
+  elementsKey,
+  manifestKey,
+  schemaJsonKey,
+  searchIndexKey,
+  INDEX_KEY,
+} from '../../src/store/keys.ts'
+
+const STABLE_VERSION = parseVersion('ai@2026-04-16')
+const BETA_VERSION = parseVersion('ai@2026-04-16-beta')
+
+const sampleManifest = {
+  version: STABLE_VERSION.canonical,
+  status: 'stable',
+  created_at: '2026-04-16T00:00:00.000Z',
+  notes: '',
+  content_hash: `sha256-${'a'.repeat(64)}`,
+  locales: ['en'],
+}
+
+const betaManifest = { ...sampleManifest, version: BETA_VERSION.canonical, status: 'beta' }
+
+const sampleCategory = {
+  id: 'ai__decision',
+  name: [{ locale: 'en', value: 'Decision' }],
+  description: [{ locale: 'en', value: 'How decisions are made.' }],
+  prompt: [],
+  required: true,
+  order: 1,
+  datachain_type: 'ai',
+  element_variables: [],
+}
+
+const sampleElement = {
+  id: 'accept_deny',
+  category_ids: ['ai__decision'],
+  title: [{ locale: 'en', value: 'Accept / Deny' }],
+  description: [{ locale: 'en', value: 'Binary outcome.' }],
+  citation: [],
+  icon: { url: '/i/accept_deny.svg', format: 'svg', alt_text: [{ locale: 'en', value: 'icon' }] },
+  variables: [],
+}
+
+async function clearBucket(bucket: R2Bucket): Promise<void> {
+  // Delete in batches to keep one helper covering both per-test cleanup
+  // and the rare case where a bucket starts non-empty.
+  let cursor: string | undefined
+  do {
+    const list = await bucket.list({ cursor, limit: 1000 })
+    if (list.objects.length > 0) {
+      await bucket.delete(list.objects.map((o) => o.key))
+    }
+    cursor = list.truncated ? list.cursor : undefined
+  } while (cursor)
+}
+
+async function putJson(bucket: R2Bucket, key: string, value: unknown): Promise<void> {
+  await bucket.put(key, JSON.stringify(value))
+}
+
+beforeEach(async () => {
+  await clearBucket(env.CONTENT)
+  _resetInlineBundles()
+})
+
+afterEach(async () => {
+  _resetInlineBundles()
+})
+
+describe('r2-loader: loadManifest', () => {
+  it('returns null when manifest is absent', async () => {
+    const r = await loadManifest({ bucket: env.CONTENT }, STABLE_VERSION)
+    expect(r).toBeNull()
+  })
+
+  it('returns the parsed manifest when present', async () => {
+    await putJson(env.CONTENT, manifestKey(STABLE_VERSION), sampleManifest)
+    const r = await loadManifest({ bucket: env.CONTENT }, STABLE_VERSION)
+    expect(r).toEqual(sampleManifest)
+  })
+
+  it('cache hit on second call for stable versions (R2 reads exactly once)', async () => {
+    const key = manifestKey(STABLE_VERSION)
+    await putJson(env.CONTENT, key, sampleManifest)
+    await loadManifest({ bucket: env.CONTENT }, STABLE_VERSION)
+    // Mutate the underlying bytes; the cached call must still return the original.
+    await putJson(env.CONTENT, key, { ...sampleManifest, notes: 'mutated' })
+    const r2 = await loadManifest({ bucket: env.CONTENT }, STABLE_VERSION)
+    expect(r2).toEqual(sampleManifest)
+  })
+
+  it('beta versions are not cached so freshly-uploaded bytes are visible immediately', async () => {
+    const key = manifestKey(BETA_VERSION)
+    await putJson(env.CONTENT, key, betaManifest)
+    const a = await loadManifest({ bucket: env.CONTENT }, BETA_VERSION)
+    expect(a?.notes).toBe('')
+    await putJson(env.CONTENT, key, { ...betaManifest, notes: 'edit' })
+    const b = await loadManifest({ bucket: env.CONTENT }, BETA_VERSION)
+    expect(b?.notes).toBe('edit')
+  })
+})
+
+describe('r2-loader: per-entity loaders', () => {
+  it('loadCategories returns the array', async () => {
+    await putJson(env.CONTENT, categoriesKey(STABLE_VERSION), [sampleCategory])
+    const r = await loadCategories({ bucket: env.CONTENT }, STABLE_VERSION)
+    expect(r).toEqual([sampleCategory])
+  })
+
+  it('loadElements returns the array', async () => {
+    await putJson(env.CONTENT, elementsKey(STABLE_VERSION), [sampleElement])
+    const r = await loadElements({ bucket: env.CONTENT }, STABLE_VERSION)
+    expect(r).toEqual([sampleElement])
+  })
+
+  it('loadElement returns a single element by id', async () => {
+    await putJson(env.CONTENT, elementKey(STABLE_VERSION, 'accept_deny'), sampleElement)
+    const r = await loadElement({ bucket: env.CONTENT }, STABLE_VERSION, 'accept_deny')
+    expect(r?.id).toBe('accept_deny')
+  })
+
+  it('loadElement returns null for an unknown id', async () => {
+    const r = await loadElement({ bucket: env.CONTENT }, STABLE_VERSION, 'nope')
+    expect(r).toBeNull()
+  })
+
+  it('loadDatachainType, loadSchemaJson round-trip', async () => {
+    await putJson(env.CONTENT, datachainTypeKey(STABLE_VERSION), {
+      id: 'ai',
+      name: [{ locale: 'en', value: 'AI' }],
+      description: [{ locale: 'en', value: 'AI datachain' }],
+      categories: ['ai__decision'],
+      locales: ['en'],
+    })
+    await putJson(env.CONTENT, schemaJsonKey(STABLE_VERSION), { Element: { type: 'object' } })
+
+    const dct = await loadDatachainType({ bucket: env.CONTENT }, STABLE_VERSION)
+    expect(dct?.id).toBe('ai')
+    const sj = await loadSchemaJson({ bucket: env.CONTENT }, STABLE_VERSION)
+    expect(sj?.Element).toEqual({ type: 'object' })
+  })
+
+  it('loadSearchIndex returns the raw serialized index', async () => {
+    const serialized = '{"index":{"_documentCount":1}}'
+    await env.CONTENT.put(searchIndexKey(STABLE_VERSION, 'en'), serialized)
+    const r = await loadSearchIndex({ bucket: env.CONTENT }, STABLE_VERSION, 'en')
+    expect(r).toBe(serialized)
+  })
+})
+
+describe('r2-loader: loadSchemaIndex', () => {
+  it('returns empty versions when index is absent', async () => {
+    const r = await loadSchemaIndex({ bucket: env.CONTENT })
+    expect(r).toEqual({ versions: [] })
+  })
+
+  it('returns parsed index when present', async () => {
+    const index: SchemaIndex = {
+      versions: [
+        {
+          id: 'ai@2026-04-16',
+          status: 'stable',
+          created_at: '2026-04-16T00:00:00.000Z',
+          content_hash: `sha256-${'b'.repeat(64)}`,
+        },
+      ],
+    }
+    await putJson(env.CONTENT, INDEX_KEY, index)
+    const r = await loadSchemaIndex({ bucket: env.CONTENT })
+    expect(r).toEqual(index)
+  })
+})
+
+describe('inline-bundle fallback', () => {
+  it('short-circuits R2 reads when an inline bundle is registered for the version', async () => {
+    registerInlineBundle(STABLE_VERSION.canonical, {
+      manifest: sampleManifest as never,
+      datachainType: { id: 'ai' } as never,
+      categories: [sampleCategory] as never,
+      elements: [sampleElement] as never,
+      schemaJson: { Inline: true },
+      searchIndexesByLocale: { en: '{"inline":1}' },
+    })
+    // Note: bucket is empty. If routing is correct, every loader returns
+    // inline data without a single R2 call.
+    expect(await loadManifest({ bucket: env.CONTENT }, STABLE_VERSION)).toEqual(sampleManifest)
+    expect(await loadCategories({ bucket: env.CONTENT }, STABLE_VERSION)).toEqual([sampleCategory])
+    expect(await loadElements({ bucket: env.CONTENT }, STABLE_VERSION)).toEqual([sampleElement])
+    const el = await loadElement({ bucket: env.CONTENT }, STABLE_VERSION, 'accept_deny')
+    expect(el?.id).toBe('accept_deny')
+    const missing = await loadElement({ bucket: env.CONTENT }, STABLE_VERSION, 'nope')
+    expect(missing).toBeNull()
+    const search = await loadSearchIndex({ bucket: env.CONTENT }, STABLE_VERSION, 'en')
+    expect(search).toBe('{"inline":1}')
+  })
+})

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -23,6 +23,22 @@
       "bucket_name": "dtpr-api"
     }
   ],
+  "unsafe": {
+    "bindings": [
+      {
+        "name": "RL_READ",
+        "type": "ratelimit",
+        "namespace_id": "1001",
+        "simple": { "limit": 300, "period": 60 }
+      },
+      {
+        "name": "RL_VALIDATE",
+        "type": "ratelimit",
+        "namespace_id": "1002",
+        "simple": { "limit": 30, "period": 60 }
+      }
+    ]
+  },
   "env": {
     "preview": {
       "name": "dtpr-api-preview",
@@ -40,7 +56,23 @@
           "binding": "CONTENT",
           "bucket_name": "dtpr-api-preview"
         }
-      ]
+      ],
+      "unsafe": {
+        "bindings": [
+          {
+            "name": "RL_READ",
+            "type": "ratelimit",
+            "namespace_id": "2001",
+            "simple": { "limit": 300, "period": 60 }
+          },
+          {
+            "name": "RL_VALIDATE",
+            "type": "ratelimit",
+            "namespace_id": "2002",
+            "simple": { "limit": 30, "period": 60 }
+          }
+        ]
+      }
     }
   }
 }

--- a/docs/plans/2026-04-16-001-feat-dtpr-api-mcp-plan.md
+++ b/docs/plans/2026-04-16-001-feat-dtpr-api-mcp-plan.md
@@ -428,7 +428,7 @@ YAML source (api/schemas/ai/<version>/)
 
 _Last updated: 2026-04-17._
 
-**Complete:** Units 1–6 (all of Phase P1). Branch `feat/dtpr-schema-mcp`.
+**Complete:** Units 1–12 (Phase P1 + Phase P2). Branch `feat/dtpr-ai-docs`.
 
 | Unit | Status | Notes |
 |------|--------|-------|
@@ -438,8 +438,14 @@ _Last updated: 2026-04-17._
 | 4: `schema:build` + `schema:validate` CLI | ✅ Done | Pure-function libs (version parser, content hash, MiniSearch builder, JSON emitter) + fs wrapper (yaml-reader) + Node-bin entry. End-to-end tested against a committed 2-cat / 2-el fixture. |
 | 5: AI migration | ✅ Done | **11 categories + 75 elements × 6 locales** ported from `app/content/dtpr.v1/` to `api/schemas/ai/2026-04-16-beta/`. Validation clean (0 errors, 0 warnings). Idempotent. ~441 KB bundle (well under R10b's 512 KB inline threshold). `app/content/dtpr.v1/README.md` documents the freeze. |
 | 6: CI deploy workflow | ✅ Done | Workers `dtpr-api` (`api.dtpr.io`) + `dtpr-api-preview` (`api-preview.dtpr.io`) deployed manually on 2026-04-17 against R2 buckets `dtpr-api` / `dtpr-api-preview` (renamed from plan's `dtpr-content-{prod,preview}` to match user's existing bucket). `.github/workflows/api-{test,deploy}.yaml` + `api/scripts/r2-upload.ts` + `api/docs/deploy-tokens.md` landed. CI itself runs once GitHub Actions secrets are populated (see deploy-tokens.md). Account upgraded to Workers Paid 2026-04-17; `limits.cpu_ms: 500` re-enabled in `wrangler.jsonc` (next deploy after CF plan-flag propagation will accept it). |
+| 7: R2 loader + Cache API wrapper | ✅ Done | `api/src/store/{r2-loader,cache-wrapper,index-loader,inline-bundles,keys,index}.ts`. Stable versions cached for 24h; beta is no-store. Null results never cached. Inline-bundle hook wired for R10b (empty registry at P1). 20 new tests against Miniflare R2 + Cache API. |
+| 8: Hono middleware stack | ✅ Done | CORS (allow-list + preview-subdomain regex), request-id (wraps `hono/request-id`), logging (one JSON line per req), payload-limits (64 KB), timeout (AbortController, signal exposed on `c.var`), typed error envelope with R2LoadError → 502 mapping. 23 tests. |
+| 9: REST v2 endpoints | ✅ Done | `api/src/rest/{routes,responses,pagination,search,version-resolver}.ts`. Full route set under `/api/v2`; version @/%40 normalization; locale filter; projection (default vs `all`); opaque cursor pagination; BM25 search via MiniSearch; content-hash header; cache-control by stability. 36 tests. |
+| 10: MCP server + 7 tools | ✅ Done | **Plan fallback path taken**: hand-rolled JSON-RPC dispatcher in `api/src/mcp/server.ts` (replaces `@hono/mcp` + `@modelcontextprotocol/sdk`, which pull CJS-only Ajv that workerd's vitest-pool-workers loader can't handle). See `api/docs/mcp-fallback.md`. Seven tools registered through `buildToolRegistry(ctx)`; inputSchema emitted via `z.toJSONSchema` (draft-2020-12, io:'input'). `validate_datachain` and per-id `get_elements` misses return `ok:false, isError:false` (soft failure). 22 tests. |
+| 11: Rate limiting + DTPR-Client header | ✅ Done | `RL_READ` (300/min) + `RL_VALIDATE` (30/min) bindings in `wrangler.jsonc`; middleware keys on `(cf-connecting-ip, DTPR-Client)` tuple, no-ops when binding is absent (dev/test/preview). `api/docs/waf-rules.md` documents the tier-1 WAF rules for manual provisioning. 8 tests. |
+| 12: E2E test suite + harness parity | ✅ Done | `api/test/api/{schemas,helpers,seed,mcp-client,harness-parity,rate-limit,locale-filtering,rest,mcp}.ts`. Fingerprint snapshots (ported from `app/test/api/helpers.ts`); response-shape Zod conformance; full MCP flow integration test (initialize → tools/list → versions → schema → search → bulk → validate); session timing canary (log-only). |
 
-**Test totals:** 94 passing (79 workers-pool + 15 Node-pool for fs-touching CLI / migration tests). Typecheck clean.
+**Test totals:** 208 passing (193 workers-pool + 15 Node-pool for fs-touching CLI / migration tests). Typecheck clean.
 
 **Commits on branch (main → HEAD):** see `git log main..HEAD`. Unit 6 lands as a single commit.
 
@@ -449,14 +455,15 @@ _Last updated: 2026-04-17._
 - **Installed workerd lags the targeted compat date.** `wrangler.jsonc` pins `compatibility_date: "2026-04-16"`; the vitest-pool-workers shim installed here maxes out at `2025-09-06` and falls back with a warning (not an error). Will clear when `@cloudflare/vitest-pool-workers` ships a newer workerd.
 - **`list_elements` fixture-expectation adjustment.** Plan said the first port would contain an empty `tech__facial_recognition.md`; the actual source has **no such file** (closest name is `tech__facial_characterization.md`, which ports cleanly). No warnings were emitted by the migration. If the plan's author wants the missing tile re-added, that's a separate authoring task.
 
-**Next up — Phase P2 (REST + MCP read path):**
-
-- **Unit 7: R2 loader + Cache API wrapper** — gated on the Cloudflare infrastructure spike from Unit 1. Once verified, implements `src/store/*` with R2 binding + `caches.default` per-version cache.
-- **Units 8–12:** Hono middleware stack, REST `/api/v2/*`, MCP server + 7 tools, two-tier rate limiting, E2E test harness.
-
 **Next up — Phase P3 (Drafting + demo):**
 
 - **Units 13–15:** `schema:new` / `schema:promote` CLI, preview deployments, wow-factor agent demo.
+
+**Phase P2 deviations from plan worth knowing:**
+
+- **MCP transport: hand-rolled JSON-RPC instead of `@hono/mcp` + `@modelcontextprotocol/sdk`.** The SDK pulls Ajv 8 (CJS-only) which workerd's vitest-pool-workers loader rejects (`?mf_vitest_no_cjs_esm_shim` skips the CJS shim and Ajv's `require('./refs/data.json')` fails). The plan anticipated this fallback; documented in `api/docs/mcp-fallback.md`. The wire format is identical (JSON-RPC 2.0, methods: initialize / tools/list / tools/call / ping), so MCP clients see no difference. Removed `@hono/mcp` and `@modelcontextprotocol/sdk` from the worker bundle.
+- **Rate-limit middleware tolerates absent bindings.** In dev/test/preview the `RL_READ` / `RL_VALIDATE` bindings may not be provisioned; the middleware no-ops in that case so non-prod environments don't 500. Production still enforces.
+- **`LoadContext.ctx` is structurally typed** (just `{ waitUntil }`) rather than the full `ExecutionContext` so Hono's slightly different `ExecutionContext` type doesn't require a cast at every call site.
 
 ### Phase P1 — Foundation
 
@@ -787,7 +794,7 @@ _Last updated: 2026-04-17._
 
 ### Phase P2 — REST v2 + MCP read
 
-- [ ] **Unit 7: R2 loader + Cache API wrapper**
+- [x] **Unit 7: R2 loader + Cache API wrapper**
 
 **Goal:** A typed loader that reads schema version bundles from R2 with Cloudflare Cache API in front for hot reads. Transparent to callers; returns decoded objects.
 
@@ -836,7 +843,7 @@ _Last updated: 2026-04-17._
 
 ---
 
-- [ ] **Unit 8: Hono app skeleton (middleware stack)**
+- [x] **Unit 8: Hono app skeleton (middleware stack)**
 
 **Goal:** Mount the Hono app with cross-cutting middleware: CORS, request-id, error envelope, payload caps, wall-clock timeout (AbortController), and structured logging.
 
@@ -881,7 +888,7 @@ _Last updated: 2026-04-17._
 
 ---
 
-- [ ] **Unit 9: REST v2 endpoints**
+- [x] **Unit 9: REST v2 endpoints**
 
 **Goal:** REST routes at `/api/v2/...` serving schema version list, manifest, categories, elements, single element, validate. Version-pinned paths; `@` / `%40` normalization; locale filtering; content hash headers.
 
@@ -937,7 +944,7 @@ _Last updated: 2026-04-17._
 
 ---
 
-- [ ] **Unit 10: MCP server + 7 tools**
+- [x] **Unit 10: MCP server + 7 tools**
 
 **Goal:** MCP server mounted at `/mcp` via `@hono/mcp`. Seven tools: `list_schema_versions`, `get_schema`, `list_categories`, `list_elements`, `get_element`, **`get_elements` (bulk)**, `validate_datachain`. Structured content + text fallback, opaque cursor pagination, fix_hint error envelopes, provenance-tagged element content.
 
@@ -1012,7 +1019,7 @@ _Last updated: 2026-04-17._
 
 ---
 
-- [ ] **Unit 11: Rate limiting + client-identification header**
+- [x] **Unit 11: Rate limiting + client-identification header**
 
 **Goal:** Two-tier rate limiting — WAF rules (absolute, per-IP) + Workers Rate Limit API binding (per-endpoint quotas, keyed on `(IP, DTPR-Client)` tuple). Document `DTPR-Client` header convention.
 
@@ -1061,7 +1068,7 @@ _Last updated: 2026-04-17._
 
 ---
 
-- [ ] **Unit 12: E2E test suite + API harness parity**
+- [x] **Unit 12: E2E test suite + API harness parity**
 
 **Goal:** Vitest-pool-workers-based test suite mirroring the existing `app/test/api/` patterns — schema conformance, structural fingerprint snapshots, locale filtering, rate-limit, error envelopes. Binds a Miniflare R2 with seeded bundles.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,15 +10,9 @@ importers:
 
   api:
     dependencies:
-      '@hono/mcp':
-        specifier: ^0.2.5
-        version: 0.2.5(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(hono-rate-limiter@0.4.2(hono@4.12.14))(hono@4.12.14)(zod@4.3.6)
       '@hono/zod-validator':
         specifier: ^0.7.6
         version: 0.7.6(hono@4.12.14)(zod@4.3.6)
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.3.6)
       hono:
         specifier: ^4.12.14
         version: 4.12.14
@@ -1215,14 +1209,6 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       vue: ^3.2.0
-
-  '@hono/mcp@0.2.5':
-    resolution: {integrity: sha512-JsaJes7VlNvUrUQ9j2b9C13xjFLvyKQY515aWtsdJ9cwhBmWz5od2yUCbDu7cX38GeADmlLmpu4BKNNAV6G27w==}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.1
-      hono: '*'
-      hono-rate-limiter: ^0.4.2
-      zod: ^3.25.0 || ^4.0.0
 
   '@hono/node-server@1.19.9':
     resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
@@ -9924,14 +9910,6 @@ snapshots:
     dependencies:
       '@tanstack/vue-virtual': 3.13.19(vue@3.5.29(typescript@5.9.3))
       vue: 3.5.29(typescript@5.9.3)
-
-  '@hono/mcp@0.2.5(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(hono-rate-limiter@0.4.2(hono@4.12.14))(hono@4.12.14)(zod@4.3.6)':
-    dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
-      hono: 4.12.14
-      hono-rate-limiter: 0.4.2(hono@4.12.14)
-      pkce-challenge: 5.0.1
-      zod: 4.3.6
 
   '@hono/node-server@1.19.9(hono@4.12.14)':
     dependencies:


### PR DESCRIPTION
## Summary

Phase P2 of the [DTPR API plan](docs/plans/2026-04-16-001-feat-dtpr-api-mcp-plan.md) — the worker now serves the AI datachain over REST at `/api/v2/*` and over MCP at `/mcp`, both reading from R2 with `caches.default` in front, both protected by the typed error envelope and a two-tier rate-limit story. Six commits, one per implementation unit (7 through 12), 208 tests passing (193 worker-pool, 15 CLI), typecheck clean.

## What's new

### REST `/api/v2`

- `GET /schemas` (version index), `GET /schemas/:version/{manifest,categories,elements,elements/:id}`, `POST /schemas/:version/validate`.
- `@` and `%40` versions normalize identically; malformed → 400, unknown → 404 with a `fix_hint` pointing at `GET /schemas`.
- `?locales=en,fr` filters every `LocaleValue[]` recursively. `?fields=id,title` projects rows; `?fields=all` returns the whole element. Opaque base64 cursor pagination (default limit 50, max 200).
- BM25 search via MiniSearch rehydrated per-locale from R2; `?query=video` ranks `identifiable_video` first.
- Stable versions get `Cache-Control: public, max-age=86400, immutable` + `DTPR-Content-Hash`; beta gets `no-store`.

### MCP `/mcp` — 7 read-side tools

`list_schema_versions`, `get_schema`, `list_categories`, `list_elements`, `get_element`, `get_elements` (bulk, max 100, server-side dedup), `validate_datachain`. Each tool returns both `structuredContent` and a JSON `text` block (back-compat with older clients), with `content_hash` in `meta` for pinning. `validate_datachain` and per-id `get_elements` misses use `isError: false` (soft failure: the call succeeded; the *result* is "invalid").

**Plan fallback path taken.** The MCP SDK + `@hono/mcp` pull CJS-only Ajv 8, which workerd's vitest-pool-workers loader rejects (`?mf_vitest_no_cjs_esm_shim` skips the CJS shim and Ajv's `require('./refs/data.json')` fails). Replaced with a hand-rolled JSON-RPC dispatcher implementing `initialize`, `tools/list`, `tools/call`, `ping`, plus the `notifications/initialized` ack — the entire stateless read surface DTPR needs. Wire format is unchanged. See `api/docs/mcp-fallback.md` for the full rationale and the path to revert if/when workerd fixes the loader.

### Middleware + storage

- CORS allow-list with preview-subdomain regex; `request-id` (wraps `hono/request-id`); JSON log line per request; 64 KB payload cap; AbortController wall-clock timeout (signal exposed on `c.var`); typed error envelope `{ok, errors:[{code,message,path?,fix_hint?}]}` with `R2LoadError → 502` mapping and unexpected errors redacted to a generic 500.
- `api/src/store/*` wraps every R2 read in `caches.default` keyed on the version directory. Stable versions cache 24 h; beta is `no-store`. Null results never cached, so a freshly uploaded version is visible immediately. Inline-bundle hook wired for R10b (registry empty at P1).
- Two-tier rate limiting: `RL_READ` (300/min) + `RL_VALIDATE` (30/min) Worker bindings keyed on `(cf-connecting-ip, DTPR-Client)` — middleware no-ops when the binding is absent so dev/test/preview don't 500. Tier-1 WAF rules documented in `api/docs/waf-rules.md` for manual provisioning.

## Test plan

`pnpm --filter ./api test` is the one-liner — runs the worker-pool suite (vitest-pool-workers against Miniflare R2 + Cache API + the rate-limit binding) and the Node-pool CLI suite. The interesting harnesses are `api/test/api/harness-parity.test.ts` (full agent-style MCP flow: initialize → tools/list → versions → schema → search → bulk → validate, with response-shape Zod conformance and content-agnostic fingerprint snapshots ported from `app/test/api/helpers.ts`) and `api/test/api/rate-limit.test.ts` (proves bucket isolation by `(IP, DTPR-Client)` tuple plus the no-binding fallback).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)