### PR TITLE
ci: build @dtpr/ui + api/schema before typecheck in deploy workflows

### DIFF
--- a/.github/workflows/api-deploy.yaml
+++ b/.github/workflows/api-deploy.yaml
@@ -32,6 +32,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # @dtpr/api/schema + @dtpr/api/validator ship via tsup-compiled dist/;
+      # @dtpr/ui's three subpaths ship via Vite library mode. Both must be
+      # built before `tsc --noEmit` can resolve the subpath imports.
+      - run: pnpm --filter ./api build:schema
+      - run: pnpm --filter @dtpr/ui build
+
       # Re-run the test suite on the exact deploy artifact to catch any
       # path-filter slippage (e.g. a non-api/ change that affects api/).
       - run: pnpm --filter ./api typecheck

--- a/.github/workflows/api-preview-deploy.yaml
+++ b/.github/workflows/api-preview-deploy.yaml
@@ -25,6 +25,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # @dtpr/api/schema + @dtpr/api/validator ship via tsup-compiled dist/;
+      # @dtpr/ui's three subpaths ship via Vite library mode. Both must be
+      # built before `tsc --noEmit` can resolve the subpath imports.
+      - run: pnpm --filter ./api build:schema
+      - run: pnpm --filter @dtpr/ui build
+
       # Resolve the newest beta version in the repo. Preview deploys
       # always target the in-flight draft, so hardcoding a version
       # would go stale the first time the current beta is promoted.


### PR DESCRIPTION
## Summary
- `API deploy` failed on the PR #267 merge commit with `TS2307` errors: `@dtpr/ui/html`, `@dtpr/ui/core`, `@dtpr/api/schema`, and `@dtpr/api/validator` were unresolvable.
- Those subpaths resolve through each package's `exports` map to `dist/` files (Vite library mode for `@dtpr/ui`, tsup for `@dtpr/api`'s schema/validator). When the deploy workflow runs `tsc --noEmit` straight after install, no `dist/` exists yet, so every subpath import blows up.
- `api-test.yaml` already runs `build:schema` and `@dtpr/ui build` before typecheck ([api-test.yaml:31-34](.github/workflows/api-test.yaml#L31-L34)). The two deploy workflows just need the same prebuild steps.

## Changes
- `.github/workflows/api-deploy.yaml`: run `pnpm --filter ./api build:schema` and `pnpm --filter @dtpr/ui build` before `typecheck`.
- `.github/workflows/api-preview-deploy.yaml`: same prebuild, so label-gated preview deploys can't regress the same way.

## Test plan
- [x] Reproduced `TS2307` locally by running `pnpm --filter ./api typecheck` against a clean install.
- [x] Verified `pnpm --filter ./api build:schema && pnpm --filter @dtpr/ui build && pnpm --filter ./api typecheck` passes.
- [x] `pnpm --filter ./api test` passes after the prebuild.
- [ ] CI: `API deploy` must go green on merge (the actual prod deploy will then run, which also needs the secrets to be intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)