### PR TITLE
feat(docs-site): add Nuxt Studio with Google + GitHub OAuth

### DIFF
--- a/docs-site/.env.example
+++ b/docs-site/.env.example
@@ -1,0 +1,24 @@
+# Local development secrets for Nuxt Studio.
+# Copy to `.env` and fill in real values. `.env` is gitignored.
+# `nuxt dev` (via `pnpm -F dtpr-docs dev`) loads this file automatically.
+# For production, each of these is set via `npx wrangler secret put <NAME>` — see docs-site/docs/studio-setup.md.
+#
+# Note: if you run the production build locally via `npx wrangler dev`, copy this to `.dev.vars` instead
+# (also gitignored). That path is rarely needed — prefer `nuxt dev`.
+
+# --- Google OAuth (non-technical editors) ---
+STUDIO_GOOGLE_CLIENT_ID=
+STUDIO_GOOGLE_CLIENT_SECRET=
+# Comma-separated list of Google email addresses allowed into the editor UI.
+STUDIO_GOOGLE_MODERATORS=
+
+# --- GitHub OAuth (developer editors; commits authored under signed-in user) ---
+STUDIO_GITHUB_CLIENT_ID=
+STUDIO_GITHUB_CLIENT_SECRET=
+# Comma-separated list of GitHub emails allowed into the editor UI.
+# MUST be kept in sync with STUDIO_GOOGLE_MODERATORS.
+STUDIO_GITHUB_MODERATORS=
+
+# --- Bot PAT (used only for Google-OAuth-path commits) ---
+# Fine-grained PAT scoped to helpful-places/dtpr with Contents: Read and write.
+STUDIO_GITHUB_TOKEN=

--- a/docs-site/.gitignore
+++ b/docs-site/.gitignore
@@ -5,6 +5,7 @@ node_modules
 .cache
 .output
 .env
+.dev.vars
 dist
 .data
 .DS_Store

--- a/docs-site/docs/studio-setup.md
+++ b/docs-site/docs/studio-setup.md
@@ -1,0 +1,132 @@
+# Nuxt Studio Setup Runbook (docs.dtpr.io)
+
+Operational runbook for the Nuxt Studio editor at `https://docs.dtpr.io/_studio`. Maintainers use this to add/remove moderators, rotate credentials, and debug auth failures.
+
+**Never commit real credentials, client IDs, account names, or email addresses to this file.** This repository is public — anything committed here is crawlable and cached forever. All sensitive and semi-sensitive values (OAuth client IDs, PAT owners, moderator lists, bot account names) live in the team password manager and in Cloudflare Workers secrets. Refer to the password-manager entry **"DTPR Nuxt Studio"** for the canonical values.
+
+## How it fits together
+
+Nuxt Studio runs on the `docs-site/` Nuxt app and writes edits directly back to this repo on branch `main`, rooted at `docs-site/`. Editors authenticate via one of two providers:
+
+| Sign-in path | Moderator check | Commit authorship |
+|---|---|---|
+| **Google OAuth** | `STUDIO_GOOGLE_MODERATORS` | Shared bot PAT (`STUDIO_GITHUB_TOKEN`) |
+| **GitHub OAuth** | `STUDIO_GITHUB_MODERATORS` | The signed-in user's own GitHub identity (OAuth token) |
+
+Audit-trail implication: commits from Google-path editors are all attributed to the bot identity; commits from GitHub-path editors are attributed to the individual user. If you need per-editor attribution, require the GitHub path.
+
+Studio commits land on `main` and trigger the existing Cloudflare Workers deploy. There is no staging branch.
+
+## Google OAuth client
+
+- **GCP project, client ID, client secret, project owner:** password manager ("DTPR Nuxt Studio" → Google OAuth section).
+- **Redirect URIs registered:**
+  - `http://localhost:3000/__nuxt_studio/auth/google` (dev)
+  - `https://docs.dtpr.io/__nuxt_studio/auth/google` (prod)
+
+## GitHub OAuth App
+
+Two OAuth Apps owned by the `helpful-places` org — one for prod, one for dev. App names, client IDs, and client secrets live in the password manager ("DTPR Nuxt Studio" → GitHub OAuth section).
+
+- **Prod callback URL:** `https://docs.dtpr.io/__nuxt_studio/auth/github`
+- **Dev callback URL:** `http://localhost:3000/__nuxt_studio/auth/github`
+- **Homepage URLs:** `https://docs.dtpr.io` (prod) / `http://localhost:3000` (dev)
+
+GitHub OAuth Apps allow only one callback URL each, which is why we run two apps.
+
+## GitHub bot PAT (Google-path commits only)
+
+- **Bot account, token value, PAT owner:** password manager.
+- **Token type:** fine-grained (not classic).
+- **Repository scope:** `helpful-places/dtpr` only.
+- **Permissions:** `Contents: Read and write` only — nothing else.
+- **Expiration:** GitHub fine-grained PATs require an expiration (max 1 year). Set **90 days** at issuance and record the renewal date in the password-manager entry. A calendar reminder on that date is required — there is no automatic rotation.
+- **Rotation cadence:** every 90 days; absolute maximum 1 year from issuance.
+
+GitHub-OAuth-path commits do **not** use this PAT — they use the user's OAuth token. If this PAT expires, Google-path saves fail; GitHub-path saves keep working.
+
+## Moderator list
+
+One canonical comma-separated email list, stored in **two** Cloudflare secrets (Google + GitHub). **Both must stay in sync** — updating one without the other means a moderator can sign in via one provider but not the other.
+
+The list itself is stored in the password manager entry. The current member count (as of the most recent rotation) is recorded there. **Do not commit email addresses to this repo.**
+
+`STUDIO_GITHUB_MODERATORS` is technically optional for the module, but leaving it unset lets any GitHub user on the internet reach the editor UI. **We always set it.**
+
+### Updating moderators (safe pattern)
+
+Always set both secrets in the same shell session so they can't drift apart:
+
+```sh
+# Paste the full, updated comma-separated list here. No spaces.
+MODS="alice@example.com,bob@example.com"
+echo -n "$MODS" | pnpm -F dtpr-docs exec wrangler secret put STUDIO_GOOGLE_MODERATORS
+echo -n "$MODS" | pnpm -F dtpr-docs exec wrangler secret put STUDIO_GITHUB_MODERATORS
+# Then redeploy so the Worker picks up the new secrets.
+```
+
+For GitHub OAuth: list the primary email on each moderator's GitHub account. A user's `@users.noreply.github.com` address won't match a real address.
+
+## Cloudflare Workers secrets (production)
+
+All seven secrets are set on the `dtpr-docs` Worker. A redeploy is required after any secret change before it takes effect.
+
+```sh
+cd docs-site
+pnpm exec wrangler secret put STUDIO_GOOGLE_CLIENT_ID
+pnpm exec wrangler secret put STUDIO_GOOGLE_CLIENT_SECRET
+pnpm exec wrangler secret put STUDIO_GOOGLE_MODERATORS
+pnpm exec wrangler secret put STUDIO_GITHUB_CLIENT_ID
+pnpm exec wrangler secret put STUDIO_GITHUB_CLIENT_SECRET
+pnpm exec wrangler secret put STUDIO_GITHUB_MODERATORS
+pnpm exec wrangler secret put STUDIO_GITHUB_TOKEN
+```
+
+Verify what's configured (values are not shown):
+
+```sh
+pnpm exec wrangler secret list
+```
+
+Use the **prod** GitHub OAuth App credentials for `STUDIO_GITHUB_CLIENT_ID`/`_SECRET` (not the dev app's).
+
+## Local dev setup
+
+1. Copy `docs-site/.env.example` to `docs-site/.env`.
+2. Fill in real values from the password manager. `.env` is gitignored.
+3. Start the dev server: `pnpm -F dtpr-docs dev`.
+4. Open `http://localhost:3000/_studio`. Both "Sign in with Google" and "Sign in with GitHub" buttons should appear.
+
+`nuxt dev` reads `.env` automatically. Nuxt does **not** read `.dev.vars` — that file is a `wrangler dev` convention for locally running the production Workers build, which we rarely need. If you do need `wrangler dev` (e.g., to test Workers-specific behavior), copy the same values to `docs-site/.dev.vars` (also gitignored).
+
+Any test commits made from local dev land on `main` the same way production commits do. Prefer using a sandbox file (or immediately reverting) when testing.
+
+## Troubleshooting
+
+**Editor won't load / blank page at `/_studio`**
+- Check browser devtools network tab for `/__nuxt_studio/*` requests.
+- 500s on `/__nuxt_studio/*` usually mean a missing env var. In dev, check `.env`; in prod, `pnpm exec wrangler secret list`.
+- Check the Cloudflare Workers deploy logs for module init errors.
+
+**One provider works but the other doesn't**
+- Most common: that provider's `CLIENT_ID`/`CLIENT_SECRET`/redirect URI is misconfigured.
+- Compare the redirect URI in the OAuth app exactly against `http(s)://<host>/__nuxt_studio/auth/<provider>`.
+- Verify the other provider's three secrets are set (`wrangler secret list`).
+
+**"You are not a moderator" despite being on the list**
+- Check for typos in the moderator list (extra spaces, wrong domain).
+- For GitHub OAuth: confirm the user's primary email on GitHub matches the list. A `@users.noreply.github.com` email won't match if we listed their real email.
+- Confirm both `STUDIO_GOOGLE_MODERATORS` and `STUDIO_GITHUB_MODERATORS` were updated on the last moderator change.
+
+**Commits not appearing after save**
+- If Google-path: likely PAT expired or scope is wrong. Check PAT expiration in the password manager; re-verify `Contents: Read and write` on `helpful-places/dtpr`.
+- If GitHub-path: the user's OAuth token may be missing repo scope. They can re-sign-in to refresh consent.
+- Check the GitHub repo's audit log for blocked push events (branch protection, required reviews).
+
+**Commit authored by the wrong identity**
+- This is expected, not a bug: Google-path commits are authored by the bot PAT identity; GitHub-path commits by the signed-in user. If you want user attribution, sign in with GitHub instead of Google.
+
+**Production deploy fails after adding Studio**
+- See earlier commit `d7e619a Fix docs-site Cloudflare Workers deploy failure` for context on Workers fragility.
+- Confirm `nuxt-studio` is at `>=1.6.0` (earlier versions break on Workers due to `ipx`/`sharp-wasm32`).
+- Roll back by reverting the most recent merge to `main` and redeploying.

--- a/docs-site/nuxt.config.ts
+++ b/docs-site/nuxt.config.ts
@@ -1,8 +1,20 @@
 export default defineNuxtConfig({
   extends: ['docus'],
 
+  modules: ['nuxt-studio'],
+
   site: {
     name: 'Digital Trust for Places & Routines',
+  },
+
+  studio: {
+    repository: {
+      provider: 'github',
+      owner: 'helpful-places',
+      repo: 'dtpr',
+      branch: 'main',
+      rootDir: 'docs-site'
+    }
   },
 
   $production: {

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -10,7 +10,8 @@
     "@nuxt/ui": "^4.5.1",
     "better-sqlite3": "^12.2.0",
     "docus": "latest",
-    "nuxt": "^4.0.0"
+    "nuxt": "^4.0.0",
+    "nuxt-studio": "^1.6.0"
   },
   "devDependencies": {
     "wrangler": "^4.83.0"

--- a/docs/plans/2026-04-17-001-feat-nuxt-studio-docs-site-plan.md
+++ b/docs/plans/2026-04-17-001-feat-nuxt-studio-docs-site-plan.md
@@ -1,0 +1,349 @@
+---
+title: Add Nuxt Studio to docs-site with Google + GitHub OAuth
+type: feat
+status: active
+date: 2026-04-17
+---
+
+# Add Nuxt Studio to docs-site with Google + GitHub OAuth
+
+## Overview
+
+Install the self-hosted `nuxt-studio` module on `docs-site/` so a small internal team can edit content at `docs.dtpr.io` through a visual editor. Enable **both Google OAuth and GitHub OAuth** as editor login options — developers who already have GitHub accounts use GitHub (commits authored by them), while non-technical editors use Google (commits authored by a shared bot PAT). Both providers gate UI access with an explicit moderator email whitelist.
+
+## Problem Frame
+
+Nuxt Studio is **not currently set up** on `docs-site/` — verified by inspecting `docs-site/package.json`, `docs-site/nuxt.config.ts`, `docs-site/app.config.ts`, and searching for any `@nuxthq/studio`/`nuxt-studio`/`studio` references in `docs-site/`. (The `studio/` directory at the repo root is a separate symbol-generation app, unrelated to Nuxt Studio.)
+
+Content lives in `docs-site/content/` as markdown. Today the only way to edit pages is to open a PR against `helpful-places/dtpr` on GitHub. The DTPR team wants a web-based editor that doesn't require editors to create GitHub accounts. A small internal team (<10 known emails) needs access.
+
+## Requirements Trace
+
+- R1. Install and configure `nuxt-studio` in `docs-site/` so the editor loads at `/_studio` in dev and production.
+- R2. Offer **two** editor login options — **Google OAuth** (for non-technical editors; no GitHub account required) and **GitHub OAuth** (for developer editors; commits authored by them). Both providers must be gated by a moderator email whitelist so the UI is not open to the public.
+- R3. Studio must commit edits back to the `helpful-places/dtpr` repo on branch `main`, rooted at `docs-site/`. Google-path commits go through a single bot GitHub PAT; GitHub-OAuth-path commits go through the signed-in user's own OAuth token.
+- R4. Deploy must continue to succeed on Cloudflare Workers (current preset, current custom domain, current D1 binding).
+- R5. Document the operational setup (Google Cloud OAuth client, GitHub OAuth App, GitHub bot PAT, Cloudflare Workers secrets) so the team can rotate credentials and add moderators later.
+
+## Scope Boundaries
+
+- Editor UX customization (custom field editors, validation rules) — out of scope; use Studio defaults.
+- Internationalization / per-locale content collections — out of scope; the old `docs/plans/2026-02-06-feat-cms-editable-markdown-pages-plan.md` covered that for a different app directory and is orthogonal to this work.
+- Migrating existing content structure — out of scope. Content already lives in `docs-site/content/` in the shape Studio expects.
+- Adding additional auth providers (GitLab, Nuxt Studio SSO) — out of scope. Google OAuth is the chosen provider.
+- Per-editor audit logs / role-based permissions — Studio treats every moderator equally; if richer RBAC is needed, handle in a follow-up.
+- Changes to the separate `studio/` symbol-generation app — unrelated to this plan.
+
+### Deferred to Separate Tasks
+
+- Expanding moderator list for community contributors — this plan scopes to the internal team only.
+- Switching to custom auth (email/password, Clerk, etc.) — keep Google OAuth as the starting point; revisit only if it proves insufficient.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `docs-site/nuxt.config.ts` — currently `extends: ['docus']` with a Cloudflare-specific rollup stub for `agents/mcp` under `$production`. The `studio` config block will live here.
+- `docs-site/wrangler.toml` — Cloudflare Workers config with custom domain `docs.dtpr.io` and D1 binding. No env vars set today; secrets will be added via `wrangler secret put`.
+- `docs-site/package.json` — Nuxt 4 + `docus@latest` + `@nuxt/ui@^4.5.1`. Studio is additive here.
+- `docs-site/app.config.ts` — already declares `github.url`, `github.branch`, `github.rootDir` for docs — useful reference for the Studio `repository` fields but they are distinct config and don't carry over automatically.
+- `docs-site/content/` — flat-ish folder tree (e.g. `1.getting-started/1.introduction.md`) using standard Nuxt Content frontmatter + markdown, which Studio's MDC editor handles natively.
+- `.github/workflows/` and `docs-site` CI — previous commits (`d7e619a`, `ca22ebd`) show recent Cloudflare Workers build fixes; Studio's Cloudflare compatibility is handled at the module version level (see Key Decisions).
+
+### Institutional Learnings
+
+- Previous plan `docs/plans/2026-02-06-feat-cms-editable-markdown-pages-plan.md` assumed Nuxt Studio would be set up later and called it out as "Future work: Studio production config". This plan delivers that for the new `docs-site/` app.
+- Recent commits show active Cloudflare Workers deploy fragility (`d7e619a Fix docs-site Cloudflare Workers deploy failure`) — treat deploy verification as a first-class acceptance gate, not an afterthought.
+
+### External References
+
+- [Nuxt Studio setup](https://nuxt.studio/setup) — current install command is `npx nuxt module add nuxt-studio`; legacy `@nuxthq/studio` is deprecated.
+- [Nuxt Studio auth providers](https://nuxt.studio/auth-providers) — Google OAuth env vars and moderator whitelist mechanics.
+- [Nuxt Studio git providers](https://nuxt.studio/git-providers) — bot PAT requirements and `studio.repository` schema.
+- [nuxt-content/nuxt-studio PR #404](https://github.com/nuxt-content/nuxt-studio/pull/404) — `ipx` moved to `optionalDependencies` in v1.6.0 (2026-04-09), fixing Cloudflare Workers `@img/sharp-wasm32/versions` build failure. Media thumbnails fall back to full-size originals on Workers — acceptable for a docs site.
+- [Docus v5 + Studio](https://docus.dev/en/getting-started/studio) — Docus does **not** auto-enable Studio; it must be added explicitly. Docus' MDC components render in the Studio editor.
+- [Nuxt Content v3 on Cloudflare Workers](https://content.nuxt.com/docs/deploy/cloudflare-workers) — confirms the current deploy preset is the right one.
+
+## Key Technical Decisions
+
+- **Module: `nuxt-studio` pinned `>=1.6.0`** — v1.6.0 is the first release that builds on Cloudflare Workers (ipx is optional). Pin with `^1.6.0` to allow non-breaking upgrades.
+- **Auth: enable both Google OAuth and GitHub OAuth simultaneously** — Studio fully supports multi-provider setups, each with its own callback path (`/__nuxt_studio/auth/google` and `/__nuxt_studio/auth/github`). The docs explicitly endorse this pattern: *"use GitHub OAuth for developers and Google OAuth for non-technical content editors."*
+- **Moderator whitelist on BOTH providers** — `STUDIO_GOOGLE_MODERATORS` is **required** by Studio ("Without moderators, no one can access Studio"). `STUDIO_GITHUB_MODERATORS` is technically optional, **but we set it anyway** — without it, any GitHub user on the internet who completes OAuth can reach the Studio UI. The same comma-separated email list is used for both env vars.
+- **Commit authorship differs by login path:**
+  - *Google OAuth login* → commits authored by the shared bot PAT (`STUDIO_GITHUB_TOKEN`).
+  - *GitHub OAuth login* → commits authored by the signed-in user's own GitHub identity via their OAuth token; the bot PAT is not used.
+  - This is fine for an internal team, but note the audit-trail split in the runbook.
+- **Bot PAT: one GitHub fine-grained PAT** scoped to `helpful-places/dtpr` with `Contents: Read and write`. Stored as `STUDIO_GITHUB_TOKEN`. Used only for Google-path commits.
+- **Repository config in `nuxt.config.ts`** — set `studio.repository` explicitly (provider, owner, repo, branch, rootDir). Auto-detection exists but is brittle on Cloudflare Workers; explicit config is more durable.
+  - `rootDir: 'docs-site'` — Studio only writes inside this subtree, matching the existing repo layout.
+  - `branch: 'main'` — matches the live deploy branch.
+- **Editor route: default `/_studio`** — no reason to relocate for a small internal team.
+- **Callback URLs (Studio defaults):** `/__nuxt_studio/auth/google` and `/__nuxt_studio/auth/github`. Register the dev (`http://localhost:3000/...`) and prod (`https://docs.dtpr.io/...`) URIs for each in the respective OAuth app.
+- **Secret management: `wrangler secret put` for production, `docs-site/.dev.vars` (gitignored) for local dev** — matches the standard Cloudflare Workers pattern and avoids committing secrets. No new Nuxt runtime-config plumbing is needed; Studio reads these env vars directly.
+- **Dev-only first, then production** — land dev-mode editing first and validate locally before flipping production on. Minimizes blast radius if Workers-specific issues surface.
+- **No session-secret env var configured** — the Studio docs do not document a `STUDIO_SECRET`-style variable, and the module manages sessions internally. If one is required later, we'll add it when the module surfaces the requirement.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Which auth provider(s)?** → Google OAuth **and** GitHub OAuth, both enabled simultaneously with a shared moderator whitelist (user-confirmed).
+- **Who gets access?** → Small internal team, <10 known emails (user-confirmed). Collect the actual address list from the team lead during Unit 2.
+- **Does GitHub OAuth need its own moderator list?** → Yes, we set one. Omitting `STUDIO_GITHUB_MODERATORS` would let any GitHub user sign in to the editor UI; push authorization still happens via OAuth scopes, but we don't want random GitHub users inside our editor at all.
+- **Is Nuxt Studio already installed?** → No — confirmed by inspection of `docs-site/` contents and `grep`.
+- **Should Studio write to a separate branch?** → No — write to `main` for now (matches current content editing flow). Revisit if editor velocity warrants a staging/preview branch.
+- **Does Docus auto-include Studio?** → No — must add `nuxt-studio` to `modules` explicitly.
+
+### Deferred to Implementation
+
+- **Exact Google Cloud project to use** — whether to reuse an existing Helpful Places GCP project or create a new one (`dtpr-docs-studio`). Decide during Unit 2 based on who owns the DNS/org.
+- **GitHub OAuth App owner** — organization-level OAuth App on `helpful-places` (preferred, survives personnel changes) vs. a maintainer's personal GitHub. Decide during Unit 2 based on org admin availability.
+- **Bot account identity for the GitHub PAT** — whether to use a personal account, a machine user, or a GitHub App. For <10 internal editors, a fine-grained PAT on an existing maintainer account is the simplest choice, but the team may prefer a dedicated `dtpr-bot` machine user. Decide during Unit 3.
+- **PAT rotation cadence** — fine-grained PATs expire at most 1 year out. Document the rotation owner and renewal date during Unit 5 documentation.
+
+## Implementation Units
+
+- [ ] **Unit 1: Install `nuxt-studio` module and wire up repository config**
+
+**Goal:** Add the module to `docs-site/`, declare the `studio.repository` block in `nuxt.config.ts`, and confirm the editor route loads (unauthenticated) in dev.
+
+**Requirements:** R1, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `docs-site/package.json` (add `nuxt-studio` to dependencies — pin `^1.6.0`)
+- Modify: `docs-site/nuxt.config.ts` (add `modules: ['nuxt-studio']` and a `studio` block)
+- Modify: `pnpm-lock.yaml` (lockfile update from `pnpm install`)
+
+**Approach:**
+- Use `pnpm -F dtpr-docs add nuxt-studio@^1.6.0` so the workspace scoping stays correct (the repo has a `pnpm-workspace.yaml`).
+- In `nuxt.config.ts`, add `modules: ['nuxt-studio']` and a `studio` object with `repository: { provider: 'github', owner: 'helpful-places', repo: 'dtpr', branch: 'main', rootDir: 'docs-site' }`.
+- Leave the existing `$production` cloudflare-module rollup config and `extends: ['docus']` untouched. Studio is additive.
+- Do not hardcode any secrets in `nuxt.config.ts`; everything sensitive reads from env.
+
+**Patterns to follow:**
+- Existing `$production` block in `docs-site/nuxt.config.ts` is the reference for Cloudflare-specific config shape.
+- `docs-site/app.config.ts` already has a `github` block — note that it is **separate** from `studio.repository` and both should exist side-by-side.
+
+**Test scenarios:**
+- Happy path — Run `pnpm -F dtpr-docs dev`, open `http://localhost:3000/_studio` in a browser → editor shell loads, prompts for login. Studio UI chrome renders.
+- Happy path — Run `pnpm -F dtpr-docs build` → build succeeds with no `@img/sharp-wasm32/versions` or `ipx` resolution errors, confirming the v1.6.0 pin is working under the Cloudflare preset.
+- Edge case — Open `http://localhost:3000/` (a regular docs page) → site still renders normally. Adding Studio does not break the public site.
+
+**Verification:**
+- `pnpm-lock.yaml` diff shows exactly one new root dependency (`nuxt-studio`) plus its transitive graph; no duplicated or downgraded packages.
+- `pnpm -F dtpr-docs build` output contains no Workers-incompatible module warnings.
+
+- [ ] **Unit 2: Create Google + GitHub OAuth apps and define the shared moderator list**
+
+**Goal:** Produce a Google OAuth 2.0 client and a GitHub OAuth App, both configured for Studio's callback URLs, and lock in the shared moderator email whitelist. No code changes in this unit — this is environment setup plus documentation capture.
+
+**Requirements:** R2, R5
+
+**Dependencies:** Unit 1 (need the callback URL shape confirmed)
+
+**Files:**
+- Create: `docs-site/docs/studio-setup.md` (internal setup runbook — see Unit 5 for full content; Unit 2 adds the Google + GitHub OAuth sections)
+
+**Approach:**
+- **Google OAuth:** In Google Cloud Console, create or reuse a project, enable the OAuth 2.0 Web Application client, and register both redirect URIs:
+  - `http://localhost:3000/__nuxt_studio/auth/google` (dev)
+  - `https://docs.dtpr.io/__nuxt_studio/auth/google` (prod)
+- **GitHub OAuth App:** Under the `helpful-places` GitHub org settings (preferred) — or a maintainer's personal account if org admin isn't available — create a new OAuth App with:
+  - Homepage URL: `https://docs.dtpr.io`
+  - Dev callback: `http://localhost:3000/__nuxt_studio/auth/github`
+  - Prod callback: `https://docs.dtpr.io/__nuxt_studio/auth/github`
+  - (If GitHub's UI requires a single callback field, register the prod URL and use a second OAuth App for dev. The docs don't specify current GitHub OAuth App capabilities — decide at creation time.)
+- Capture `client_id` + `client_secret` for each provider. Store all four values in the team password manager; they'll feed `.dev.vars` in Unit 4 and Cloudflare Workers secrets in Unit 6.
+- Confirm the final moderator email list with the team lead (<10 addresses). The **same** list is used for both `STUDIO_GOOGLE_MODERATORS` and `STUDIO_GITHUB_MODERATORS`.
+- Record the GCP project ID, Google client ID, GitHub OAuth App name/ID, and all redirect URIs in `docs-site/docs/studio-setup.md`. Client secrets and the moderator list live only in the secret store.
+
+**Patterns to follow:**
+- No existing code pattern — first OAuth integrations in this repo.
+
+**Test scenarios:**
+- Test expectation: none — this is external service configuration. Functional proof comes in Unit 4 (first successful login via each provider).
+
+**Verification:**
+- Google OAuth client is listed in GCP Console with both redirect URIs visible.
+- GitHub OAuth App is listed under the owning org/account with the correct callback URL(s).
+- All four credentials are captured in the team password manager (nothing committed).
+- Moderator list is confirmed in writing with the team lead and is identical for both providers.
+
+- [ ] **Unit 3: Create and scope the GitHub bot PAT**
+
+**Goal:** Issue a fine-grained Personal Access Token that Studio will use to commit edits back to `helpful-places/dtpr` **when a user has signed in via Google OAuth**. Users who sign in via GitHub OAuth commit under their own identity and don't use this PAT.
+
+**Requirements:** R3, R5
+
+**Dependencies:** None (can run in parallel with Unit 2)
+
+**Files:**
+- Modify: `docs-site/docs/studio-setup.md` (append GitHub PAT section once created — see Unit 5)
+
+**Approach:**
+- Decide bot identity with the team: personal maintainer PAT vs. dedicated `dtpr-bot` machine user. Default to a dedicated machine user if the team already has one; otherwise start with a maintainer PAT and migrate later.
+- Create a **fine-grained** PAT (not classic) scoped to **only** `helpful-places/dtpr`, with `Contents: Read and write` and nothing else.
+- Set expiration to the team's rotation standard (recommend 90 days for fine-grained tokens; at most 1 year).
+- Store as `STUDIO_GITHUB_TOKEN` — record the expiration date and owner in `docs-site/docs/studio-setup.md`.
+
+**Patterns to follow:**
+- No existing PAT-based integrations in this repo to mirror.
+
+**Test scenarios:**
+- Test expectation: none — token validity is proven by Unit 4's end-to-end edit-and-commit flow. Unit 6 re-verifies in production.
+
+**Verification:**
+- Token is scoped only to `helpful-places/dtpr` (confirmed in the PAT's repository-access setting).
+- Token is stored in the team password manager with its expiration date noted.
+
+- [ ] **Unit 4: Wire secrets for local dev and prove BOTH login + edit flows**
+
+**Goal:** Configure local env vars so Studio works end-to-end on `localhost:3000` for both providers: a Google moderator can edit (bot-authored commit), a GitHub OAuth moderator can edit (user-authored commit), and non-moderators are rejected on both paths.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** Units 1, 2, 3
+
+**Files:**
+- Create: `docs-site/.dev.vars` (gitignored — local-only env file consumed by wrangler dev)
+- Modify: `docs-site/.gitignore` (ensure `.dev.vars` is ignored — check current state; add if missing)
+
+**Approach:**
+- Populate `docs-site/.dev.vars` with all six vars:
+  - `STUDIO_GOOGLE_CLIENT_ID`, `STUDIO_GOOGLE_CLIENT_SECRET`, `STUDIO_GOOGLE_MODERATORS`
+  - `STUDIO_GITHUB_CLIENT_ID`, `STUDIO_GITHUB_CLIENT_SECRET`, `STUDIO_GITHUB_MODERATORS` (same list as Google)
+  - `STUDIO_GITHUB_TOKEN` (bot PAT, used by Google-path only)
+- Start dev server. Visit `/_studio` — both "Sign in with Google" and "Sign in with GitHub" buttons should be visible.
+- **Google path test:** sign in with a whitelisted Google address. Make a one-character edit to `docs-site/content/1.getting-started/1.introduction.md`, save, confirm commit on `main` authored by the **bot** identity.
+- **GitHub path test:** sign out, sign in with a whitelisted GitHub account. Make another one-character edit, save, confirm commit on `main` authored by the **signed-in user's** GitHub identity (not the bot).
+- Revert test edits via Studio saves (keeps history clean) or squash-revert locally.
+- **Rejection tests:** confirm a non-whitelisted Google account is rejected, and a non-whitelisted GitHub account is rejected.
+
+**Patterns to follow:**
+- Cloudflare Workers projects in this repo (`api/`, `studio/`) already use the wrangler secrets pattern for production; `.dev.vars` is the conventional local counterpart.
+
+**Test scenarios:**
+- Happy path (Google) — Moderator signs in with Google → editor renders; edit + save produces a commit on `main` authored by the bot PAT identity. Verifies `STUDIO_GOOGLE_CLIENT_ID/SECRET`, `STUDIO_GOOGLE_MODERATORS`, `STUDIO_GITHUB_TOKEN`, and `studio.repository` end-to-end.
+- Happy path (GitHub) — Moderator signs in with GitHub → editor renders; edit + save produces a commit on `main` authored by **the signed-in user's** GitHub identity (not the bot). Verifies `STUDIO_GITHUB_CLIENT_ID/SECRET`, `STUDIO_GITHUB_MODERATORS`, and the OAuth-scope commit path.
+- Happy path (multi-provider UI) — The `/_studio` login screen shows both buttons; each routes to its own callback path without collision.
+- Error path (Google whitelist) — Non-whitelisted Google account is rejected at login. **Blocking check** — must pass before production rollout.
+- Error path (GitHub whitelist) — Non-whitelisted GitHub account is rejected at login. **Blocking check** — without this, any GitHub user on the internet could reach the editor UI.
+- Edge case — Remove one of the seven env vars and re-run `pnpm -F dtpr-docs dev` → Studio surfaces a clear configuration error on `/_studio`, not a silent 500. (If unclear, that's a documentation signal for Unit 5, not a blocker.)
+
+**Verification:**
+- One Google-path test commit on `main` authored by the bot; one GitHub-path test commit on `main` authored by the signed-in user.
+- Both non-moderator rejections confirmed.
+- `docs-site/.dev.vars` is confirmed gitignored (via `git check-ignore docs-site/.dev.vars`).
+
+- [ ] **Unit 5: Document the setup and operational runbook**
+
+**Goal:** Leave a runbook future maintainers can follow to add moderators, rotate credentials, and debug Studio auth failures.
+
+**Requirements:** R5
+
+**Dependencies:** Units 2, 3, 4 (need the real configured values and the proven flow)
+
+**Files:**
+- Create: `docs-site/docs/studio-setup.md` (if Units 2/3 haven't started it already) — single runbook with sections:
+  - Overview of how editor auth + git writes fit together (Google path → bot PAT; GitHub path → user's OAuth token; audit-trail implication)
+  - Google OAuth client details (project, client ID, redirect URIs, who owns it)
+  - GitHub OAuth App details (org or owner, app name, client ID, redirect URIs)
+  - GitHub bot PAT details (owner, scope, expiration, rotation cadence — used for Google-path commits only)
+  - Moderator list management (single canonical list used for both `STUDIO_GOOGLE_MODERATORS` and `STUDIO_GITHUB_MODERATORS`; how to add/remove; reminder to update BOTH secrets)
+  - Cloudflare Workers secrets (all seven names + `wrangler secret put` commands; do **not** record values)
+  - Local dev setup (what goes in `.dev.vars`)
+  - Troubleshooting: "editor won't load", "one provider works but the other doesn't", "login rejected despite being on the list", "commits not appearing", "commit authored by wrong identity"
+
+**Approach:**
+- Record only non-secret metadata in the doc (names, IDs, expirations, owners). Secrets live in the password manager and Cloudflare Workers, never in the repo.
+- Link from `docs-site/README.md` or the repo-root `README.md` if there's a natural spot, so maintainers discover it.
+
+**Patterns to follow:**
+- Existing `README.md` at repo root and `docs/` conventions.
+
+**Test scenarios:**
+- Test expectation: none — this is documentation. Sanity-check it by having a second team member read through without prior context and confirm they could execute a moderator add and a PAT rotation from the doc alone.
+
+**Verification:**
+- All non-secret config is captured; no secret values appear in the committed file.
+- Document is reachable from at least one existing README.
+
+- [ ] **Unit 6: Configure production secrets on Cloudflare Workers and verify live editing**
+
+**Goal:** Promote the proven dev setup to production — secrets live in Cloudflare Workers, a moderator can sign in at `https://docs.dtpr.io/_studio` and commit an edit to `main` via the bot.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** Units 1–5
+
+**Files:**
+- Modify: `docs-site/docs/studio-setup.md` (fill in the Cloudflare Workers secrets section after setting them)
+
+**Approach:**
+- From `docs-site/`, run `npx wrangler secret put` for each of the seven secrets:
+  - `STUDIO_GOOGLE_CLIENT_ID`, `STUDIO_GOOGLE_CLIENT_SECRET`, `STUDIO_GOOGLE_MODERATORS`
+  - `STUDIO_GITHUB_CLIENT_ID`, `STUDIO_GITHUB_CLIENT_SECRET`, `STUDIO_GITHUB_MODERATORS`
+  - `STUDIO_GITHUB_TOKEN`
+- Trigger a production deploy (whichever mechanism the repo currently uses — likely CI on merge to `main`, based on recent commits).
+- Verify `/_studio` loads on `https://docs.dtpr.io/_studio` after deploy and shows both login buttons.
+- Perform one moderator edit-and-save round-trip **per provider** on production, reverting each test change immediately.
+
+**Patterns to follow:**
+- Recent commit `d7e619a Fix docs-site Cloudflare Workers deploy failure` is a signal that Workers deploys have been fragile — keep a close eye on the post-deploy logs and be ready to roll back by reverting the merge if `/_studio` 500s.
+
+**Test scenarios:**
+- Happy path (Google) — Moderator signs in on `https://docs.dtpr.io/_studio` with Google and saves a trivial edit → commit appears on `main` authored by the bot, production redeploys, change is live within the normal deploy window.
+- Happy path (GitHub) — Moderator signs in on production with GitHub and saves a trivial edit → commit authored by the signed-in user's GitHub identity, redeploys, change visible.
+- Happy path — Regular visitors hitting `https://docs.dtpr.io/` see no regression. Homepage, any nested content page, and the existing D1-backed content still render correctly.
+- Error path — Non-moderator rejection re-validated in production for **both** providers.
+- Edge case — Studio's commit triggers the existing CI / deploy pipeline. Confirm the loop closes (commit → deploy → change visible) and that both authorship patterns (bot vs. user) are acceptable in the audit trail.
+
+**Verification:**
+- Production `/_studio` returns the editor shell with both login buttons.
+- One Google-path and one GitHub-path round-trip commit are both visible on `main` with the expected authorship.
+- Non-moderator rejection re-confirmed on production for both providers.
+- No regression in `https://docs.dtpr.io/` normal browsing.
+
+## System-Wide Impact
+
+- **Interaction graph:** Studio adds a `/_studio` route (editor UI), a `/__nuxt_studio/*` API surface (auth + publish endpoints), and a git commit side-channel via the bot PAT. The public site routes are untouched.
+- **Error propagation:** Misconfigured env vars should surface at `/_studio` load time (editor prompts a config error) rather than as a 500 on public routes. Confirm in Unit 4's edge-case scenario.
+- **State lifecycle risks:** Studio writes directly to `main` with every save. No staging branch, no preview. That's acceptable for a small internal team but is the single biggest blast-radius risk; documented in the runbook.
+- **API surface parity:** None — no public API is added or changed.
+- **Integration coverage:** The most important integration point is "edit in Studio → commit appears on GitHub → deploy publishes to docs.dtpr.io". Verified end-to-end in Units 4 and 6; unit tests alone cannot prove this.
+- **Unchanged invariants:** The `docus` theme, D1 content binding, Cloudflare `cloudflare-module` preset, custom domain routing, and the `agents/mcp` rollup stub all continue to work exactly as they do today. Studio is strictly additive.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `nuxt-studio` < 1.6.0 gets pulled in via a transitive resolution or a bad pin, breaking Workers build | Pin `^1.6.0`; Unit 1 includes a Workers build verification. Revisit if the module's range semantics change. |
+| OAuth redirect URI mismatch (dev works, prod fails) for either provider | Register dev + prod redirect URIs up front in Unit 2 for **both** providers; Unit 6 validates each on production explicitly. |
+| `STUDIO_GITHUB_MODERATORS` forgotten → any GitHub user on the internet can access the editor UI | Unit 4 includes an explicit **blocking** rejection test with a non-whitelisted GitHub account. Unit 6 re-runs the same test on production. |
+| Moderator list drift — someone updates `STUDIO_GOOGLE_MODERATORS` but forgets `STUDIO_GITHUB_MODERATORS` (or vice versa) | Runbook documents that both must be updated together; consider a small shell helper in the runbook that sets both in one invocation. |
+| PAT expires silently and Studio's Google-path saves start failing | Runbook (Unit 5) records expiration date + rotation owner. Note that GitHub-path saves are unaffected by PAT expiry — they use the user's OAuth token. |
+| Editor accidentally commits a broken build to `main` | Small internal team + low volume makes this acceptable; mitigations (staging branch, required review) are deferred. |
+| Someone adds a secret to the committed runbook by accident | Document explicitly says "never record values here"; `.gitignore` keeps `.dev.vars` out. |
+| Cloudflare Workers cold-start or KV limits break Studio's session handling | Studio docs don't call out any Workers-specific session storage config; if issues appear, escalate to maintainers rather than patching blindly (per researcher's flagged unknown). |
+| Docus theme upgrade changes MDC component contracts that Studio renders | Out of scope for this plan; watch Docus release notes in normal upgrade cycles. |
+
+## Documentation / Operational Notes
+
+- `docs-site/docs/studio-setup.md` is the canonical runbook — created in Unit 5, referenced from Units 2, 3, 4, 6.
+- Moderator list is stored in **two** Cloudflare Workers secrets (`STUDIO_GOOGLE_MODERATORS` and `STUDIO_GITHUB_MODERATORS`). To add or remove a moderator, run `npx wrangler secret put` for BOTH secrets with the updated comma-separated list — they must stay in sync.
+- PAT rotation is manual — the runbook records expiration and owner; the owning maintainer sets their own reminder. Only affects Google-path commits; GitHub-path users keep working during a PAT outage.
+- After a secret change, a redeploy is required for Workers to pick it up.
+
+## Sources & References
+
+- [Nuxt Studio setup](https://nuxt.studio/setup)
+- [Nuxt Studio auth providers](https://nuxt.studio/auth-providers)
+- [Nuxt Studio git providers](https://nuxt.studio/git-providers)
+- [nuxt-content/studio module repo](https://github.com/nuxt-content/studio)
+- [PR #404 — ipx optional for Cloudflare Workers (v1.6.0)](https://github.com/nuxt-content/nuxt-studio/pull/404)
+- [Nuxt Content v3 on Cloudflare Workers](https://content.nuxt.com/docs/deploy/cloudflare-workers)
+- [Docus + Studio guide](https://docus.dev/en/getting-started/studio)
+- Related plan (different app, orthogonal work): `docs/plans/2026-02-06-feat-cms-editable-markdown-pages-plan.md`
+- Current config: `docs-site/nuxt.config.ts`, `docs-site/wrangler.toml`, `docs-site/app.config.ts`, `docs-site/package.json`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,10 +131,13 @@ importers:
         version: 12.6.2
       docus:
         specifier: latest
-        version: 5.7.0(94da9891bae81f51db44a849ce069131)
+        version: 5.7.0(cfa0b75c1099625a7e599ef5fb365524)
       nuxt:
         specifier: ^4.0.0
         version: 4.3.1(@parcel/watcher@2.5.6)(@types/node@25.3.3)(@vue/compiler-sfc@3.5.29)(better-sqlite3@12.6.2)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4(better-sqlite3@12.6.2))(eslint@10.0.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.2)
+      nuxt-studio:
+        specifier: ^1.6.0
+        version: 1.6.0(db0@0.3.4(better-sqlite3@12.6.2))(ioredis@5.10.0)(magicast@0.5.2)(vue@3.5.29(typescript@5.9.3))
     devDependencies:
       wrangler:
         specifier: ^4.83.0
@@ -231,6 +234,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@3.0.104':
+    resolution: {integrity: sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.46':
     resolution: {integrity: sha512-zH1UbNRjG5woOXXFOrVCZraqZuFTtmPvLardMGcgLkzpxKV0U3tAGoyWKSZ862H+eBJfI/Hf2yj/zzGJcCkycg==}
     engines: {node: '>=18'}
@@ -273,12 +282,24 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.23':
+    resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
 
   '@ai-sdk/vue@3.0.116':
     resolution: {integrity: sha512-9+3Pi2T9F4ImvboJabeoApcXz4zjk1Gi2USjFscGfapfBIuYBkPBfJLmG1/7EAt0+3/GieGqeU553jVPa7pnQw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      vue: ^3.3.4
+
+  '@ai-sdk/vue@3.0.168':
+    resolution: {integrity: sha512-HO9s+ufO6h7aDpayAFNkokeLlipUn2zr5UkTojwwy8pdJqh7JYZ56GK6IirHUGzZIr87gbdGIuegQIf5U/XHEQ==}
     engines: {node: '>=18'}
     peerDependencies:
       vue: ^3.3.4
@@ -552,6 +573,11 @@ packages:
 
   '@babel/parser@7.29.0':
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1466,6 +1492,9 @@ packages:
   '@iconify-json/heroicons@1.2.3':
     resolution: {integrity: sha512-n+vmCEgTesRsOpp5AB5ILB6srsgsYK+bieoQBNlafvoEhjVXLq8nIGN4B0v/s4DUfa0dOrjwE/cKJgIKdJXOEg==}
 
+  '@iconify-json/lucide@1.2.102':
+    resolution: {integrity: sha512-Dm3EEqu5NrmzyDMB2U1+8yroEj2/dB9V4KlH0m/szwwF/ofSf0cPaGTZqkd1aExXjCor+vU53ttRMCGuXf+/cg==}
+
   '@iconify-json/lucide@1.2.95':
     resolution: {integrity: sha512-SxDM/NEJtcGGAiLAnaZ7rcmVxkJI8esswTZLCm5BfNcoPf/yawIImb4nNfsu4dtFzP/Cl6KRg+vZq521zOUOnQ==}
 
@@ -2064,6 +2093,10 @@ packages:
     resolution: {integrity: sha512-UjBFt72dnpc+83BV3OIbCT0YHLevJtgJCHpxMX0YRKWLDhhbcDdUse87GtsQBrjvOzK7WUNUYLDS/hQLYev5rA==}
     engines: {node: '>=18.12.0'}
 
+  '@nuxt/kit@4.4.2':
+    resolution: {integrity: sha512-5+IPRNX2CjkBhuWUwz0hBuLqiaJPRoKzQ+SvcdrQDbAyE+VDeFt74VpSFr5/R0ujrK4b+XnSHUJWdS72w6hsog==}
+    engines: {node: '>=18.12.0'}
+
   '@nuxt/nitro-server@4.3.1':
     resolution: {integrity: sha512-4aNiM69Re02gI1ywnDND0m6QdVKXhWzDdtvl/16veytdHZj3FSq57ZCwOClNJ7HQkEMqXgS+bi6S2HmJX+et+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2209,6 +2242,9 @@ packages:
 
   '@nuxtjs/mdc@0.20.2':
     resolution: {integrity: sha512-afAJKnXKdvDtoNOGARQMpZoGprL1T3OGnj+K9edJjX+WdhCwvVabBijhi8BAlpx+YzA/DpcZx8bDFZk/aoSJmA==}
+
+  '@nuxtjs/mdc@0.21.1':
+    resolution: {integrity: sha512-DIeUD7IahWVUSoZExysxH9dX51Io6hcQYgGJODq0cMTGqaoDD32lRfHBJxYUmy+sUCV1+1hfa2ixspgJgEd2GA==}
 
   '@nuxtjs/robots@5.7.1':
     resolution: {integrity: sha512-1y1pW8Dh2gqJGFpXwkTin1KokBofYAG91C1gqxR4XbI7Xkl7DAXQ+BropHF2AeCV/uCxs6qz28ONp0+60TSw1Q==}
@@ -3375,11 +3411,19 @@ packages:
     resolution: {integrity: sha512-vWvqi9JNgz1dRL9Nvog5wtx7RuNkf7MEPl2mU/cyUUxJeH1CAr3t+81h8zO8zs7DK6cKLMoU9TvukWIDjP4Lzg==}
     engines: {node: '>=20'}
 
+  '@shikijs/core@4.0.2':
+    resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
+    engines: {node: '>=20'}
+
   '@shikijs/engine-javascript@3.23.0':
     resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
 
   '@shikijs/engine-javascript@4.0.1':
     resolution: {integrity: sha512-DJK9NiwtGYqMuKCRO4Ip0FKNDQpmaiS+K5bFjJ7DWFn4zHueDWgaUG8kAofkrnXF6zPPYYQY7J5FYVW9MbZyBg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.0.2':
+    resolution: {integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==}
     engines: {node: '>=20'}
 
   '@shikijs/engine-oniguruma@3.23.0':
@@ -3389,6 +3433,10 @@ packages:
     resolution: {integrity: sha512-oCWdCTDch3J8Kc0OZJ98KuUPC02O1VqIE3W/e2uvrHqTxYRR21RGEJMtchrgrxhsoJJCzmIciKsqG+q/yD+Cxg==}
     engines: {node: '>=20'}
 
+  '@shikijs/engine-oniguruma@4.0.2':
+    resolution: {integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==}
+    engines: {node: '>=20'}
+
   '@shikijs/langs@3.23.0':
     resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
 
@@ -3396,8 +3444,16 @@ packages:
     resolution: {integrity: sha512-v/mluaybWdnGJR4GqAR6zh8qAZohW9k+cGYT28Y7M8+jLbC0l4yG085O1A+WkseHTn+awd+P3UBymb2+MXFc8w==}
     engines: {node: '>=20'}
 
+  '@shikijs/langs@4.0.2':
+    resolution: {integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==}
+    engines: {node: '>=20'}
+
   '@shikijs/primitive@4.0.1':
     resolution: {integrity: sha512-ns0hHZc5eWZuvuIEJz2pTx3Qecz0aRVYumVQJ8JgWY2tq/dH8WxdcVM49Fc2NsHEILNIT6vfdW9MF26RANWiTA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.0.2':
+    resolution: {integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==}
     engines: {node: '>=20'}
 
   '@shikijs/themes@3.23.0':
@@ -3407,14 +3463,26 @@ packages:
     resolution: {integrity: sha512-FW41C/D6j/yKQkzVdjrRPiJCtgeDaYRJFEyCKFCINuRJRj9WcmubhP4KQHPZ4+9eT87jruSrYPyoblNRyDFzvA==}
     engines: {node: '>=20'}
 
+  '@shikijs/themes@4.0.2':
+    resolution: {integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==}
+    engines: {node: '>=20'}
+
   '@shikijs/transformers@3.23.0':
     resolution: {integrity: sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ==}
+
+  '@shikijs/transformers@4.0.2':
+    resolution: {integrity: sha512-1+L0gf9v+SdDXs08vjaLb3mBFa8U7u37cwcBQIv/HCocLwX69Tt6LpUCjtB+UUTvQxI7BnjZKhN/wMjhHBcJGg==}
+    engines: {node: '>=20'}
 
   '@shikijs/types@3.23.0':
     resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
 
   '@shikijs/types@4.0.1':
     resolution: {integrity: sha512-EaygPEn57+jJ76mw+nTLvIpJMAcMPokFbrF8lufsZP7Ukk+ToJYEcswN1G0e49nUZAq7aCQtoeW219A8HK1ZOw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.0.2':
+    resolution: {integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==}
     engines: {node: '>=20'}
 
   '@shikijs/vscode-textmate@10.0.2':
@@ -4163,6 +4231,10 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-vue-jsx@5.1.4':
     resolution: {integrity: sha512-70LmoVk9riR7qc4W2CpjsbNMWTPnuZb9dpFKX1emru0yP57nsc9k8nhLA6U93ngQapv5VDIUq2JatNfLbBIkrA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4297,6 +4369,9 @@ packages:
   '@vue/compiler-core@3.5.29':
     resolution: {integrity: sha512-cuzPhD8fwRHk8IGfmYaR4eEe4cAyJEL66Ove/WZL7yWNL134nqLddSLwNRIsFlnnW1kK+p8Ck3viFnC0chXCXw==}
 
+  '@vue/compiler-core@3.5.32':
+    resolution: {integrity: sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==}
+
   '@vue/compiler-dom@3.5.29':
     resolution: {integrity: sha512-n0G5o7R3uBVmVxjTIYcz7ovr8sy7QObFG8OQJ3xGCDNhbG60biP/P5KnyY8NLd81OuT1WJflG7N4KWYHaeeaIg==}
 
@@ -4358,6 +4433,9 @@ packages:
 
   '@vue/shared@3.5.29':
     resolution: {integrity: sha512-w7SR0A5zyRByL9XUkCfdLs7t9XOHUyJ67qPGQjOou3p6GvBeBW+AVjUUmlxtZ4PIYaRvE+1LmK44O4uajlZwcg==}
+
+  '@vue/shared@3.5.32':
+    resolution: {integrity: sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==}
 
   '@vue/test-utils@2.4.6':
     resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
@@ -4543,6 +4621,12 @@ packages:
 
   ai@6.0.116:
     resolution: {integrity: sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@6.0.168:
+    resolution: {integrity: sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -4791,6 +4875,10 @@ packages:
 
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -5058,6 +5146,9 @@ packages:
   cookie-es@1.2.2:
     resolution: {integrity: sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==}
 
+  cookie-es@1.2.3:
+    resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
+
   cookie-es@2.0.0:
     resolution: {integrity: sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==}
 
@@ -5286,6 +5377,9 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -5965,6 +6059,9 @@ packages:
   gzip-size@7.0.0:
     resolution: {integrity: sha512-O1Ld7Dr+nqPnmGpdhzLmMTQ4vAsD+rHwMm1NLUmoUFFymBOMKxCCrtDxqdBRYXdeEPEi3SyoR4TizJLQrnKBNA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  h3@1.15.11:
+    resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
   h3@1.15.5:
     resolution: {integrity: sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==}
@@ -6665,6 +6762,10 @@ packages:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
     engines: {node: 20 || >=22}
 
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -6933,6 +7034,10 @@ packages:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
@@ -6966,6 +7071,9 @@ packages:
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
   mocked-exports@0.1.1:
     resolution: {integrity: sha512-aF7yRQr/Q0O2/4pIXm6PZ5G+jAd7QS4Yu8m+WEeEHGnbo+7mE36CbLSDQiXYV8bVL3NfmdeqPJct0tUlnjVSnA==}
@@ -7119,6 +7227,9 @@ packages:
 
   nuxt-site-config@3.2.21:
     resolution: {integrity: sha512-WCqo4cirBc+GLPBZOU1ye5+f4xjC7Sf7qbKt/zpeCtEUqJLHDR0MoKICfsGt/8EdkSDYUo+m5BNZ1oxai0isgQ==}
+
+  nuxt-studio@1.6.0:
+    resolution: {integrity: sha512-7j0fAeZpNXw5XgiB+jUCXoujCIOAiMvxSETbzfqzwdC/kSh7YFBArd741hPfEOgKgVAmWbW9zU2/4FJy/K+6iA==}
 
   nuxt@4.3.1:
     resolution: {integrity: sha512-bl+0rFcT5Ax16aiWFBFPyWcsTob19NTZaDL5P6t0MQdK63AtgS6fN6fwvwdbXtnTk6/YdCzlmuLzXhSM22h0OA==}
@@ -8069,6 +8180,10 @@ packages:
     resolution: {integrity: sha512-EkAEhDTN5WhpoQFXFw79OHIrSAfHhlImeCdSyg4u4XvrpxKEmdo/9x/HWSowujAnUrFsGOwWiE58a6GVentMnQ==}
     engines: {node: '>=20'}
 
+  shiki@4.0.2:
+    resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
+    engines: {node: '>=20'}
+
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
@@ -8771,6 +8886,68 @@ packages:
       uploadthing:
         optional: true
 
+  unstorage@1.17.5:
+    resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.8.0
+      '@azure/cosmos': ^4.2.0
+      '@azure/data-tables': ^13.3.0
+      '@azure/identity': ^4.6.0
+      '@azure/keyvault-secrets': ^4.9.0
+      '@azure/storage-blob': ^12.26.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.9.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.34.3
+      '@vercel/blob': '>=0.27.1'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1 || ^2 || ^3
+      aws4fetch: ^1.0.20
+      db0: '>=0.2.1'
+      idb-keyval: ^6.2.1
+      ioredis: ^5.4.2
+      uploadthing: ^7.4.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      uploadthing:
+        optional: true
+
   untun@0.1.3:
     resolution: {integrity: sha512-4luGP9LMYszMRZwsvyUd9MrxgEGZdZuZgpVQHEEX0lCYFESasVRvZd0EYpCkOIbJKHMuv0LskpXc/8Un+MJzEQ==}
     hasBin: true
@@ -9346,6 +9523,11 @@ packages:
     peerDependencies:
       zod: ^3.25 || ^4
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@3.22.3:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
 
@@ -9364,6 +9546,13 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/gateway@3.0.104(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
       zod: 4.3.6
 
   '@ai-sdk/gateway@3.0.46(zod@4.3.6)':
@@ -9415,6 +9604,13 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@4.0.23(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
   '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
@@ -9423,6 +9619,15 @@ snapshots:
     dependencies:
       '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
       ai: 6.0.116(zod@4.3.6)
+      swrv: 1.1.0(vue@3.5.29(typescript@5.9.3))
+      vue: 3.5.29(typescript@5.9.3)
+    transitivePeerDependencies:
+      - zod
+
+  '@ai-sdk/vue@3.0.168(vue@3.5.29(typescript@5.9.3))(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      ai: 6.0.168(zod@4.3.6)
       swrv: 1.1.0(vue@3.5.29(typescript@5.9.3))
       vue: 3.5.29(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10039,6 +10244,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -10637,6 +10846,10 @@ snapshots:
       '@iconify/types': 2.0.0
 
   '@iconify-json/heroicons@1.2.3':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/lucide@1.2.102':
     dependencies:
       '@iconify/types': 2.0.0
 
@@ -11625,6 +11838,31 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@nuxt/kit@4.4.2(magicast@0.5.2)':
+    dependencies:
+      c12: 3.3.3(magicast@0.5.2)
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      errx: 0.1.0
+      exsolve: 1.0.8
+      ignore: 7.0.5
+      jiti: 2.6.1
+      klona: 2.0.6
+      mlly: 1.8.2
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      rc9: 3.0.0
+      scule: 1.3.0
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ufo: 1.6.3
+      unctx: 2.5.0
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
   '@nuxt/nitro-server@4.3.1(better-sqlite3@12.6.2)(db0@0.3.4(better-sqlite3@12.6.2))(ioredis@5.10.0)(magicast@0.5.2)(nuxt@4.3.1(@parcel/watcher@2.5.6)(@types/node@25.3.3)(@vue/compiler-sfc@3.5.29)(better-sqlite3@12.6.2)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4(better-sqlite3@12.6.2))(eslint@10.0.2(jiti@1.21.7))(ioredis@5.10.0)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.2))(typescript@5.9.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
@@ -12306,6 +12544,56 @@ snapshots:
       remark-stringify: 11.0.0
       scule: 1.3.0
       shiki: 3.23.0
+      ufo: 1.6.3
+      unified: 11.0.5
+      unist-builder: 4.0.0
+      unist-util-visit: 5.1.0
+      unwasm: 0.5.3
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - magicast
+      - supports-color
+
+  '@nuxtjs/mdc@0.21.1(magicast@0.5.2)':
+    dependencies:
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@shikijs/core': 4.0.2
+      '@shikijs/engine-javascript': 4.0.2
+      '@shikijs/langs': 4.0.2
+      '@shikijs/themes': 4.0.2
+      '@shikijs/transformers': 4.0.2
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@vue/compiler-core': 3.5.32
+      consola: 3.4.2
+      debug: 4.4.3
+      defu: 6.1.7
+      destr: 2.0.5
+      detab: 3.0.2
+      github-slugger: 2.0.0
+      hast-util-format: 1.1.0
+      hast-util-to-mdast: 10.1.2
+      hast-util-to-string: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      micromark-util-sanitize-uri: 2.0.1
+      parse5: 8.0.0
+      pathe: 2.0.3
+      property-information: 7.1.0
+      rehype-external-links: 3.0.0
+      rehype-minify-whitespace: 6.0.2
+      rehype-raw: 7.0.0
+      rehype-remark: 10.0.1
+      rehype-slug: 6.0.0
+      rehype-sort-attribute-values: 5.0.1
+      rehype-sort-attributes: 5.0.1
+      remark-emoji: 5.0.2
+      remark-gfm: 4.0.1
+      remark-mdc: 3.10.0
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-stringify: 11.0.0
+      scule: 1.3.0
+      shiki: 4.0.2
       ufo: 1.6.3
       unified: 11.0.5
       unist-builder: 4.0.0
@@ -13111,6 +13399,14 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
+  '@shikijs/core@4.0.2':
+    dependencies:
+      '@shikijs/primitive': 4.0.2
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
   '@shikijs/engine-javascript@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0
@@ -13120,6 +13416,12 @@ snapshots:
   '@shikijs/engine-javascript@4.0.1':
     dependencies:
       '@shikijs/types': 4.0.1
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.4
+
+  '@shikijs/engine-javascript@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.4
 
@@ -13133,6 +13435,11 @@ snapshots:
       '@shikijs/types': 4.0.1
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@shikijs/engine-oniguruma@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@shikijs/langs@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0
@@ -13141,9 +13448,19 @@ snapshots:
     dependencies:
       '@shikijs/types': 4.0.1
 
+  '@shikijs/langs@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+
   '@shikijs/primitive@4.0.1':
     dependencies:
       '@shikijs/types': 4.0.1
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/primitive@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
@@ -13155,10 +13472,19 @@ snapshots:
     dependencies:
       '@shikijs/types': 4.0.1
 
+  '@shikijs/themes@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+
   '@shikijs/transformers@3.23.0':
     dependencies:
       '@shikijs/core': 3.23.0
       '@shikijs/types': 3.23.0
+
+  '@shikijs/transformers@4.0.2':
+    dependencies:
+      '@shikijs/core': 4.0.2
+      '@shikijs/types': 4.0.2
 
   '@shikijs/types@3.23.0':
     dependencies:
@@ -13166,6 +13492,11 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/types@4.0.1':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@4.0.2':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -14039,6 +14370,8 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitejs/plugin-vue-jsx@5.1.4(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.29(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.29.0
@@ -14253,6 +14586,14 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.5.32':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@vue/shared': 3.5.32
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.5.29':
     dependencies:
       '@vue/compiler-core': 3.5.29
@@ -14356,6 +14697,8 @@ snapshots:
       vue: 3.5.29(typescript@5.9.3)
 
   '@vue/shared@3.5.29': {}
+
+  '@vue/shared@3.5.32': {}
 
   '@vue/test-utils@2.4.6':
     dependencies:
@@ -14473,6 +14816,14 @@ snapshots:
       '@ai-sdk/gateway': 3.0.66(zod@4.3.6)
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
+
+  ai@6.0.168(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.104(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 
@@ -14712,6 +15063,10 @@ snapshots:
       balanced-match: 1.0.2
 
   brace-expansion@5.0.4:
+    dependencies:
+      balanced-match: 4.0.4
+
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
@@ -14973,6 +15328,8 @@ snapshots:
 
   cookie-es@1.2.2: {}
 
+  cookie-es@1.2.3: {}
+
   cookie-es@2.0.0: {}
 
   cookie-signature@1.2.2: {}
@@ -15179,6 +15536,8 @@ snapshots:
 
   defu@6.1.4: {}
 
+  defu@6.1.7: {}
+
   delayed-stream@1.0.0: {}
 
   delegates@1.0.0: {}
@@ -15213,7 +15572,7 @@ snapshots:
 
   dlv@1.1.3: {}
 
-  docus@5.7.0(94da9891bae81f51db44a849ce069131):
+  docus@5.7.0(cfa0b75c1099625a7e599ef5fb365524):
     dependencies:
       '@ai-sdk/gateway': 3.0.59(zod@4.3.6)
       '@ai-sdk/mcp': 1.0.22(zod@4.3.6)
@@ -15242,7 +15601,7 @@ snapshots:
       motion-v: 1.10.3(@vueuse/core@14.2.1(vue@3.5.29(typescript@5.9.3)))(vue@3.5.29(typescript@5.9.3))
       nuxt: 4.3.1(@parcel/watcher@2.5.6)(@types/node@25.3.3)(@vue/compiler-sfc@3.5.29)(better-sqlite3@12.6.2)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4(better-sqlite3@12.6.2))(eslint@10.0.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.2)
       nuxt-llms: 0.2.0(magicast@0.5.2)
-      nuxt-og-image: 5.1.13(@unhead/vue@2.1.10(vue@3.5.29(typescript@5.9.3)))(magicast@0.5.2)(unstorage@1.17.4(db0@0.3.4(better-sqlite3@12.6.2))(ioredis@5.10.0))(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.29(typescript@5.9.3))
+      nuxt-og-image: 5.1.13(@unhead/vue@2.1.10(vue@3.5.29(typescript@5.9.3)))(magicast@0.5.2)(unstorage@1.17.5(db0@0.3.4(better-sqlite3@12.6.2))(ioredis@5.10.0))(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.29(typescript@5.9.3))
       pkg-types: 2.3.0
       scule: 1.3.0
       shiki-stream: 0.1.4(vue@3.5.29(typescript@5.9.3))
@@ -16144,6 +16503,18 @@ snapshots:
     dependencies:
       duplexer: 0.1.2
 
+  h3@1.15.11:
+    dependencies:
+      cookie-es: 1.2.3
+      crossws: 0.3.5
+      defu: 6.1.7
+      destr: 2.0.5
+      iron-webcrypto: 1.2.1
+      node-mock-http: 1.0.4
+      radix3: 1.1.2
+      ufo: 1.6.3
+      uncrypto: 0.1.3
+
   h3@1.15.5:
     dependencies:
       cookie-es: 1.2.2
@@ -17006,6 +17377,8 @@ snapshots:
 
   lru-cache@11.2.6: {}
 
+  lru-cache@11.3.5: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -17461,6 +17834,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.4
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
@@ -17490,6 +17867,13 @@ snapshots:
   mkdirp-classic@0.5.3: {}
 
   mlly@1.8.0:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  mlly@1.8.2:
     dependencies:
       acorn: 8.16.0
       pathe: 2.0.3
@@ -17719,7 +18103,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-og-image@5.1.13(@unhead/vue@2.1.10(vue@3.5.29(typescript@5.9.3)))(magicast@0.5.2)(unstorage@1.17.4(db0@0.3.4(better-sqlite3@12.6.2))(ioredis@5.10.0))(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.29(typescript@5.9.3)):
+  nuxt-og-image@5.1.13(@unhead/vue@2.1.10(vue@3.5.29(typescript@5.9.3)))(magicast@0.5.2)(unstorage@1.17.5(db0@0.3.4(better-sqlite3@12.6.2))(ioredis@5.10.0))(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.29(typescript@5.9.3)):
     dependencies:
       '@nuxt/devtools-kit': 3.2.2(magicast@0.5.2)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
@@ -17750,7 +18134,7 @@ snapshots:
       strip-literal: 3.1.0
       ufo: 1.6.3
       unplugin: 2.3.11
-      unstorage: 1.17.4(db0@0.3.4(better-sqlite3@12.6.2))(ioredis@5.10.0)
+      unstorage: 1.17.5(db0@0.3.4(better-sqlite3@12.6.2))(ioredis@5.10.0)
       unwasm: 0.5.3
       yoga-wasm-web: 0.3.3
     transitivePeerDependencies:
@@ -17784,6 +18168,50 @@ snapshots:
     transitivePeerDependencies:
       - magicast
       - vite
+      - vue
+
+  nuxt-studio@1.6.0(db0@0.3.4(better-sqlite3@12.6.2))(ioredis@5.10.0)(magicast@0.5.2)(vue@3.5.29(typescript@5.9.3)):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.104(zod@4.3.6)
+      '@ai-sdk/vue': 3.0.168(vue@3.5.29(typescript@5.9.3))(zod@4.3.6)
+      '@iconify-json/lucide': 1.2.102
+      '@nuxtjs/mdc': 0.21.1(magicast@0.5.2)
+      '@vueuse/core': 14.2.1(vue@3.5.29(typescript@5.9.3))
+      ai: 6.0.168(zod@4.3.6)
+      defu: 6.1.7
+      destr: 2.0.5
+      js-yaml: 4.1.1
+      minimatch: 10.2.5
+      nuxt-component-meta: 0.17.2(magicast@0.5.2)
+      remark-mdc: 3.10.0
+      shiki: 4.0.2
+      unstorage: 1.17.5(db0@0.3.4(better-sqlite3@12.6.2))(ioredis@5.10.0)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    optionalDependencies:
+      ipx: 3.1.1(db0@0.3.4(better-sqlite3@12.6.2))(ioredis@5.10.0)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - idb-keyval
+      - ioredis
+      - magicast
+      - supports-color
+      - uploadthing
       - vue
 
   nuxt@4.3.1(@parcel/watcher@2.5.6)(@types/node@25.3.3)(@vue/compiler-sfc@3.5.29)(better-sqlite3@12.6.2)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4(better-sqlite3@12.6.2))(eslint@10.0.2(jiti@1.21.7))(ioredis@5.10.0)(lightningcss@1.31.1)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.2):
@@ -19302,6 +19730,17 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  shiki@4.0.2:
+    dependencies:
+      '@shikijs/core': 4.0.2
+      '@shikijs/engine-javascript': 4.0.2
+      '@shikijs/engine-oniguruma': 4.0.2
+      '@shikijs/langs': 4.0.2
+      '@shikijs/themes': 4.0.2
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -20088,6 +20527,20 @@ snapshots:
       db0: 0.3.4(better-sqlite3@12.6.2)
       ioredis: 5.10.0
 
+  unstorage@1.17.5(db0@0.3.4(better-sqlite3@12.6.2))(ioredis@5.10.0):
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.11
+      lru-cache: 11.3.5
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.3
+    optionalDependencies:
+      db0: 0.3.4(better-sqlite3@12.6.2)
+      ioredis: 5.10.0
+
   untun@0.1.3:
     dependencies:
       citty: 0.1.6
@@ -20823,6 +21276,10 @@ snapshots:
       zod: 3.25.76
 
   zod-to-json-schema@3.25.1(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
 


### PR DESCRIPTION
## Summary

Installs `nuxt-studio@^1.6.0` on `docs-site/` so a small internal team can edit content at `docs.dtpr.io/_studio`. Supports **both** Google OAuth (for non-technical editors, commits authored by a shared bot PAT) and GitHub OAuth (for developer editors, commits authored by the signed-in user). Both paths are gated by a moderator email whitelist. The `studio.repository` config points at `helpful-places/dtpr` on `main`, rooted at `docs-site/`.

Ships the full operational runbook at `docs-site/docs/studio-setup.md` (OAuth apps, bot PAT, moderator list, Cloudflare Workers secrets, local dev, troubleshooting), the `.env.example` template, and the original plan doc. The Cloudflare Workers build passes on v1.6.0 (earlier versions break on `ipx`/`sharp-wasm32`).

## Test plan

- [x] `pnpm -F dtpr-docs build` succeeds on the Cloudflare preset.
- [x] `/_studio` loads locally with both provider buttons once `.env` is populated.
- [ ] Whitelisted Google moderator: sign in, edit, save, commit on `main` authored by the bot PAT.
- [ ] Whitelisted GitHub moderator: sign in, edit, save, commit on `main` authored by the signed-in user (not the bot).
- [ ] Non-whitelisted Google account is rejected at login.
- [ ] Non-whitelisted GitHub account is rejected at login.
- [ ] Set all seven secrets via `pnpm -F dtpr-docs exec wrangler secret put`, deploy, repeat the four flows above on `https://docs.dtpr.io/_studio`.
- [ ] `https://docs.dtpr.io/` normal browsing shows no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)