### PR TITLE
docs(dtpr-ai): MCP + REST v2 + icons + @dtpr/ui reference

### DIFF
--- a/docs-site/nuxt.config.ts
+++ b/docs-site/nuxt.config.ts
@@ -7,6 +7,8 @@ export default defineNuxtConfig({
     name: 'Digital Trust for Places & Routines',
   },
 
+  ogImage: { enabled: false },
+
   studio: {
     repository: {
       provider: 'github',

--- a/docs/plans/2026-04-18-001-feat-dtpr-ai-documentation-structure-plan.md
+++ b/docs/plans/2026-04-18-001-feat-dtpr-ai-documentation-structure-plan.md
@@ -1,0 +1,576 @@
+---
+title: "feat: Documentation structure for dtpr.ai microsite (REST v2, MCP, icons, @dtpr/ui)"
+type: feat
+status: active
+date: 2026-04-18
+---
+
+# feat: Documentation structure for dtpr.ai microsite (REST v2, MCP, icons, @dtpr/ui)
+
+## Overview
+
+The DTPR-for-AI microsite at `dtpr.ai` (package `dtpr-ai/`) is currently a one-page Docus placeholder. This plan turns it into the canonical public documentation surface for everything we shipped in the recent API / UI / icon waves: the v2 REST API served from `api.dtpr.io`, the MCP server at `/mcp` (9 tools + 1 resource), the DTPR icon composition pipeline (shapes + symbols + composed variants), and the `@dtpr/ui` component library (core / vue / html). The output is (a) a concrete information architecture and Docus content layout, and (b) per-unit scope for the first docs pass — not the docs themselves.
+
+## Problem Frame
+
+Over the last two weeks we've landed substantial platform surface area:
+
+- `@dtpr/api` — v2 REST + MCP on Cloudflare Workers (PR #262/#263 era, reinforced by icon composition in #270)
+- `@dtpr/ui` — framework-neutral core + Vue SFCs + SSR HTML renderer (#267)
+- `dtpr-ai/` microsite skeleton on Cloudflare Workers (#271)
+- DTPR icon composition pipeline (shape × symbol × variant) with MCP `get_icon_url` and composed-icon REST endpoints (#270)
+
+None of this is documented publicly. Internal READMEs exist (`api/README.md`, `packages/ui/README.md`) but they target contributors, not consumers. MCP clients, REST consumers, and UI adopters currently have to read source or commit messages to learn the surface. `dtpr-ai/` is the AI-focused web surface and — because the MCP server, the `render_datachain` MCP App, and `get_icon_url` all exist for AI clients — it is the natural home for this documentation.
+
+The AI-focused framing matters for structure: developers arriving from AI tooling (Claude, MCP hosts, agentic frameworks) should find MCP-first quickstart and reference, with the REST API available as the underlying HTTP contract and `@dtpr/ui` available for anyone rendering DTPR content in their own surface.
+
+## Requirements Trace
+
+- R1. Publish a coherent IA in `dtpr-ai/content/` that covers MCP, REST v2, icons, `@dtpr/ui`, and a minimal conceptual foundation.
+- R2. Every MCP tool (`list_schema_versions`, `get_schema`, `list_categories`, `list_elements`, `get_element`, `get_elements`, `validate_datachain`, `render_datachain`, `get_icon_url`) has its own reference page with input/output schema, example call, and error/fix-hint coverage.
+- R3. Every REST v2 endpoint (schemas list, manifest, categories, elements list, element detail, validate, shapes, symbols, composed icons) has its own reference page with request/response, headers (version, cache, cors), and error shape.
+- R4. Every `@dtpr/ui` export (6 Vue SFCs, 6 core helpers, 1 SSR helper) has prop/parameter docs with at least one usage example.
+- R5. An MCP-first quickstart walks a reader from "zero" to a working `tools/call` + `resources/read` for `render_datachain`, including required headers.
+- R6. A conceptual section explains DTPR-level ideas (datachain, element, category, version / release, icon composition) enough to read the reference docs without hunting through `docs.dtpr.io`.
+- R7. Navigation is Docus-native — numeric-prefixed directories, `index.md` per section, `app.config.ts` header populated.
+- R8. The existing `dtpr.ai` placeholder landing is replaced with a landing page that orients developers toward the four pillars (MCP, REST, UI, icons).
+- R9. `pnpm --filter ./dtpr-ai build` stays green and the Cloudflare Worker deploys without regressions.
+
+## Scope Boundaries
+
+- Not re-documenting the broader DTPR standard — `docs.dtpr.io` owns design principles, signage, governance, v0/v1 REST. Cross-link, don't duplicate.
+- Not migrating v1 REST docs from `docs-site/` to `dtpr-ai/`. v1 stays where it is; dtpr-ai documents v2 only.
+- Not auto-generating reference from Zod schemas in this pass. Hand-written docs first; the Zod-in, markdown-out toolchain is a future optimization (see Deferred).
+- Not publishing an OpenAPI spec. The v2 REST surface is small enough to hand-author; OpenAPI can follow if third-party consumers need it.
+- Not writing contributor-facing docs (how to add a new category, promote a schema, etc.) — those live in `api/README.md` today and can migrate later if we decide `dtpr-ai/` should host both audiences.
+- Not changing the public API surface of `@dtpr/api` or `@dtpr/ui` in this plan. Documentation reflects what exists; any API tweaks discovered while writing are filed as separate issues.
+- Not introducing interactive / live-runner tooling (e.g., embedded MCP explorer). Markdown + curl + copy-pasteable JSON is sufficient for v1.
+
+### Deferred to Separate Tasks
+
+- **Reference auto-generation from Zod**: once IA is stable, we can generate per-tool and per-endpoint pages from the same Zod schemas the API uses (`api/src/mcp/tools.ts`, `api/src/schema/*`). Separate plan, separate PR.
+- **Contributor/authoring docs in `dtpr-ai/`**: if we want `dtpr-ai/` to host the schema-authoring CLI docs too, that's a follow-up. For this plan, contributor docs stay in `api/README.md` and we link to them.
+- **Docs-site cross-surface decisions**: whether v2 REST docs should *also* be mirrored into `docs-site/content/4.api/v2/` (following the v1 pattern) is an open strategic question — see Open Questions.
+- **Interactive MCP explorer / REST playground**: nice-to-have, not in scope.
+- **OpenAPI / AsyncAPI spec generation**: can follow after the hand-authored pass validates the surface shape.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `api/src/app.ts` — Hono app wiring; shows exact middleware order, route mounts (`/api/v2`, `/mcp`, `/healthz`), and per-route wall-clock budgets. Source of truth for what `dtpr.ai` docs say about base URL + paths.
+- `api/src/rest/routes.ts` — all v2 REST handlers. Endpoints to document: `GET /schemas`, `GET /schemas/:version/manifest`, `GET /schemas/:version/categories`, `GET /schemas/:version/elements` (category_id + query + locale + fields + cursor), `GET /schemas/:version/elements/:element_id`, `POST /schemas/:version/validate`, `GET /shapes/:shape.svg`, `GET /schemas/:version/symbols/:symbol_id.svg`, `GET /schemas/:version/elements/:element_id/icon[.<variant>].svg`.
+- `api/src/mcp/server.ts` — hand-rolled JSON-RPC over HTTP handler (no SSE); documents the wire format (`initialize`, `tools/list`, `tools/call`, `resources/list`, `resources/read`, `ping`), `mcp-session-id` header, and batch behavior. Source of truth for the "Connecting to MCP" page.
+- `api/src/mcp/tools.ts` — 9 tool registry. Each tool has a Zod `inputSchema`, a stable envelope (`ok`/`err` + `meta.content_hash` + `meta.version`), and — for some — `toSoftFailureResult` semantics (validate, render, bulk-get partial). Each tool gets its own reference page.
+- `api/src/mcp/tools/render_datachain.ts` + `api/src/mcp/resources/datachain_resource.ts` — the MCP Apps (SEP-1865) flow: tool returns `_meta.ui.resourceUri = ui://dtpr/datachain/view.html`, `resources/read` returns `text/html;profile=mcp-app`. Sessions keyed by `mcp-session-id`.
+- `api/src/icons/compositor.ts` + `api/src/icons/shapes.ts` + `api/src/icons/color.ts` — shape × symbol × variant composition model. Three variant forms: `default`, `dark`, `{ kind: 'colored', color }`. Source of truth for the "Icon composition" concept page and for `get_icon_url` docs.
+- `api/src/rest/responses.ts` — `X-DTPR-Content-Hash`, `X-DTPR-Version`, `Cache-Control` behavior; `fields` + `locales` projection semantics. Referenced across every REST endpoint doc.
+- `api/src/rest/pagination.ts` — opaque cursor scheme + `MAX_LIMIT`. One dedicated reference page plus inline references.
+- `api/src/middleware/errors.ts` — `ApiError` shape and error codes (`bad_request`, `not_found`, `parse_error`, `unknown_version`, `element_not_found`, `unknown_variant`, etc.). Source of truth for the unified "Errors" page.
+- `api/src/rest/version-resolver.ts` — `ai@2026-04-16` canonical form, alias resolution, error shape on unknown version. Referenced by every version-scoped route.
+- `packages/ui/src/core/index.ts` — 7 framework-neutral exports (`extract`, `extractWithLocale`, `interpolate`, `interpolateSegments`, `groupElementsByCategory`, `sortCategoriesByOrder`, `findCategoryDefinition`, `deriveElementDisplay`, `validateDatachain`, `HEXAGON_FALLBACK_DATA_URI`).
+- `packages/ui/src/vue/index.ts` — 6 SFCs (`DtprIcon`, `DtprElement`, `DtprElementDetail`, `DtprCategorySection`, `DtprDatachain`, `DtprElementGrid`). Each SFC file contains `defineProps` — read each to lift prop signatures into the doc page.
+- `packages/ui/src/html/index.ts` — `renderDatachainDocument` + `RenderedSection` + `RenderDatachainOptions`. SSR pathway for MCP App iframes.
+- `packages/ui/README.md` — existing internal-facing README; valuable as a starting point for the `@dtpr/ui` section but reframe for public consumers.
+- `api/README.md` — existing internal-facing README; valuable context for the authoring section but keep contributor detail out of public docs for now.
+- `docs-site/content/4.api/v1/*.md` — established reference-doc shape: numeric-prefixed files, `title` + `description` frontmatter, Docus MDC components (`::callout`, `::version-switcher`), sample REST shapes with `GET` / `POST` headings. Mirror this structure for `dtpr.ai` REST and MCP references so a reader moving between surfaces feels consistent.
+- `docs-site/content/3.implementation/` — pattern for conceptual/narrative sections (numbered files, single `description`, free-form MDC). Mirror for the concepts section.
+- `dtpr-ai/app.config.ts` / `dtpr-ai/nuxt.config.ts` — existing Docus + Nuxt 4 config. Header title is already `DTPR for AI`; SEO and socials are populated. The `$production` block has the `agents/mcp` stub Docus requires. Extending navigation goes through Docus, not custom Vue pages.
+- `docs-site/` deployment pattern — Nuxt Content auto-switches to D1 on the `cloudflare-module` preset. `dtpr-ai/wrangler.jsonc` already has the D1 binding (`dtpr-ai-content`). Adding content files does not require new bindings.
+
+### Institutional Learnings
+
+- `docs/brainstorms/2026-04-16-dtpr-schema-api-mcp-brainstorm.md` established the envelope shape (`ok` / `errors[]` / `meta`), `content_hash` discipline, soft-failure semantics for validate/render, and `mcp-session-id`-keyed render state — all are user-facing contracts that must be documented.
+- `docs/brainstorms/2026-04-17-dtpr-icon-composition-brainstorm.md` captured why `default` + `dark` are universal and colored variants are per-category (context values) — this is a critical mental model the icon docs must convey.
+- `api/docs/mcp-fallback.md` — why we hand-rolled JSON-RPC instead of using `@modelcontextprotocol/sdk` on workerd. This is operator-relevant and belongs in an "Architecture" appendix rather than on the hot path, but reference docs should note "MCP Streamable HTTP, read-only subset."
+- `docs/plans/2026-04-17-001-feat-dtpr-ai-microsite-placeholder-plan.md` — the placeholder skeleton deliberately shipped with no IA decisions so this documentation plan could make them. The `agents/mcp` stub and `NODE_OPTIONS=--max-old-space-size=4096` quirks are established; don't rediscover them.
+- Recent PRs (#267, #270, #271) show that UI + icons + microsite landed roughly in parallel. Documentation must reflect the shipped state at `2026-04-18`, not a mid-flight snapshot.
+
+### External References
+
+- Docus Content docs — numeric-prefixed directories drive nav order; `navigation.title` frontmatter overrides display name; `::callout` and other MDC components are first-class.
+- Nuxt Content v3 collections — Docus already configures the default collection (`content/`). No additional `content.config.ts` work is required for a text-only docs site; collections only matter if we need typed queries, which we don't.
+- MCP spec 2025-06-18 — read-only subset (`initialize`, `tools/list`, `tools/call`, `resources/list`, `resources/read`). Our wire-format docs should reference this version explicitly, matching `PROTOCOL_VERSION` in `api/src/mcp/server.ts`.
+- MCP Apps SEP-1865 — `text/html;profile=mcp-app` mime type and `_meta.ui.resourceUri` convention. `render_datachain` docs must cite this.
+
+## Key Technical Decisions
+
+- **Single docs home at `dtpr.ai`**: the v2 REST, MCP, icons, and `@dtpr/ui` are the "AI-era" surfaces and belong together on the AI-focused microsite. Rationale: developers integrating an AI client don't care whether a URL they hit is MCP or REST — they care that both are on the same doc surface with shared vocabulary. Splitting across `dtpr.ai` (MCP/UI) and `docs.dtpr.io` (REST) would fracture that. Cross-linking from `docs.dtpr.io/api` to `dtpr.ai` covers the legacy-consumer path.
+- **MCP-first IA, REST as underlying HTTP contract**: top-level sections follow the expected developer journey — "Getting started" → "MCP server" → "REST API" → "Icons" → "UI library" → "Concepts" → "Changelog". MCP sits above REST because the positioning statement (`DTPR for AI`) implies that's the primary integration surface for the audience we're courting.
+- **Hand-written reference in this pass**: emitting pages from Zod schemas is attractive but premature. The surface is small (9 tools, ~9 REST routes, ~13 UI exports). Hand-authoring validates the IA and sets a template; auto-gen can slot in later without rearranging the tree. See Deferred.
+- **Numeric-prefixed directories mirroring `docs-site/`**: reader muscle memory and Docus navigation both benefit from the shared convention. New readers moving between `docs.dtpr.io` and `dtpr.ai` shouldn't have to re-learn layout rules.
+- **`::callout` + `::code-group` MDC, not custom Vue components**: Docus ships these out of the box. A custom "Try it" component or embedded MCP runner is tempting but violates the "no interactive tooling" scope.
+- **One page per MCP tool, one page per REST endpoint**: matches the v1 pattern and gives each unit-of-surface its own stable URL for deep-linking (important for support, Slack, and AI-tool-generated references).
+- **Concepts section comes after reference, not before**: the reference docs are the destination for most sessions; concepts exist to unblock readers who get lost in terminology. Putting concepts first risks making readers scroll past the thing they came for.
+- **`@dtpr/ui` docs target consumers, not internal-only audiences**: the neutrality rule, R2 governance, and build scripts from the current README are contributor-facing and will not be surfaced on `dtpr.ai`. The public docs stay focused on props, slots, and examples.
+- **Changelog is a single page, not per-surface**: one chronological stream, grouped by area via headings. Matches the `docs-site/content/7.changelog/` pattern (a single file there works fine) and avoids forcing readers to merge four separate streams mentally.
+- **No redirects, no sitemap work in this pass**: Docus defaults are adequate for a new docs site. SEO and redirects become interesting once we have inbound traffic to preserve.
+- **Do not block on `docs-site` v2 mirroring decision**: that decision (open question below) affects what we cross-link to, not what we author. Authoring proceeds; cross-links adapt when the decision lands.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Which surfaces are in scope?** All four from the user's request: REST v2, MCP server (tools + resources), icon composition, and `@dtpr/ui`. The schema-authoring CLI is explicitly deferred to contributor docs.
+- **Should we auto-generate from Zod?** Not in this pass. Hand-authored is faster to iterate on IA; auto-gen follows once IA is proven.
+- **Do we need a content config?** No. Docus's default content collection handles the tree we're adding.
+- **How do we handle the placeholder `content/index.md`?** Replace it in Unit 1 with the new landing page; no redirect history to preserve.
+- **Tone / framing?** Developer-reference, third-person, terse. Match `docs-site/` voice.
+
+### Deferred to Implementation
+
+- **Which exact `::callout` variants to use for "note", "warning", "danger"**: Docus defaults are `info`, `warning`, `tip`, `note`. Confirm at first authoring, standardize across pages.
+- **Whether to show curl or fetch first in REST examples**: bikeshed — pick one at first authoring. Weak preference for curl (AI-copy-pasteable).
+- **Whether each MCP tool page includes the tool's full `inputSchema` JSON**: yes in principle, but exact formatting (collapsible? code block? rendered table?) is a first-authoring decision.
+- **Whether `@dtpr/ui` examples use the package name or relative imports**: package name (`import { DtprDatachain } from '@dtpr/ui/vue'`) — matches the current README and is what external consumers will write.
+
+### Deferred to Product / Team
+
+- **Should `docs-site/content/4.api/` get a `v2/` sibling pointing at `dtpr.ai`?** Two options: (a) mirror the v1 structure with a thin v2 index that redirects readers to `dtpr.ai`, or (b) add a prominent callout on `docs.dtpr.io/api` linking out. Weak preference for (b) — avoids maintaining two indices. Flagging for the team; this plan's authoring does not depend on the answer.
+- **Is there an audience for contributor-facing docs (`schema:build`, R2 layout) on `dtpr.ai`?** If yes, add a future "Authoring" section. If no, `api/README.md` stays canonical.
+
+## Output Structure
+
+The plan creates a new Docus content tree under `dtpr-ai/content/`. This is the expected shape at the end of Unit 2–6; Unit 7 populates the changelog.
+
+    dtpr-ai/
+      content/
+        index.md                               # landing (replaces placeholder)
+        1.getting-started/
+          0.index.md                           # "What is DTPR for AI?"
+          1.mcp-quickstart.md                  # zero-to-tools-call in 5 minutes
+          2.rest-quickstart.md                 # zero-to-manifest via curl
+          3.ui-quickstart.md                   # DtprDatachain in a Vue app
+        2.mcp/
+          0.index.md                           # MCP server overview
+          1.connection.md                      # endpoint, headers, wire format, batches
+          2.envelope.md                        # ok / err / _meta + soft-failure semantics
+          3.resources.md                       # ui://dtpr/datachain/view.html + sessions
+          4.tools/
+            0.index.md                         # tool registry + common patterns
+            1.list-schema-versions.md
+            2.get-schema.md
+            3.list-categories.md
+            4.list-elements.md
+            5.get-element.md
+            6.get-elements.md
+            7.validate-datachain.md
+            8.render-datachain.md
+            9.get-icon-url.md
+        3.rest/
+          0.index.md                           # base URL, versioning, CORS, rate limits
+          1.schemas.md                         # GET /schemas
+          2.manifest.md                        # GET /schemas/:version/manifest
+          3.categories.md                      # GET /schemas/:version/categories
+          4.elements-list.md                   # GET /schemas/:version/elements
+          5.element-detail.md                  # GET /schemas/:version/elements/:id
+          6.validate.md                        # POST /schemas/:version/validate
+          7.icons.md                           # GET /shapes, /symbols, /icon[.<variant>]
+          8.pagination-and-fields.md           # cursor, limit, fields, locales
+          9.errors.md                          # shared error shape + codes
+        4.icons/
+          0.index.md                           # shape × symbol × variant mental model
+          1.shapes.md                          # shape primitives
+          2.symbols.md                         # release-pinned symbol SVGs
+          3.composed-variants.md               # default / dark / context colors
+          4.urls.md                            # how to resolve a URL (REST + get_icon_url)
+        5.ui/
+          0.index.md                           # package layout, three subpath exports
+          1.core.md                            # framework-neutral helpers + types
+          2.vue.md                             # 6 SFCs with props + examples
+          3.html.md                            # renderDatachainDocument SSR
+          4.theming.md                         # cascade layer, CSS custom properties
+        6.concepts/
+          0.index.md
+          1.datachains.md
+          2.elements-categories.md
+          3.versions-and-releases.md
+          4.content-hash.md
+        7.changelog.md
+
+**Note:** the per-unit `**Files:**` fields remain authoritative. The implementer may adjust this tree if an authoring pass reveals a cleaner split (e.g., folding `5.ui/3.html.md` into `5.ui/2.vue.md`).
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+Per-page skeleton for reference docs (both MCP tools and REST endpoints):
+
+```markdown
+---
+title: <tool or endpoint name>
+description: <one-line purpose>
+---
+
+# <H1: same name>
+
+::callout{type="info"}
+<one-sentence positioning — what this is for, when to reach for it>
+::
+
+## Summary
+<2–4 lines of prose>
+
+## Request  (REST)  |  Input  (MCP)
+<table or fenced JSON: params, types, required?, description>
+
+## Response  (REST)  |  Output  (MCP)
+<fenced JSON example of success envelope>
+
+## Errors
+<table: code · http (REST only) · meaning · fix hint>
+
+## Example
+::code-group
+```bash [curl]
+curl ...
+```
+```json [tools/call]
+{ "jsonrpc": "2.0", ... }
+```
+::
+
+## See also
+- link to adjacent endpoint / tool
+- link to concept page
+```
+
+This shape carries intentionally across MCP and REST so a reader switching surfaces finds the same sections in the same order.
+
+For `@dtpr/ui` pages, the skeleton is slightly different:
+
+```markdown
+## Import
+<fenced import line>
+
+## Props  |  Parameters
+<table>
+
+## Slots  (Vue only)
+<table>
+
+## Example
+<fenced template + script>
+
+## Notes
+- cascade layer implications
+- SSR caveats (if any)
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: IA scaffolding + navigation config**
+
+**Goal:** Stand up the empty numbered-directory tree, populate the landing page, and wire Docus navigation so every future unit can drop files in place without config changes.
+
+**Requirements:** R1, R7, R8, R9
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `dtpr-ai/content/index.md`
+- Create: `dtpr-ai/content/1.getting-started/0.index.md` (stub)
+- Create: `dtpr-ai/content/2.mcp/0.index.md` (stub)
+- Create: `dtpr-ai/content/3.rest/0.index.md` (stub)
+- Create: `dtpr-ai/content/4.icons/0.index.md` (stub)
+- Create: `dtpr-ai/content/5.ui/0.index.md` (stub)
+- Create: `dtpr-ai/content/6.concepts/0.index.md` (stub)
+- Create: `dtpr-ai/content/7.changelog.md` (stub)
+- Modify (if needed): `dtpr-ai/app.config.ts` (header links or socials updates)
+- Modify (if needed): `dtpr-ai/nuxt.config.ts`
+
+**Approach:**
+- Replace the placeholder `content/index.md` with a landing page that orients to four pillars: MCP server, REST API, icons, UI library. Keep copy under ~200 words; Docus landing renders from frontmatter + first paragraph.
+- Write each section's `0.index.md` as a 1-paragraph section intro + a bulleted list of the section's pages (short, so each later unit can extend in place).
+- Do not introduce custom Vue pages, custom layouts, or Docus overrides. Any navigation tweak should be done via `navigation.title` frontmatter or Docus config — not by hand-rolling a sidebar.
+- Verify `pnpm --filter ./dtpr-ai build` succeeds before moving on; the new tree must not regress the production build.
+
+**Patterns to follow:**
+- `docs-site/content/index.md` + `docs-site/content/1.getting-started/0.index.md` for landing + section-intro shape.
+- `docs-site/nuxt.config.ts` for Docus config style (no custom overrides beyond what's already in `dtpr-ai/nuxt.config.ts`).
+
+**Test scenarios:**
+- Happy path: `pnpm --filter ./dtpr-ai dev` renders landing + six section index pages without console errors.
+- Happy path: navigation (Docus sidebar) lists each section in the numeric order the directories imply.
+- Happy path: `pnpm --filter ./dtpr-ai build` exits 0 with no new warnings beyond the pre-existing `agents/mcp` stub notice.
+- Edge case: each `0.index.md` stub has `title` + `description` frontmatter; Docus does not emit "untitled" in nav.
+
+**Verification:**
+- Local dev server renders the new tree; production build passes.
+
+- [ ] **Unit 2: MCP reference (server + connection + envelope + 9 tools + resource)**
+
+**Goal:** Document the entire MCP surface such that an agent author can go from zero to a working `tools/call` + `resources/read` cycle, including the MCP Apps iframe flow, without reading source.
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** Unit 1 (section scaffolding).
+
+**Files:**
+- Modify: `dtpr-ai/content/2.mcp/0.index.md` (expand from stub)
+- Create: `dtpr-ai/content/2.mcp/1.connection.md`
+- Create: `dtpr-ai/content/2.mcp/2.envelope.md`
+- Create: `dtpr-ai/content/2.mcp/3.resources.md`
+- Create: `dtpr-ai/content/2.mcp/4.tools/0.index.md`
+- Create: `dtpr-ai/content/2.mcp/4.tools/1.list-schema-versions.md`
+- Create: `dtpr-ai/content/2.mcp/4.tools/2.get-schema.md`
+- Create: `dtpr-ai/content/2.mcp/4.tools/3.list-categories.md`
+- Create: `dtpr-ai/content/2.mcp/4.tools/4.list-elements.md`
+- Create: `dtpr-ai/content/2.mcp/4.tools/5.get-element.md`
+- Create: `dtpr-ai/content/2.mcp/4.tools/6.get-elements.md`
+- Create: `dtpr-ai/content/2.mcp/4.tools/7.validate-datachain.md`
+- Create: `dtpr-ai/content/2.mcp/4.tools/8.render-datachain.md`
+- Create: `dtpr-ai/content/2.mcp/4.tools/9.get-icon-url.md`
+
+**Approach:**
+- `connection.md` covers endpoint (`POST /mcp`), `Content-Type: application/json`, `mcp-session-id` header semantics (from `api/src/mcp/server.ts`), protocol version (`2025-06-18`), supported methods, batch + notification behavior, and the "GET returns 405" quirk.
+- `envelope.md` covers the `ok`/`err` payload shape, `_meta.content_hash`, `_meta.version`, `_meta.next_cursor`, and the soft-failure split (`isError: false` with `ok: false`) used by `validate_datachain`, `render_datachain`, and `get_elements` partial results.
+- `resources.md` covers `ui://dtpr/datachain/view.html`, the `text/html;profile=mcp-app` mime type, session keying, and the placeholder-HTML behavior when `resources/read` arrives before any `render_datachain` call.
+- Each tool page follows the MCP reference skeleton in High-Level Technical Design. Pull input shapes straight from `api/src/mcp/tools.ts` Zod schemas; show success and typical-error envelopes; link to related REST endpoints.
+- `render_datachain.md` is longer — it must cover the MCP Apps iframe handoff (`_meta.ui.resourceUri`), the session-scoped HTML slot, and why the client must follow the tool call with a `resources/read` on the same `mcp-session-id`.
+- `get_icon_url.md` cross-links to the icons section (variants, URL layout) rather than duplicating that content.
+
+**Patterns to follow:**
+- `docs-site/content/4.api/v1/1.overview.md` as the overall reference-page shape.
+- Skeleton shown in High-Level Technical Design.
+
+**Test scenarios:**
+- Happy path: each tool page has title, description, one usage example, and an errors table.
+- Happy path: the `render_datachain` page explicitly shows the two-call sequence (`tools/call` → `resources/read`) with matching `mcp-session-id`.
+- Happy path: `envelope.md` shows both a success envelope and at least one `err` envelope with `_meta`.
+- Edge case: `list_elements` and `get_elements` pages mention pagination + the 100-id cap, linking to REST pagination page.
+- Edge case: `validate_datachain` page explains why `ok: false` returns `isError: false` (soft failure).
+- Integration: tool page examples use `api.dtpr.io`, not `api-preview.dtpr.io` or localhost, so copy-paste works out of the box.
+
+**Verification:**
+- A reader can follow `connection.md` + `4.tools/8.render-datachain.md` + `3.resources.md` end-to-end and understand every step of the MCP Apps flow.
+
+- [ ] **Unit 3: REST v2 reference (endpoints + pagination + errors)**
+
+**Goal:** Document the full v2 REST surface served at `api.dtpr.io`, including cross-cutting headers, pagination, field/locale projection, and the unified error shape.
+
+**Requirements:** R1, R3
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `dtpr-ai/content/3.rest/0.index.md`
+- Create: `dtpr-ai/content/3.rest/1.schemas.md`
+- Create: `dtpr-ai/content/3.rest/2.manifest.md`
+- Create: `dtpr-ai/content/3.rest/3.categories.md`
+- Create: `dtpr-ai/content/3.rest/4.elements-list.md`
+- Create: `dtpr-ai/content/3.rest/5.element-detail.md`
+- Create: `dtpr-ai/content/3.rest/6.validate.md`
+- Create: `dtpr-ai/content/3.rest/7.icons.md`
+- Create: `dtpr-ai/content/3.rest/8.pagination-and-fields.md`
+- Create: `dtpr-ai/content/3.rest/9.errors.md`
+
+**Approach:**
+- `0.index.md` covers base URL (`https://api.dtpr.io`), path prefix (`/api/v2`), authentication (none — public read; validate has a stricter rate limit bucket), `X-DTPR-Content-Hash` / `X-DTPR-Version` response headers, `Cache-Control` behavior (from `responses.ts`), and CORS.
+- Each endpoint page follows the REST skeleton in High-Level Technical Design. Pull request/response from `api/src/rest/routes.ts`; use fresh canonical examples (`ai@2026-04-16-beta` if that's the current live version).
+- `7.icons.md` merges the three icon routes (`/shapes/:shape.svg`, `/schemas/:version/symbols/:symbol_id.svg`, `/schemas/:version/elements/:element_id/icon[.<variant>].svg`) onto a single page because they're tightly related; dedicated conceptual coverage lives in `4.icons/`.
+- `8.pagination-and-fields.md` unifies cursor/limit/fields/locales across `list_elements`, `list_categories`, and their MCP equivalents. Linked from each page that supports these parameters.
+- `9.errors.md` enumerates every code surfaced by `api/src/middleware/errors.ts` (`bad_request`, `not_found`, `parse_error`, `unknown_version`, `element_not_found`, `unknown_variant`, etc.) with HTTP status, meaning, and fix_hint example.
+
+**Patterns to follow:**
+- `docs-site/content/4.api/v1/1.overview.md` for the page skeleton.
+- Skeleton shown in High-Level Technical Design.
+
+**Test scenarios:**
+- Happy path: each endpoint page has request, response, headers, errors, and example in consistent order.
+- Happy path: `6.validate.md` shows both a valid and an invalid example and notes that the HTTP status stays 200 in both cases (semantic failure is in the body).
+- Happy path: `9.errors.md` table includes all eight+ codes found in `errors.ts`.
+- Edge case: `4.elements-list.md` shows a cursor round-trip example (first page, then `cursor=<value>`).
+- Edge case: `7.icons.md` shows all three variant URL forms (`icon.svg`, `icon.dark.svg`, `icon.<context>.svg`).
+- Integration: example curls on each page include the version-header + caching headers in the response output so readers see what the real wire format looks like.
+
+**Verification:**
+- A reader with only curl and this section can hit every v2 endpoint successfully and interpret its response.
+
+- [ ] **Unit 4: Icon composition reference (shapes, symbols, variants, URLs)**
+
+**Goal:** Document the shape × symbol × variant mental model, including how categories' `context` field drives per-category colored variants, so a consumer can predict a URL from first principles and understand what they'll get back.
+
+**Requirements:** R1, R3, R4 (partial — covers `DtprIcon` indirectly)
+
+**Dependencies:** Unit 1 (section scaffold); Unit 3 (`rest/7.icons.md` — cross-links).
+
+**Files:**
+- Modify: `dtpr-ai/content/4.icons/0.index.md`
+- Create: `dtpr-ai/content/4.icons/1.shapes.md`
+- Create: `dtpr-ai/content/4.icons/2.symbols.md`
+- Create: `dtpr-ai/content/4.icons/3.composed-variants.md`
+- Create: `dtpr-ai/content/4.icons/4.urls.md`
+
+**Approach:**
+- `0.index.md` presents the compositional model in one diagram or mermaid snippet: `shape (category) + symbol (element) + variant (default | dark | context-colored) → 36×36 SVG`.
+- `1.shapes.md` documents the shape primitives bundled in the worker (from `api/src/icons/shapes.ts`), including when each is used and what the underlying SVG fragment looks like.
+- `2.symbols.md` documents release-pinned symbol SVGs, where they live (R2), and how `element.symbol_id` ties to them.
+- `3.composed-variants.md` is the core conceptual page: `default` (outlined), `dark` (filled), and `{ kind: 'colored', color }` derived from a category's `context.values[].color`. Must explain the `innerColor` luminance rule (from `api/src/icons/color.ts`).
+- `4.urls.md` lays out the URL layout (`/api/v2/schemas/:version/elements/:id/icon[.<variant>].svg`) and shows how to discover valid variants for an element (via `element.icon_variants`). Cross-links to the MCP `get_icon_url` tool and the REST icon routes.
+
+**Patterns to follow:**
+- `docs-site/content/3.implementation/` section for conceptual pages.
+- Existing brainstorm at `docs/brainstorms/2026-04-17-dtpr-icon-composition-brainstorm.md` for mental-model vocabulary.
+
+**Test scenarios:**
+- Happy path: `0.index.md` contains a diagram showing the three-axis composition.
+- Happy path: `3.composed-variants.md` has a worked example of picking a color and showing the resulting `innerColor`.
+- Edge case: `4.urls.md` shows the fallback behavior (`icon_miss_fallback` log) and reassures consumers they'll get a byte-identical response.
+- Edge case: `4.urls.md` documents the `ID_REGEX` constraint on `element_id` and `variant` with the 400 response shape.
+
+**Verification:**
+- A reader can derive the correct icon URL for any (version, element, variant) triple from this section alone.
+
+- [ ] **Unit 5: @dtpr/ui reference (core + vue + html + theming)**
+
+**Goal:** Document every public export across the three `@dtpr/ui` subpaths with props, parameters, slots, usage examples, and theming guidance — focused on consumers, not contributors.
+
+**Requirements:** R1, R4
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `dtpr-ai/content/5.ui/0.index.md`
+- Create: `dtpr-ai/content/5.ui/1.core.md`
+- Create: `dtpr-ai/content/5.ui/2.vue.md`
+- Create: `dtpr-ai/content/5.ui/3.html.md`
+- Create: `dtpr-ai/content/5.ui/4.theming.md`
+
+**Approach:**
+- `0.index.md` explains the three-subpath layering (`core` → `vue`, `core` → `html`, `html` uses `vue` via `@vue/server-renderer`), quick install snippet (`pnpm add @dtpr/ui`), and when a consumer reaches for each subpath.
+- `1.core.md` documents the 10 `core` exports + type exports. Each has: signature (TypeScript), parameters, return, one-line example.
+- `2.vue.md` documents the 6 SFCs with props (read from `defineProps` in each `.vue` file), slots, and a representative example per component. Include a minimal end-to-end example rendering `DtprDatachain` with `@dtpr/ui/vue/styles.css` imported.
+- `3.html.md` documents `renderDatachainDocument`, `RenderedSection`, `RenderDatachainOptions`, and `trustAsHtml`. Include the MCP Apps SSR example (`new Response(html, { headers: { 'content-type': 'text/html;profile=mcp-app' } })`).
+- `4.theming.md` covers the `dtpr` cascade layer and the CSS custom-property token set (from `src/vue/styles.css`). Show both a color override and a font-family override.
+- Do not include the "neutrality governance" rule from the current README — that's a contributor-facing concern.
+
+**Patterns to follow:**
+- `packages/ui/README.md` as a starting point, but reframe for external consumers.
+- `docs-site/content/4.api/v1/` skeleton for per-page shape.
+
+**Test scenarios:**
+- Happy path: `2.vue.md` example uses `@dtpr/ui/vue` + `@dtpr/ui/vue/styles.css` imports and renders a complete datachain.
+- Happy path: `1.core.md` documents every export listed in `packages/ui/src/core/index.ts`.
+- Happy path: `3.html.md` example shows SSR + MCP Apps mime-type header in one snippet.
+- Edge case: `4.theming.md` shows the recommended `@layer` order to integrate with Tailwind.
+- Edge case: `1.core.md` documents `HEXAGON_FALLBACK_DATA_URI` and when an app would use it (missing-icon fallback in `deriveElementDisplay`).
+
+**Verification:**
+- A reader can install `@dtpr/ui`, render a datachain in a Vue app, and render the same datachain server-side from this section alone.
+
+- [ ] **Unit 6: Quickstarts + concepts**
+
+**Goal:** Connect the reference docs with a pragmatic front door (three quickstarts) and a thin conceptual foundation (five concept pages) so readers don't bounce off reference pages when a term is unfamiliar.
+
+**Requirements:** R1, R5, R6
+
+**Dependencies:** Units 2, 3, 5 (quickstarts link into their references); Unit 4 (icons concepts inform `4.icons/0.index.md` cross-links).
+
+**Files:**
+- Modify: `dtpr-ai/content/1.getting-started/0.index.md`
+- Create: `dtpr-ai/content/1.getting-started/1.mcp-quickstart.md`
+- Create: `dtpr-ai/content/1.getting-started/2.rest-quickstart.md`
+- Create: `dtpr-ai/content/1.getting-started/3.ui-quickstart.md`
+- Modify: `dtpr-ai/content/6.concepts/0.index.md`
+- Create: `dtpr-ai/content/6.concepts/1.datachains.md`
+- Create: `dtpr-ai/content/6.concepts/2.elements-categories.md`
+- Create: `dtpr-ai/content/6.concepts/3.versions-and-releases.md`
+- Create: `dtpr-ai/content/6.concepts/4.content-hash.md`
+
+**Approach:**
+- `1.mcp-quickstart.md`: five-minute walkthrough — `initialize` → `tools/list` → `tools/call list_schema_versions` → `tools/call render_datachain` → `resources/read ui://dtpr/datachain/view.html`. One copy-pasteable curl block per step. End with "next: browse the tool reference."
+- `2.rest-quickstart.md`: three calls — `GET /api/v2/schemas` → `GET /schemas/:version/elements` → `POST /schemas/:version/validate` with a minimal instance. End with "next: browse the endpoint reference."
+- `3.ui-quickstart.md`: minimal Vue 3 app rendering `<DtprDatachain :sections="..." />`, fetched from the REST API. ~30 lines of code in total.
+- Each concept page is ≤500 words, focused on what a reader must know to use the reference docs, explicitly linking out to `docs.dtpr.io` for deeper treatment of the standard.
+- `4.content-hash.md` covers why `_meta.content_hash` exists and how it helps AI agents detect schema updates (aligning with the "build tools that invalidate on content_hash change" guidance).
+
+**Patterns to follow:**
+- `docs-site/content/1.getting-started/` for the quickstart arc.
+- `docs-site/content/5.concepts/` for concept-page length and tone.
+
+**Test scenarios:**
+- Happy path: MCP quickstart's five curls can be pasted into a terminal and each succeeds against `api.dtpr.io` (session id reused across calls).
+- Happy path: UI quickstart's code compiles against Vue 3 + `@dtpr/ui/vue` with no additional deps beyond those listed at the top.
+- Edge case: REST quickstart's validate example intentionally triggers one semantic warning so the reader sees the soft-failure body shape.
+- Integration: every concept page has at least one outbound link into the relevant reference section.
+
+**Verification:**
+- A reader landing on `dtpr.ai/getting-started/mcp-quickstart` can complete the flow in one session.
+
+- [ ] **Unit 7: Changelog + cross-links back to docs.dtpr.io**
+
+**Goal:** Seed the changelog with the four shipping waves (API, UI, microsite skeleton, icon composition) so readers can see the "what landed when" history, and add prominent cross-links from `docs.dtpr.io/api` (or a banner) back to `dtpr.ai` for v2-interested readers.
+
+**Requirements:** R1, R9
+
+**Dependencies:** Units 2–6 (changelog references populated pages).
+
+**Files:**
+- Modify: `dtpr-ai/content/7.changelog.md`
+- Modify (if team chooses option (b) from Open Questions): `docs-site/content/4.api/0.index.md` or equivalent — add callout linking to `dtpr.ai` for v2 docs.
+
+**Approach:**
+- Changelog entries grouped by area (`## API`, `## MCP`, `## Icons`, `## @dtpr/ui`, `## Site`), reverse-chronological. Pull dates and PR numbers from `git log` and recent commits on `main`.
+- For `docs-site/` cross-link: a single `::callout{type="info"}` at the top of `4.api/0.index.md` pointing readers at `dtpr.ai` when they're after v2 / MCP / UI reference. Defer the decision whether to do this to the team (see Open Questions).
+- Do not backfill changelog entries for pre-2026-04 work; start the stream at the API + MCP landing.
+
+**Patterns to follow:**
+- `docs-site/content/7.changelog/` for structure.
+
+**Test scenarios:**
+- Happy path: changelog entries map 1:1 to the four shipping waves with correct dates.
+- Happy path: each entry links into a reference page in this site.
+- Edge case: if the cross-link to `docs-site/` is chosen, the callout renders and does not break the existing `4.api/v1` nav.
+
+**Verification:**
+- A reader can find "when did `get_icon_url` land" by browsing the changelog.
+
+## System-Wide Impact
+
+- **Interaction graph:** This plan only adds content files and possibly a short callout in `docs-site/`. No runtime system touched; no API handlers changed.
+- **Error propagation:** N/A (static content).
+- **State lifecycle risks:** N/A — Docus + Nuxt Content builds deterministically from the filesystem. D1 is used only for content queries; new pages require no schema change.
+- **API surface parity:** Documentation adds zero new public surface. Every fact in the docs must already be true in `api/src/**` and `packages/ui/src/**` at author time.
+- **Integration coverage:** The only integration boundary at risk is the Cloudflare Workers build (Nitro `cloudflare-module` preset + `agents/mcp` stub + D1 binding). Unit 1's verification gate (`pnpm --filter ./dtpr-ai build` passing) is the canary.
+- **Unchanged invariants:**
+  - `api/src/**` and `packages/ui/src/**` are read-only for the duration of this plan. Any behavior change discovered during authoring goes to a separate issue or PR.
+  - `docs-site/` v1 content is untouched; only a single outbound callout may be added in Unit 7, subject to the team decision.
+  - `dtpr-ai/wrangler.jsonc`, `dtpr-ai/nuxt.config.ts`, and the `agents/mcp` stub remain as-is (Unit 1 verifies, doesn't modify).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| API or UI behavior drifts between authoring and publishing, making docs wrong on day one. | Each unit pulls examples directly from `api/src/**` and `packages/ui/src/**` at authoring time; run a final `pnpm --filter ./api test && pnpm --filter @dtpr/ui test` pass before the unit 6 landing to catch silent drift. |
+| Docus D1 binding or `agents/mcp` stub regresses on Cloudflare Workers. | Unit 1's verification gate runs a full build; escalate to the `docs-site` team if the stub needs updating (same pattern was fixed twice in `docs-site/`). |
+| The 9-tool MCP + 9-endpoint REST authoring load exceeds one session. | Units 2 and 3 are independent of each other and can land in separate PRs. The plan does not require all of them to ship together. |
+| `@dtpr/ui` prop signatures change before Unit 5 lands, invalidating the doc pass. | Unit 5 reads `defineProps` at authoring time and cites version in the page footer; if we ship breaking UI changes between unit drafts, rebaseline by re-reading the SFCs. |
+| The open strategic question (mirror v2 into `docs-site/`?) pushes back on the whole plan. | Plan is structured so authoring proceeds regardless; the decision affects only the Unit 7 cross-link, not the content tree. |
+| Docus navigation surprises (e.g., nested `4.tools/` directory). | Unit 1 verifies navigation rendering end-to-end; worst case we flatten `4.tools/*` to `4.tools/<name>.md` without nesting — IA degrades gracefully. |
+| Docs-site D1 content collisions. | N/A — `dtpr-ai` uses its own D1 (`dtpr-ai-content`, id `27036ee8-bdae-4183-b5a7-d751dc0bac96`); content namespaces are isolated. |
+
+## Documentation / Operational Notes
+
+- Each reference page should include a "Last updated" footer (manual, matching date format `YYYY-MM-DD`) so readers and agents can spot stale content.
+- Link strategy: internal links use Docus-style relative URLs (`/rest/elements-list`, `/mcp/tools/get-icon-url`); external links to `docs.dtpr.io` are absolute.
+- No new environment variables, secrets, or deploy workflow changes. Cloudflare Workers Builds continues to handle `dtpr-ai/` deploys from `main`.
+- Monitoring: `dtpr.ai` has no product analytics configured. That's consistent with `docs.dtpr.io`. Leave unchanged.
+- Rollout: this is a docs-only change. Units land in separate PRs; each PR's impact is limited to `dtpr-ai/content/` (and possibly one callout in `docs-site/` for Unit 7).
+
+## Sources & References
+
+- Origin document: none — direct-entry plan; user request was "document [the api, packages, and icons] in @dtpr-ai; suggest a structure and documentation plan."
+- Related plan: `docs/plans/2026-04-16-001-feat-dtpr-api-mcp-plan.md`
+- Related plan: `docs/plans/2026-04-17-001-feat-dtpr-component-library-plan.md`
+- Related plan: `docs/plans/2026-04-17-001-feat-dtpr-ai-microsite-placeholder-plan.md`
+- Related plan: `docs/plans/2026-04-17-002-feat-dtpr-icon-composition-plan.md`
+- Related brainstorm: `docs/brainstorms/2026-04-16-dtpr-schema-api-mcp-brainstorm.md`
+- Related brainstorm: `docs/brainstorms/2026-04-17-dtpr-component-library-brainstorm.md`
+- Related brainstorm: `docs/brainstorms/2026-04-17-dtpr-icon-composition-brainstorm.md`
+- Source of truth (API): `api/src/app.ts`, `api/src/rest/routes.ts`, `api/src/mcp/server.ts`, `api/src/mcp/tools.ts`, `api/src/mcp/resources/datachain_resource.ts`, `api/src/mcp/tools/render_datachain.ts`, `api/src/rest/responses.ts`, `api/src/rest/pagination.ts`, `api/src/rest/version-resolver.ts`, `api/src/middleware/errors.ts`, `api/src/icons/compositor.ts`, `api/src/icons/shapes.ts`, `api/src/icons/color.ts`
+- Source of truth (UI): `packages/ui/src/core/index.ts`, `packages/ui/src/vue/index.ts`, `packages/ui/src/html/index.ts`, `packages/ui/README.md`
+- Existing internal READMEs: `api/README.md`, `packages/ui/README.md`
+- Existing docs site pattern reference: `docs-site/content/4.api/v1/`, `docs-site/content/1.getting-started/`, `docs-site/nuxt.config.ts`
+- Existing dtpr-ai skeleton: `dtpr-ai/content/index.md`, `dtpr-ai/nuxt.config.ts`, `dtpr-ai/app.config.ts`, `dtpr-ai/wrangler.jsonc`
+- Recent PRs: #262/#263 (API + MCP), #267 (@dtpr/ui), #270 (icon composition + `get_icon_url`), #271 (dtpr.ai microsite placeholder)

--- a/dtpr-ai/content/1.getting-started/0.index.md
+++ b/dtpr-ai/content/1.getting-started/0.index.md
@@ -1,0 +1,29 @@
+---
+title: Getting started
+description: What DTPR for AI is, who it's for, and how to pick a quickstart.
+---
+
+# Getting started
+
+**DTPR for AI** is the documentation surface for the AI-era of the [Digital Trust for Places & Routines](https://docs.dtpr.io) standard. If you are integrating DTPR from an MCP host, an HTTP client, or a web or server-side rendering surface, this site is for you.
+
+## Who this is for
+
+- **MCP client authors** building agent integrations against `https://api.dtpr.io/mcp`.
+- **REST consumers** pulling schemas, elements, validating datachains, or fetching composed icons over HTTPS.
+- **Frontend / SSR developers** embedding DTPR content with [`@dtpr/ui`](/ui) in Vue apps, MCP App iframes, or static HTML.
+
+For the broader DTPR standard — design principles, physical signage, governance, v0/v1 REST — see [docs.dtpr.io](https://docs.dtpr.io). This site does not duplicate that material.
+
+## Pick a quickstart
+
+- [MCP quickstart](/getting-started/mcp-quickstart) — `initialize` → `tools/call list_schema_versions` → `render_datachain` + `resources/read`.
+- [REST quickstart](/getting-started/rest-quickstart) — three curls against `api.dtpr.io/api/v2`.
+- [UI quickstart](/getting-started/ui-quickstart) — render a datachain in a minimal Vue 3 app with `@dtpr/ui/vue`.
+
+## Where to go next
+
+- [MCP server reference](/mcp) — tool and resource reference with envelope semantics.
+- [REST v2 reference](/rest) — endpoint reference with headers, pagination, and errors.
+- [Icon composition](/icons) — shape × symbol × variant mental model.
+- [Concepts](/concepts) — vocabulary you will see across the reference.

--- a/dtpr-ai/content/1.getting-started/1.mcp-quickstart.md
+++ b/dtpr-ai/content/1.getting-started/1.mcp-quickstart.md
@@ -1,0 +1,98 @@
+---
+title: MCP quickstart
+description: Zero to a working render_datachain + resources/read in five calls.
+---
+
+# MCP quickstart
+
+::callout{type="info"}
+Five curls. Five minutes. Ends with a rendered datachain HTML document fetched from the MCP Apps resource.
+::
+
+All calls target `https://api.dtpr.io/mcp` and use the same `mcp-session-id` so the rendered document persists between them.
+
+```bash
+SID=$(uuidgen)
+```
+
+## 1. Initialize
+
+```bash
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  -H "mcp-session-id: $SID" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"initialize"}'
+```
+
+Response includes `protocolVersion: "2025-06-18"` and the server capabilities.
+
+## 2. List tools
+
+```bash
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  -H "mcp-session-id: $SID" \
+  --data '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+```
+
+Returns the nine tools documented at [MCP tools](/mcp/tools).
+
+## 3. Discover schema versions
+
+```bash
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  -H "mcp-session-id: $SID" \
+  --data '{
+    "jsonrpc":"2.0","id":3,
+    "method":"tools/call",
+    "params":{"name":"list_schema_versions","arguments":{"datachain_type":"ai"}}
+  }'
+```
+
+Pick a canonical version from `data.versions[].id` for step 4.
+
+## 4. Render a datachain
+
+```bash
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  -H "mcp-session-id: $SID" \
+  --data '{
+    "jsonrpc":"2.0","id":4,
+    "method":"tools/call",
+    "params":{
+      "name":"render_datachain",
+      "arguments":{
+        "version":"ai@2026-04-16-beta",
+        "datachain":{
+          "schema_version":"ai@2026-04-16-beta",
+          "elements":[{"element_id":"purpose.example","category_id":"purpose"}]
+        }
+      }
+    }
+  }'
+```
+
+The response's `_meta.ui.resourceUri` is `ui://dtpr/datachain/view.html`. Step 5 fetches that HTML.
+
+## 5. Read the rendered HTML
+
+```bash
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  -H "mcp-session-id: $SID" \
+  --data '{
+    "jsonrpc":"2.0","id":5,
+    "method":"resources/read",
+    "params":{"uri":"ui://dtpr/datachain/view.html"}
+  }'
+```
+
+The response body carries the full HTML document (mime type `text/html;profile=mcp-app`). Hand it to your iframe's `srcdoc`.
+
+## Next
+
+- Browse the full [MCP tool reference](/mcp/tools).
+- Learn the [envelope + soft-failure pattern](/mcp/envelope).
+- Understand [MCP Apps resources](/mcp/resources).

--- a/dtpr-ai/content/1.getting-started/2.rest-quickstart.md
+++ b/dtpr-ai/content/1.getting-started/2.rest-quickstart.md
@@ -1,0 +1,65 @@
+---
+title: REST quickstart
+description: Three curls against the v2 REST API.
+---
+
+# REST quickstart
+
+::callout{type="info"}
+Three calls. No auth. All responses are JSON.
+::
+
+## 1. List schema versions
+
+```bash
+curl -s https://api.dtpr.io/api/v2/schemas
+```
+
+```json
+{
+  "ok": true,
+  "versions": [
+    { "id": "ai@2026-04-16-beta", "status": "beta", "content_hash": "sha256-…", "aliases": ["ai@latest"] }
+  ]
+}
+```
+
+## 2. Fetch elements
+
+```bash
+curl -s "https://api.dtpr.io/api/v2/schemas/ai@2026-04-16-beta/elements?fields=all&limit=5"
+```
+
+```json
+{
+  "ok": true,
+  "version": "ai@2026-04-16-beta",
+  "elements": [
+    { "id": "purpose.example", "title": [...], "category_id": "purpose" }
+  ],
+  "meta": { "total": 127, "returned": 5, "next_cursor": "eyJvZmZzZXQiOjV9" }
+}
+```
+
+Pass `meta.next_cursor` back as `?cursor=…` to paginate.
+
+## 3. Validate a datachain (with a deliberate warning)
+
+```bash
+curl -s https://api.dtpr.io/api/v2/schemas/ai@2026-04-16-beta/validate \
+  -H 'content-type: application/json' \
+  --data '{
+    "schema_version": "ai@2026-04-16-beta",
+    "elements": [
+      { "element_id": "purpose.example", "category_id": "purpose", "label": "" }
+    ]
+  }'
+```
+
+The HTTP status is **200** in both valid and invalid cases; the semantic answer is in the body. With the empty label above, expect a warning such as `placement_label_empty` (non-blocking) or an `ok:false` envelope whose `errors[]` indicates missing required categories.
+
+## Next
+
+- Browse the full [REST reference](/rest).
+- Learn about [pagination & projection](/rest/pagination-and-fields).
+- See the [canonical error codes](/rest/errors).

--- a/dtpr-ai/content/1.getting-started/3.ui-quickstart.md
+++ b/dtpr-ai/content/1.getting-started/3.ui-quickstart.md
@@ -1,0 +1,83 @@
+---
+title: UI quickstart
+description: Render a datachain in a Vue 3 app with @dtpr/ui/vue.
+---
+
+# UI quickstart
+
+::callout{type="info"}
+Minimal Vue 3 + Vite app. Fetches a datachain's elements and renders `<DtprDatachain>`.
+::
+
+## Install
+
+```bash
+pnpm create vite@latest dtpr-demo -- --template vue-ts
+cd dtpr-demo
+pnpm add @dtpr/ui
+```
+
+## App.vue
+
+```vue
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import {
+  DtprDatachain,
+  DtprElementDetail,
+  DtprElementGrid,
+} from '@dtpr/ui/vue'
+import '@dtpr/ui/vue/styles.css'
+import { deriveElementDisplay, groupElementsByCategory } from '@dtpr/ui/core'
+import type { Element, Category } from '@dtpr/ui/vue'
+
+const BASE = 'https://api.dtpr.io/api/v2'
+const VERSION = 'ai@2026-04-16-beta'
+
+const categories = ref<Category[]>([])
+const byCategory = ref<Record<string, Element[]>>({})
+const ready = ref(false)
+
+onMounted(async () => {
+  const [catsRes, elsRes] = await Promise.all([
+    fetch(`${BASE}/schemas/${VERSION}/categories`).then((r) => r.json()),
+    fetch(`${BASE}/schemas/${VERSION}/elements?fields=all&limit=200`).then((r) => r.json()),
+  ])
+  categories.value = catsRes.categories
+  byCategory.value = groupElementsByCategory(elsRes.elements)
+  ready.value = true
+})
+</script>
+
+<template>
+  <main v-if="ready">
+    <DtprDatachain :sections="categories.map((c) => ({ id: c.id, title: c.name[0]?.value ?? c.id }))">
+      <template
+        v-for="c in categories"
+        :key="c.id"
+        #[`section-${c.id}`]
+      >
+        <DtprElementGrid>
+          <DtprElementDetail
+            v-for="el in byCategory[c.id] ?? []"
+            :key="el.id"
+            :display="deriveElementDisplay(el, undefined, 'en')"
+          />
+        </DtprElementGrid>
+      </template>
+    </DtprDatachain>
+  </main>
+</template>
+```
+
+## Run
+
+```bash
+pnpm dev
+```
+
+## Next
+
+- Browse every [Vue component](/ui/vue).
+- Read the [core helpers](/ui/core).
+- Customize the look via [theming](/ui/theming).

--- a/dtpr-ai/content/2.mcp/0.index.md
+++ b/dtpr-ai/content/2.mcp/0.index.md
@@ -1,0 +1,43 @@
+---
+title: MCP server
+description: Overview of the DTPR MCP server — endpoint, tools, resources, envelope semantics.
+---
+
+# MCP server
+
+The DTPR MCP server exposes the DTPR schema, datachain validation, datachain rendering, and icon URL resolution as [Model Context Protocol](https://modelcontextprotocol.io) tools and resources. It is hosted at:
+
+```
+POST https://api.dtpr.io/mcp
+```
+
+It implements a read-only subset of the MCP **Streamable HTTP** transport (spec version `2025-06-18`) plus **MCP Apps** (SEP-1865) for the render flow.
+
+## In this section
+
+- [Connecting](/mcp/connection) — endpoint, `mcp-session-id` header, wire format, batching.
+- [Envelope](/mcp/envelope) — `ok` / `err` payloads, `_meta.content_hash`, soft-failure semantics.
+- [Resources](/mcp/resources) — the `ui://dtpr/datachain/view.html` MCP App resource.
+- [Tools](/mcp/tools) — the 9-tool registry, one page each.
+
+## Tools at a glance
+
+| Tool | Purpose |
+|------|---------|
+| [`list_schema_versions`](/mcp/tools/list-schema-versions) | Discover available schema releases and aliases. |
+| [`get_schema`](/mcp/tools/get-schema) | Manifest for a single schema version. |
+| [`list_categories`](/mcp/tools/list-categories) | Categories within a schema version. |
+| [`list_elements`](/mcp/tools/list-elements) | Paginated element list with filters. |
+| [`get_element`](/mcp/tools/get-element) | Single element with icon variants + symbol. |
+| [`get_elements`](/mcp/tools/get-elements) | Bulk fetch, up to 100 element ids. |
+| [`validate_datachain`](/mcp/tools/validate-datachain) | Validate a datachain instance; soft-failure. |
+| [`render_datachain`](/mcp/tools/render-datachain) | Render a datachain + hand off to an iframe via `resources/read`. |
+| [`get_icon_url`](/mcp/tools/get-icon-url) | Resolve a composed-icon SVG URL. |
+
+All tools share the same [envelope](/mcp/envelope) shape.
+
+## Related
+
+- [REST API (v2)](/rest) — the underlying HTTP contract.
+- [Icon composition](/icons) — the mental model behind `get_icon_url` and the icon REST routes.
+- [Concepts](/concepts) — DTPR vocabulary.

--- a/dtpr-ai/content/2.mcp/1.connection.md
+++ b/dtpr-ai/content/2.mcp/1.connection.md
@@ -1,0 +1,110 @@
+---
+title: Connecting
+description: Endpoint, headers, wire format, and batch behavior for the DTPR MCP server.
+---
+
+# Connecting
+
+::callout{type="info"}
+The DTPR MCP server implements a read-only subset of the Model Context Protocol over Streamable HTTP. There is no SSE channel and no server-initiated notifications.
+::
+
+## Endpoint
+
+```
+POST https://api.dtpr.io/mcp
+```
+
+| Header | Value | Required |
+|--------|-------|----------|
+| `Content-Type` | `application/json` | yes |
+| `Accept` | `application/json` | recommended |
+| `mcp-session-id` | Any opaque string chosen by the client | yes for `render_datachain` → `resources/read` |
+
+`GET /mcp` returns **405 Method Not Allowed**. Server-initiated streams are not supported.
+
+## Protocol version
+
+The server advertises protocol version **`2025-06-18`** in the `initialize` response. The `initialize` handshake is optional — you can call `tools/list` or `tools/call` directly — but clients that implement it will receive the capability set.
+
+## Supported methods
+
+| Method | Response shape |
+|--------|----------------|
+| `initialize` | `{ protocolVersion, serverInfo, capabilities }` |
+| `notifications/initialized` | no response (notification) |
+| `initialized` | no response (unprefixed alias) |
+| `tools/list` | `{ tools: ToolDescriptor[] }` |
+| `tools/call` | `{ structuredContent, content, isError? }` |
+| `resources/list` | `{ resources: ResourceDescriptor[] }` |
+| `resources/read` | `{ contents: [{ uri, mimeType, text }] }` |
+| `ping` | `{}` |
+
+Unknown methods return JSON-RPC error `-32601 Method not found`.
+
+## Sessions
+
+`mcp-session-id` isolates cross-call state per session. Its only current use is the `render_datachain` → `resources/read ui://dtpr/datachain/view.html` handshake: the HTML produced by a tool call lands in a per-session slot and is returned verbatim to the `resources/read` on the same session id.
+
+Clients that omit the header share a single fallback slot (`__dtpr_default_session__`). Concurrent callers that both omit the header can read each other's last-rendered HTML — set `mcp-session-id` to a per-session value to avoid that.
+
+## Batch requests
+
+A JSON array of JSON-RPC requests is processed sequentially; responses are returned in a matching array. Per JSON-RPC 2.0 §6, a batch containing only notifications produces no response body — the server returns **HTTP 204 No Content** instead of an empty array.
+
+## Wire format
+
+```http
+POST /mcp HTTP/1.1
+Host: api.dtpr.io
+Content-Type: application/json
+Accept: application/json
+mcp-session-id: 01HR...
+
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
+```
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2025-06-18",
+    "serverInfo": { "name": "dtpr-api", "version": "0.1.0" },
+    "capabilities": { "tools": {}, "resources": {} }
+  }
+}
+```
+
+## Example: initialize + list tools
+
+::code-group
+```bash [curl]
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  -H 'mcp-session-id: demo-session' \
+  --data '[
+    {"jsonrpc":"2.0","id":1,"method":"initialize"},
+    {"jsonrpc":"2.0","id":2,"method":"tools/list"}
+  ]'
+```
+
+```json [wire]
+[
+  { "jsonrpc": "2.0", "id": 1, "method": "initialize" },
+  { "jsonrpc": "2.0", "id": 2, "method": "tools/list" }
+]
+```
+::
+
+## Notes
+
+- **No SSE.** A single POST returns a single JSON response. If your MCP client insists on `text/event-stream`, use a Streamable-HTTP-aware transport that falls through to JSON.
+- **JSON-RPC 2.0 strictness.** `jsonrpc` must be exactly `"2.0"`; other values return `-32600 Invalid Request`.
+- **Why hand-rolled.** The `@modelcontextprotocol/sdk` server transport pulls CJS-only `Ajv`, which workerd's `nodejs_compat` cannot load. See [`api/docs/mcp-fallback.md`](https://github.com/helpful-places/dtpr/blob/main/api/docs/mcp-fallback.md) for the full rationale.
+
+## See also
+
+- [Envelope](/mcp/envelope) — `ok` / `err` / `_meta` shape.
+- [Resources](/mcp/resources) — the `ui://dtpr/datachain/view.html` MCP App resource.
+- [Tools](/mcp/tools) — the 9 tools.

--- a/dtpr-ai/content/2.mcp/2.envelope.md
+++ b/dtpr-ai/content/2.mcp/2.envelope.md
@@ -1,0 +1,118 @@
+---
+title: Envelope
+description: ok / err payload shape, _meta fields, and soft-failure semantics shared across every tool.
+---
+
+# Envelope
+
+::callout{type="info"}
+Every DTPR MCP tool returns the same `{ ok, data | errors, meta }` envelope, embedded in the MCP tool-result shape. REST consumers see the identical body shape without the MCP wrapper.
+::
+
+## Success envelope
+
+```json
+{
+  "ok": true,
+  "data": { "...": "..." },
+  "meta": {
+    "content_hash": "sha256-…",
+    "version": "ai@2026-04-16-beta",
+    "next_cursor": null
+  }
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `ok` | `true` for success. |
+| `data` | Tool-specific payload (see each tool page). |
+| `meta.content_hash` | Hex content hash of the schema version being read. Stable across reads of the same version. |
+| `meta.version` | Canonical schema version, e.g. `ai@2026-04-16-beta`. |
+| `meta.next_cursor` | Opaque pagination cursor for `list_elements` / `list_categories`. `null` on the final page. |
+| `meta.warnings` | Optional array of short strings. Emitted by `validate_datachain` / `render_datachain` when a non-blocking issue was found. |
+
+## Error envelope
+
+```json
+{
+  "ok": false,
+  "errors": [
+    {
+      "code": "element_not_found",
+      "message": "Element 'missing_element' not found in ai@2026-04-16-beta.",
+      "path": "elements[0].element_id",
+      "fix_hint": "Use list_elements to enumerate available elements."
+    }
+  ],
+  "meta": { "version": "ai@2026-04-16-beta" }
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `errors[].code` | Stable machine-readable code. See [Errors](/rest/errors). |
+| `errors[].message` | Human-readable diagnostic. |
+| `errors[].path` | Optional JSON path pointing into the caller's payload. |
+| `errors[].fix_hint` | Optional short instruction for a human or agent. |
+
+## MCP wrapping
+
+Tools return the envelope twice — as typed `structuredContent` for 2025-06-18-capable clients, and as a JSON string inside `content[0].text` for older clients:
+
+```json
+{
+  "structuredContent": { "ok": true, "data": { "...": "..." }, "meta": { "...": "..." } },
+  "content": [
+    { "type": "text", "text": "{\"ok\":true,\"data\":{...},\"meta\":{...}}" }
+  ]
+}
+```
+
+Both carry the same payload; read whichever your client supports.
+
+## `isError` and soft-failure
+
+Hard failures (transport, arguments, unknown version, internal error) surface with `isError: true` in the tool result. The MCP client should treat them like exceptions.
+
+**Soft failures** — where the call ran successfully but the *answer* is "no" or "invalid" — set `ok: false` without setting `isError`. The client should read the envelope and display the semantic result.
+
+The soft-failure pattern is used by three tools:
+
+| Tool | Soft-failure case |
+|------|-------------------|
+| [`validate_datachain`](/mcp/tools/validate-datachain) | Instance is well-formed but semantically invalid (missing required categories, wrong element placement, etc.). |
+| [`render_datachain`](/mcp/tools/render-datachain) | Same semantic validation as above; rendering aborts rather than returning a broken document. |
+| [`get_elements`](/mcp/tools/get-elements) | One or more requested element ids were not found. The response includes successful hits plus `null` entries for misses. |
+
+### Soft-failure example (`validate_datachain`)
+
+```json
+{
+  "structuredContent": {
+    "ok": false,
+    "errors": [
+      {
+        "code": "element_required",
+        "message": "Category 'purpose' requires at least one element.",
+        "path": "elements",
+        "fix_hint": "Add an element with category_id='purpose'."
+      }
+    ],
+    "meta": {
+      "content_hash": "sha256-…",
+      "version": "ai@2026-04-16-beta",
+      "warnings": []
+    }
+  },
+  "content": [{ "type": "text", "text": "..." }]
+}
+```
+
+Note the absence of `isError`. The client learned the datachain is invalid; the call itself succeeded.
+
+## See also
+
+- [Errors](/rest/errors) — canonical list of `code` values.
+- [`validate_datachain`](/mcp/tools/validate-datachain) — the flagship soft-failure tool.
+- [`get_elements`](/mcp/tools/get-elements) — partial-success pattern.

--- a/dtpr-ai/content/2.mcp/3.resources.md
+++ b/dtpr-ai/content/2.mcp/3.resources.md
@@ -1,0 +1,107 @@
+---
+title: Resources
+description: The ui://dtpr/datachain/view.html MCP App resource and session-scoped rendering.
+---
+
+# Resources
+
+::callout{type="info"}
+DTPR exposes one MCP resource — an [MCP App](https://modelcontextprotocol.io) HTML document produced by the [`render_datachain`](/mcp/tools/render-datachain) tool.
+::
+
+## Resource descriptor
+
+```json
+{
+  "uri": "ui://dtpr/datachain/view.html",
+  "name": "DTPR Datachain View",
+  "description": "Rendered DTPR datachain HTML (MCP App iframe)",
+  "mimeType": "text/html;profile=mcp-app"
+}
+```
+
+The `text/html;profile=mcp-app` mime type is the MCP Apps convention (SEP-1865) for HTML that an MCP client can embed inside an iframe.
+
+## Session scoping
+
+The HTML returned by `resources/read` is the **last document `render_datachain` produced in the same session**. Sessions are keyed by the `mcp-session-id` request header.
+
+```
+render_datachain   (mcp-session-id: S) → stores HTML in slot S
+resources/read     (mcp-session-id: S) → reads HTML from slot S
+```
+
+Two concurrent clients that each set a unique `mcp-session-id` will not see each other's documents. Clients that omit the header share a single fallback slot (`__dtpr_default_session__`) and may observe cross-talk — [set the header](/mcp/connection) to avoid this.
+
+## Reading before rendering
+
+`resources/read` arriving before any `render_datachain` tool call in the session returns a neutral placeholder:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head><title>DTPR datachain (awaiting tool call)</title>…
+```
+
+This keeps the MCP App UI loadable while the agent is still working.
+
+## End-to-end example
+
+```bash
+SID=$(uuidgen)
+
+# 1. Render the datachain.
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  -H "mcp-session-id: $SID" \
+  --data "{
+    \"jsonrpc\":\"2.0\",\"id\":1,
+    \"method\":\"tools/call\",
+    \"params\":{
+      \"name\":\"render_datachain\",
+      \"arguments\":{
+        \"version\":\"ai@2026-04-16-beta\",
+        \"datachain\":{
+          \"schema_version\":\"ai@2026-04-16-beta\",
+          \"elements\":[{\"element_id\":\"purpose.example\"}]
+        }
+      }
+    }
+  }"
+
+# 2. Fetch the rendered HTML.
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  -H "mcp-session-id: $SID" \
+  --data '{
+    "jsonrpc":"2.0","id":2,
+    "method":"resources/read",
+    "params":{"uri":"ui://dtpr/datachain/view.html"}
+  }'
+```
+
+The second response carries:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "contents": [
+      {
+        "uri": "ui://dtpr/datachain/view.html",
+        "mimeType": "text/html;profile=mcp-app",
+        "text": "<!DOCTYPE html>…"
+      }
+    ]
+  }
+}
+```
+
+Hand `contents[0].text` to your iframe's `srcdoc`.
+
+## See also
+
+- [`render_datachain`](/mcp/tools/render-datachain) — the tool that populates this resource.
+- [Connecting](/mcp/connection) — `mcp-session-id` semantics.
+- [`@dtpr/ui/html`](/ui/html) — the SSR helper that produces the HTML body.

--- a/dtpr-ai/content/2.mcp/4.tools/0.index.md
+++ b/dtpr-ai/content/2.mcp/4.tools/0.index.md
@@ -1,0 +1,34 @@
+---
+title: Tools
+description: The 9 DTPR MCP tools.
+---
+
+# Tools
+
+Every tool returns the same [envelope](/mcp/envelope) shape (`ok`/`errors`/`meta`). Canonical schema version in all examples: `ai@2026-04-16-beta`.
+
+| Tool | Purpose | Pagination | Soft-failure |
+|------|---------|------------|--------------|
+| [`list_schema_versions`](/mcp/tools/list-schema-versions) | Discover versions + aliases. | — | — |
+| [`get_schema`](/mcp/tools/get-schema) | Manifest + categories (+ elements) for a version. | — | — |
+| [`list_categories`](/mcp/tools/list-categories) | Category list with locale filtering. | — | — |
+| [`list_elements`](/mcp/tools/list-elements) | Paginated, searchable, projectable element list. | opaque cursor | — |
+| [`get_element`](/mcp/tools/get-element) | Single element by id. | — | — |
+| [`get_elements`](/mcp/tools/get-elements) | Bulk element read (≤100 ids). | — | per-id |
+| [`validate_datachain`](/mcp/tools/validate-datachain) | Validate an instance against a version. | — | yes |
+| [`render_datachain`](/mcp/tools/render-datachain) | Render an instance + populate the MCP App resource. | — | yes |
+| [`get_icon_url`](/mcp/tools/get-icon-url) | Resolve a composed-icon REST URL. | — | — |
+
+## Shared patterns
+
+- **Version argument** — every read tool takes `version: string`. Accept canonical form `ai@YYYY-MM-DD[-beta]` or an alias returned by `list_schema_versions`.
+- **Errors** — see [Errors](/rest/errors) for the canonical code list. Common codes: `invalid_arguments`, `unknown_version`, `element_not_found`, `unknown_variant`, `parse_error`.
+- **Locale filtering** — pass `locales: ["en"]` (or omit) to keep only specific locales in localized strings.
+- **Field projection** — `list_elements` / `get_element` / `get_elements` accept `fields: ["id","title",…]` or `fields: "all"`.
+- **Pagination** — `list_elements` returns `meta.next_cursor` when there are more rows. Pass it back as `cursor: "…"`. See [REST pagination](/rest/pagination-and-fields).
+
+## See also
+
+- [Connecting](/mcp/connection)
+- [Envelope](/mcp/envelope)
+- [Resources](/mcp/resources)

--- a/dtpr-ai/content/2.mcp/4.tools/1.list-schema-versions.md
+++ b/dtpr-ai/content/2.mcp/4.tools/1.list-schema-versions.md
@@ -1,0 +1,80 @@
+---
+title: list_schema_versions
+description: Enumerate DTPR schema versions and their stability.
+---
+
+# list_schema_versions
+
+::callout{type="info"}
+Start here when you don't yet know which version to pin. Every other tool takes a `version` argument.
+::
+
+## Summary
+
+Returns every registered schema version with its stability status (`stable` / `beta`) and its content hash. The list mirrors the `versions[]` array in `schemas/index.json`.
+
+## Input
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `datachain_type` | `string` | no | Filter to one type, e.g. `"ai"`. Omit to list every version. |
+
+## Output
+
+```json
+{
+  "ok": true,
+  "data": {
+    "versions": [
+      {
+        "id": "ai@2026-04-16-beta",
+        "status": "beta",
+        "content_hash": "sha256-…",
+        "aliases": ["ai@latest"]
+      }
+    ]
+  }
+}
+```
+
+## Errors
+
+| Code | Meaning | Fix |
+|------|---------|-----|
+| `invalid_arguments` | `datachain_type` was not a string. | Pass a string or omit the argument. |
+| `upstream_error` | Schema index read failed. | Retry. |
+
+## Example
+
+::code-group
+```bash [curl]
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  --data '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{
+      "name":"list_schema_versions",
+      "arguments":{"datachain_type":"ai"}
+    }
+  }'
+```
+
+```json [tools/call]
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "list_schema_versions",
+    "arguments": { "datachain_type": "ai" }
+  }
+}
+```
+::
+
+## See also
+
+- [REST `GET /schemas`](/rest/schemas)
+- [`get_schema`](/mcp/tools/get-schema)
+- [Versions & releases](/concepts/versions-and-releases)

--- a/dtpr-ai/content/2.mcp/4.tools/2.get-schema.md
+++ b/dtpr-ai/content/2.mcp/4.tools/2.get-schema.md
@@ -1,0 +1,84 @@
+---
+title: get_schema
+description: Fetch the manifest, categories, and optionally all elements for one schema version.
+---
+
+# get_schema
+
+::callout{type="info"}
+The fastest way to pull an entire schema version in one call. Pair with `include="full"` when you need every element inline.
+::
+
+## Summary
+
+Returns the manifest, datachain-type, and categories for a schema version. Pass `include="full"` to also inline every element — useful for one-shot agent loads, wasteful for narrow reads.
+
+## Input
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `version` | `string` | yes | — | Schema version, e.g. `"ai@2026-04-16-beta"`. |
+| `include` | `"manifest" \| "full"` | no | `"manifest"` | `"full"` inlines every element. |
+
+## Output
+
+```json
+{
+  "ok": true,
+  "data": {
+    "version": "ai@2026-04-16-beta",
+    "manifest": { "content_hash": "sha256-…", "status": "beta", "title": [...], "description": [...] },
+    "datachain_type": { "id": "ai", "categories": [...] },
+    "categories": [ { "id": "purpose", "name": [...], "description": [...] } ],
+    "schema_json": { "...": "..." }
+  },
+  "meta": {
+    "content_hash": "sha256-…",
+    "version": "ai@2026-04-16-beta"
+  }
+}
+```
+
+With `include="full"` the `data` object also carries `"elements": [...]`.
+
+## Errors
+
+| Code | Meaning | Fix |
+|------|---------|-----|
+| `invalid_arguments` | `version` was missing or malformed. | Provide a canonical version. |
+| `unknown_version` | Version is not registered. | Call `list_schema_versions` and pick a valid id. |
+
+## Example
+
+::code-group
+```bash [curl]
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  --data '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{
+      "name":"get_schema",
+      "arguments":{"version":"ai@2026-04-16-beta"}
+    }
+  }'
+```
+
+```json [tools/call]
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "get_schema",
+    "arguments": { "version": "ai@2026-04-16-beta", "include": "full" }
+  }
+}
+```
+::
+
+## See also
+
+- [REST `GET /schemas/:version/manifest`](/rest/manifest)
+- [`list_categories`](/mcp/tools/list-categories), [`list_elements`](/mcp/tools/list-elements) — narrower reads.
+- [Content hash](/concepts/content-hash)

--- a/dtpr-ai/content/2.mcp/4.tools/3.list-categories.md
+++ b/dtpr-ai/content/2.mcp/4.tools/3.list-categories.md
@@ -1,0 +1,86 @@
+---
+title: list_categories
+description: List the categories defined in a schema version, with locale filtering.
+---
+
+# list_categories
+
+::callout{type="info"}
+Small, cheap call. Use it to populate a category picker or learn the category order the schema ships with.
+::
+
+## Summary
+
+Returns every category defined in the schema version, in the order the schema declares. Categories are small — there is no pagination.
+
+## Input
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | `string` | yes | Schema version, e.g. `"ai@2026-04-16-beta"`. |
+| `locales` | `string[]` | no | Locales to retain in localized strings. Omit for every locale. |
+
+## Output
+
+```json
+{
+  "ok": true,
+  "data": {
+    "version": "ai@2026-04-16-beta",
+    "categories": [
+      {
+        "id": "purpose",
+        "name": [ { "locale": "en", "value": "Purpose" } ],
+        "description": [ { "locale": "en", "value": "Why the technology is deployed." } ],
+        "context": { "values": [ { "id": "commercial", "color": "#…", "label": [...] } ] }
+      }
+    ]
+  },
+  "meta": { "content_hash": "sha256-…", "version": "ai@2026-04-16-beta" }
+}
+```
+
+## Errors
+
+| Code | Meaning | Fix |
+|------|---------|-----|
+| `invalid_arguments` | Missing or malformed `version` / non-string entries in `locales`. | Validate the arguments. |
+| `unknown_version` | Version is not registered. | Call `list_schema_versions`. |
+
+## Example
+
+::code-group
+```bash [curl]
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  --data '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{
+      "name":"list_categories",
+      "arguments":{
+        "version":"ai@2026-04-16-beta",
+        "locales":["en"]
+      }
+    }
+  }'
+```
+
+```json [tools/call]
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "list_categories",
+    "arguments": { "version": "ai@2026-04-16-beta", "locales": ["en"] }
+  }
+}
+```
+::
+
+## See also
+
+- [REST `GET /schemas/:version/categories`](/rest/categories)
+- [`list_elements`](/mcp/tools/list-elements) — filter by `category_id`.
+- [Elements & categories](/concepts/elements-categories)

--- a/dtpr-ai/content/2.mcp/4.tools/4.list-elements.md
+++ b/dtpr-ai/content/2.mcp/4.tools/4.list-elements.md
@@ -1,0 +1,121 @@
+---
+title: list_elements
+description: Paginated element list with category filter, BM25 search, projection, and locale filtering.
+---
+
+# list_elements
+
+::callout{type="info"}
+The workhorse read. Default projection is `["id","title","category_id"]`; pass `fields: "all"` for the full element shape.
+::
+
+## Summary
+
+Returns elements in a schema version. Supports filtering by `category_id`, BM25 search via `query`, locale filtering, field projection, and opaque-cursor pagination.
+
+## Input
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `version` | `string` | yes | — | Schema version. |
+| `category_id` | `string` | no | — | Restrict to one category. |
+| `locale` | `string` | no | `"en"` | Locale used for the `query` search. |
+| `locales` | `string[]` | no | — | Locales retained in localized strings. |
+| `query` | `string` | no | — | BM25 search across title (boost 3) + description. |
+| `fields` | `string[] \| "all"` | no | `["id","title","category_id"]` | Field projection. |
+| `limit` | `integer` | no | `50` | Page size (1–200). |
+| `cursor` | `string` | no | — | Opaque cursor from a previous call. |
+
+## Output
+
+```json
+{
+  "ok": true,
+  "data": {
+    "version": "ai@2026-04-16-beta",
+    "elements": [
+      { "id": "purpose.example", "title": [{"locale":"en","value":"Example purpose"}], "category_id": "purpose" }
+    ],
+    "total": 127,
+    "returned": 50
+  },
+  "meta": {
+    "content_hash": "sha256-…",
+    "version": "ai@2026-04-16-beta",
+    "next_cursor": "eyJvZmZzZXQiOjUwfQ=="
+  }
+}
+```
+
+When `meta.next_cursor` is `null`, you reached the end.
+
+## Errors
+
+| Code | Meaning | Fix |
+|------|---------|-----|
+| `invalid_arguments` | Bad argument types (e.g. `limit` out of `[1,200]`, non-string `cursor`). | Fix the call. |
+| `bad_request` | Malformed `cursor` value. | Discard the cursor and re-issue without it. |
+| `unknown_version` | Version is not registered. | Call `list_schema_versions`. |
+
+## Example: paginate through every element
+
+::code-group
+```bash [curl]
+# first page
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  --data '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{
+      "name":"list_elements",
+      "arguments":{
+        "version":"ai@2026-04-16-beta",
+        "fields":"all",
+        "limit":50
+      }
+    }
+  }'
+
+# follow-up page (pass meta.next_cursor from the first response)
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  --data '{
+    "jsonrpc":"2.0","id":2,
+    "method":"tools/call",
+    "params":{
+      "name":"list_elements",
+      "arguments":{
+        "version":"ai@2026-04-16-beta",
+        "fields":"all",
+        "limit":50,
+        "cursor":"eyJvZmZzZXQiOjUwfQ=="
+      }
+    }
+  }'
+```
+
+```json [tools/call]
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "list_elements",
+    "arguments": {
+      "version": "ai@2026-04-16-beta",
+      "category_id": "purpose",
+      "query": "camera",
+      "locales": ["en"],
+      "limit": 25
+    }
+  }
+}
+```
+::
+
+## See also
+
+- [REST `GET /schemas/:version/elements`](/rest/elements-list)
+- [Pagination & fields](/rest/pagination-and-fields)
+- [`get_elements`](/mcp/tools/get-elements) — bulk fetch by id.

--- a/dtpr-ai/content/2.mcp/4.tools/5.get-element.md
+++ b/dtpr-ai/content/2.mcp/4.tools/5.get-element.md
@@ -1,0 +1,94 @@
+---
+title: get_element
+description: Point read for a single element by id, with full projection by default.
+---
+
+# get_element
+
+::callout{type="info"}
+Default projection is `"all"` — you get every field unless you restrict `fields`.
+::
+
+## Summary
+
+Return a single element's full record, including `icon_variants` (the variant keys valid in composed-icon URLs).
+
+## Input
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `version` | `string` | yes | — | Schema version. |
+| `element_id` | `string` | yes | — | Whitelisted to `[a-zA-Z0-9_-]`. |
+| `locales` | `string[]` | no | — | Locales to retain in localized strings. |
+| `fields` | `string[] \| "all"` | no | `"all"` | Field projection. |
+
+## Output
+
+```json
+{
+  "ok": true,
+  "data": {
+    "version": "ai@2026-04-16-beta",
+    "element": {
+      "id": "purpose.example",
+      "title": [{"locale":"en","value":"Example purpose"}],
+      "description": [{"locale":"en","value":"Short description."}],
+      "category_id": "purpose",
+      "symbol_id": "example-symbol",
+      "icon_variants": ["default", "dark", "commercial"],
+      "variables": []
+    }
+  },
+  "meta": { "content_hash": "sha256-…", "version": "ai@2026-04-16-beta" }
+}
+```
+
+## Errors
+
+| Code | Meaning | Fix |
+|------|---------|-----|
+| `invalid_arguments` | Missing / malformed arguments. | Fix the call. |
+| `unknown_version` | Version is not registered. | Call `list_schema_versions`. |
+| `element_not_found` | No element with that id. | Use `list_elements` to enumerate. |
+
+## Example
+
+::code-group
+```bash [curl]
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  --data '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{
+      "name":"get_element",
+      "arguments":{
+        "version":"ai@2026-04-16-beta",
+        "element_id":"purpose.example"
+      }
+    }
+  }'
+```
+
+```json [tools/call]
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "get_element",
+    "arguments": {
+      "version": "ai@2026-04-16-beta",
+      "element_id": "purpose.example",
+      "locales": ["en"]
+    }
+  }
+}
+```
+::
+
+## See also
+
+- [REST `GET /schemas/:version/elements/:element_id`](/rest/element-detail)
+- [`get_elements`](/mcp/tools/get-elements) — bulk read up to 100 ids.
+- [`get_icon_url`](/mcp/tools/get-icon-url) — build icon URLs from `icon_variants`.

--- a/dtpr-ai/content/2.mcp/4.tools/6.get-elements.md
+++ b/dtpr-ai/content/2.mcp/4.tools/6.get-elements.md
@@ -1,0 +1,116 @@
+---
+title: get_elements
+description: Bulk point-read for up to 100 elements in one call, with per-id soft-failure.
+---
+
+# get_elements
+
+::callout{type="info"}
+Use this instead of N parallel `get_element` calls when you have a known id list. Cap is **100 unique ids** after server-side dedupe.
+::
+
+## Summary
+
+Fetch multiple elements by id. Returns a map `{ element_id → element | null }` — missing ids appear as `null` values and surface per-id errors alongside.
+
+## Input
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `version` | `string` | yes | — | Schema version. |
+| `element_ids` | `string[]` | yes | — | 1–100 unique ids (each ≤128 chars). Server-side dedupes. |
+| `locales` | `string[]` | no | — | Locales to retain. |
+| `fields` | `string[] \| "all"` | no | `"all"` | Field projection. |
+
+## Output — all hits
+
+```json
+{
+  "ok": true,
+  "data": {
+    "version": "ai@2026-04-16-beta",
+    "elements": {
+      "purpose.example": { "id": "purpose.example", "...": "..." },
+      "data.camera":     { "id": "data.camera",     "...": "..." }
+    }
+  },
+  "meta": { "content_hash": "sha256-…", "version": "ai@2026-04-16-beta" }
+}
+```
+
+## Output — partial miss (soft-failure)
+
+```json
+{
+  "ok": false,
+  "errors": [
+    {
+      "code": "element_not_found",
+      "message": "Element 'missing.id' not found.",
+      "path": "missing.id",
+      "fix_hint": "Use list_elements to enumerate available elements."
+    }
+  ],
+  "meta": { "content_hash": "sha256-…", "version": "ai@2026-04-16-beta" },
+  "data": {
+    "version": "ai@2026-04-16-beta",
+    "elements": {
+      "purpose.example": { "id": "purpose.example", "...": "..." },
+      "missing.id":      null
+    }
+  }
+}
+```
+
+The MCP tool result sets `isError: false` for this case — hits are preserved, misses surface as errors. See [envelope](/mcp/envelope).
+
+## Errors
+
+| Code | Meaning | Fix |
+|------|---------|-----|
+| `invalid_arguments` | `element_ids` empty / non-string / id too long. | Fix the call. |
+| `element_ids_too_many` | >100 unique ids after dedupe. | Split into batches of ≤100 or use `list_elements`. |
+| `unknown_version` | Version is not registered. | Call `list_schema_versions`. |
+| `element_not_found` | Per-id miss (soft-failure). | Inspect `data.elements[id] === null`. |
+
+## Example
+
+::code-group
+```bash [curl]
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  --data '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{
+      "name":"get_elements",
+      "arguments":{
+        "version":"ai@2026-04-16-beta",
+        "element_ids":["purpose.example","data.camera","missing.id"],
+        "locales":["en"]
+      }
+    }
+  }'
+```
+
+```json [tools/call]
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "get_elements",
+    "arguments": {
+      "version": "ai@2026-04-16-beta",
+      "element_ids": ["purpose.example", "data.camera"]
+    }
+  }
+}
+```
+::
+
+## See also
+
+- [Envelope — soft-failure](/mcp/envelope)
+- [REST pagination & fields](/rest/pagination-and-fields)
+- [`list_elements`](/mcp/tools/list-elements) — when you don't have an id list.

--- a/dtpr-ai/content/2.mcp/4.tools/7.validate-datachain.md
+++ b/dtpr-ai/content/2.mcp/4.tools/7.validate-datachain.md
@@ -1,0 +1,126 @@
+---
+title: validate_datachain
+description: Validate a datachain instance against a schema version — always isError:false.
+---
+
+# validate_datachain
+
+::callout{type="info"}
+Invalid is a successful answer. This tool always returns with `isError: false`; semantic failures surface as `ok: false` in the envelope.
+::
+
+## Summary
+
+Parses a DTPR datachain instance, resolves the schema version, and runs both shape and semantic validation. Returns structured errors with `fix_hint`s agents can feed back into a repair loop.
+
+## Input
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | `string` | yes | Schema version to validate against. |
+| `datachain` | `object` | yes | Datachain instance JSON. See `schema_json.DatachainInstance` on [`get_schema`](/mcp/tools/get-schema). |
+
+## Output — valid
+
+```json
+{
+  "ok": true,
+  "data": {
+    "ok": true,
+    "warnings": [
+      { "code": "placement_label_empty", "message": "…", "path": "elements[2].label" }
+    ]
+  },
+  "meta": { "content_hash": "sha256-…", "version": "ai@2026-04-16-beta" }
+}
+```
+
+Warnings are non-blocking — the instance is valid.
+
+## Output — invalid (soft-failure)
+
+```json
+{
+  "ok": false,
+  "errors": [
+    {
+      "code": "element_required",
+      "message": "Category 'purpose' requires at least one element.",
+      "path": "elements",
+      "fix_hint": "Add an element with category_id='purpose'."
+    },
+    {
+      "code": "parse_error",
+      "message": "Required",
+      "path": "elements.0.element_id",
+      "fix_hint": "Fix the field shape and retry."
+    }
+  ],
+  "meta": {
+    "content_hash": "sha256-…",
+    "version": "ai@2026-04-16-beta",
+    "warnings": ["placement_label_empty: …"]
+  }
+}
+```
+
+The MCP tool result is `isError: false` in **both** cases. See [envelope](/mcp/envelope) for the reasoning.
+
+## Errors
+
+| Code | Meaning | Fix |
+|------|---------|-----|
+| `invalid_arguments` | Missing `version` / non-object `datachain`. | Fix the call. |
+| `parse_error` | Datachain shape is malformed (Zod parse). | Fix the offending field from `errors[].path`. |
+| `unknown_version` | Version is not registered. | Call `list_schema_versions`. |
+| Semantic validator codes | Instance is shape-valid but semantically wrong. | Follow `fix_hint`. |
+
+## Example — valid
+
+::code-group
+```bash [curl]
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  --data '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{
+      "name":"validate_datachain",
+      "arguments":{
+        "version":"ai@2026-04-16-beta",
+        "datachain":{
+          "schema_version":"ai@2026-04-16-beta",
+          "elements":[
+            {"element_id":"purpose.example","category_id":"purpose"}
+          ]
+        }
+      }
+    }
+  }'
+```
+
+```json [tools/call]
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "validate_datachain",
+    "arguments": {
+      "version": "ai@2026-04-16-beta",
+      "datachain": { "schema_version": "ai@2026-04-16-beta", "elements": [] }
+    }
+  }
+}
+```
+::
+
+## Example — invalid
+
+The call above with `elements: []` returns an `ok: false` envelope whose `errors[]` contains one entry per missing required category.
+
+## See also
+
+- [REST `POST /schemas/:version/validate`](/rest/validate)
+- [Envelope — soft-failure](/mcp/envelope)
+- [Datachains](/concepts/datachains)

--- a/dtpr-ai/content/2.mcp/4.tools/8.render-datachain.md
+++ b/dtpr-ai/content/2.mcp/4.tools/8.render-datachain.md
@@ -1,0 +1,157 @@
+---
+title: render_datachain
+description: Render a datachain instance as an MCP App HTML document served via resources/read.
+---
+
+# render_datachain
+
+::callout{type="info"}
+This tool produces an [MCP App](https://modelcontextprotocol.io) — an HTML document an MCP client can embed in an iframe. The tool response carries a short text summary plus `_meta.ui.resourceUri`; the client follows with `resources/read` on the same session to fetch the HTML.
+::
+
+## Summary
+
+Runs the same semantic validation as [`validate_datachain`](/mcp/tools/validate-datachain). On success, renders the instance through [`@dtpr/ui/html`](/ui/html)'s `renderDatachainDocument` and stores the result in the session's MCP App slot. On semantic failure, returns a soft-failure envelope **without** rendering.
+
+## Input
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `version` | `string` | yes | — | Pinned schema version, e.g. `"ai@2026-04-16-beta"`. |
+| `datachain` | `object` | yes | — | Datachain instance JSON. |
+| `locale` | `string` | no | `"en"` | Locale used for rendered strings. |
+
+## Output — success
+
+```json
+{
+  "structuredContent": {
+    "ok": true,
+    "data": {
+      "resource_uri": "ui://dtpr/datachain/view.html",
+      "section_count": 4,
+      "element_count": 7,
+      "warnings": []
+    },
+    "meta": { "content_hash": "sha256-…", "version": "ai@2026-04-16-beta" }
+  },
+  "content": [
+    {
+      "type": "text",
+      "text": "Rendered DTPR datachain with 4 categories and 7 total elements. UI available at ui://dtpr/datachain/view.html.\n- Purpose (2 elements): …"
+    }
+  ],
+  "_meta": {
+    "ui": {
+      "resourceUri": "ui://dtpr/datachain/view.html",
+      "csp": { "resourceDomains": [], "connectDomains": [] }
+    }
+  }
+}
+```
+
+`_meta.ui.resourceUri` is the MCP Apps pointer. Follow up with `resources/read` on the **same `mcp-session-id`** to fetch the HTML body.
+
+## Output — semantic failure (soft-failure)
+
+```json
+{
+  "ok": false,
+  "errors": [
+    {
+      "code": "element_required",
+      "message": "Category 'purpose' requires at least one element.",
+      "path": "elements",
+      "fix_hint": "Add an element with category_id='purpose'."
+    }
+  ],
+  "meta": { "content_hash": "sha256-…", "version": "ai@2026-04-16-beta", "warnings": [] }
+}
+```
+
+No HTML is written when validation fails — the previous session's document (if any) remains untouched.
+
+## Errors
+
+| Code | Meaning | Fix |
+|------|---------|-----|
+| `invalid_arguments` | `version` missing or `locale` invalid. | Fix the call. |
+| `parse_error` | Datachain shape is malformed. | Follow `errors[].path`. |
+| `unknown_version` | Version is not registered. | Call `list_schema_versions`. |
+| Semantic validator codes | Instance is shape-valid but semantically wrong. | Follow `fix_hint`. |
+
+## The two-call sequence
+
+```
+  ┌─ tools/call render_datachain ──┐         slot(session) ← HTML
+  │   mcp-session-id: S            │────────►┌──────────┐
+  │                                │         │ htmlSlots│
+  │                                ◄─────────│  per S   │
+  └────────────────────────────────┘         └──────────┘
+                                                   ▲
+  ┌─ resources/read ui://…────────┐                │
+  │   mcp-session-id: S           │────────────────┘
+  │                               ◄── text/html;profile=mcp-app
+  └───────────────────────────────┘
+```
+
+The `mcp-session-id` header must match on both calls. See [Resources](/mcp/resources) for what `resources/read` returns when called before any `render_datachain`.
+
+## Example
+
+::code-group
+```bash [curl]
+SID=$(uuidgen)
+
+# render
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  -H "mcp-session-id: $SID" \
+  --data "{
+    \"jsonrpc\":\"2.0\",\"id\":1,
+    \"method\":\"tools/call\",
+    \"params\":{
+      \"name\":\"render_datachain\",
+      \"arguments\":{
+        \"version\":\"ai@2026-04-16-beta\",
+        \"datachain\":{
+          \"schema_version\":\"ai@2026-04-16-beta\",
+          \"elements\":[{\"element_id\":\"purpose.example\",\"category_id\":\"purpose\"}]
+        }
+      }
+    }
+  }"
+
+# fetch rendered HTML
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  -H "mcp-session-id: $SID" \
+  --data '{
+    "jsonrpc":"2.0","id":2,
+    "method":"resources/read",
+    "params":{"uri":"ui://dtpr/datachain/view.html"}
+  }'
+```
+
+```json [tools/call]
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "render_datachain",
+    "arguments": {
+      "version": "ai@2026-04-16-beta",
+      "datachain": { "schema_version": "ai@2026-04-16-beta", "elements": [] },
+      "locale": "en"
+    }
+  }
+}
+```
+::
+
+## See also
+
+- [Resources](/mcp/resources) — session-scoped HTML slot.
+- [`@dtpr/ui/html`](/ui/html) — the SSR renderer producing the HTML.
+- [`validate_datachain`](/mcp/tools/validate-datachain) — same validation, no rendering.

--- a/dtpr-ai/content/2.mcp/4.tools/9.get-icon-url.md
+++ b/dtpr-ai/content/2.mcp/4.tools/9.get-icon-url.md
@@ -1,0 +1,89 @@
+---
+title: get_icon_url
+description: Resolve a composed-icon URL for an element + optional variant.
+---
+
+# get_icon_url
+
+::callout{type="info"}
+Handy when you want a single URL to hand off to an image renderer or `<img>` tag. The returned URL is the REST icon route.
+::
+
+## Summary
+
+Given a `(version, element_id, variant?)` triple, returns the composed-icon URL, the content type, and the full `valid_variants` list for that element. The returned URL is **relative** (`/api/v2/…`); prefix `https://api.dtpr.io` to fetch.
+
+## Input
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | `string` | yes | Schema version. |
+| `element_id` | `string` | yes | Whitelisted to `[a-zA-Z0-9_-]`. |
+| `variant` | `string` | no | Variant key. Omit for the default icon. |
+
+## Output
+
+```json
+{
+  "ok": true,
+  "data": {
+    "url": "/api/v2/schemas/ai@2026-04-16-beta/elements/purpose.example/icon.svg",
+    "content_type": "image/svg+xml",
+    "variant": "default",
+    "valid_variants": ["default", "dark", "commercial", "civic"]
+  },
+  "meta": { "content_hash": "sha256-…", "version": "ai@2026-04-16-beta" }
+}
+```
+
+## Errors
+
+| Code | Meaning | Fix |
+|------|---------|-----|
+| `invalid_arguments` | Missing / malformed arguments. | Fix the call. |
+| `unknown_version` | Version is not registered. | Call `list_schema_versions`. |
+| `element_not_found` | No element with that id. | Use `list_elements`. |
+| `unknown_variant` | Variant not valid for this element. | Inspect `valid_variants` in the error `meta` or read `icon_variants` via `get_element`. |
+
+## Example
+
+::code-group
+```bash [curl]
+curl -s https://api.dtpr.io/mcp \
+  -H 'content-type: application/json' \
+  --data '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{
+      "name":"get_icon_url",
+      "arguments":{
+        "version":"ai@2026-04-16-beta",
+        "element_id":"purpose.example",
+        "variant":"dark"
+      }
+    }
+  }'
+```
+
+```json [tools/call]
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "get_icon_url",
+    "arguments": {
+      "version": "ai@2026-04-16-beta",
+      "element_id": "purpose.example",
+      "variant": "commercial"
+    }
+  }
+}
+```
+::
+
+## See also
+
+- [Icon URLs](/icons/urls) — URL layout and variant discovery.
+- [Composed variants](/icons/composed-variants) — `default` / `dark` / context colors.
+- [REST icon routes](/rest/icons) — the underlying HTTP surface.

--- a/dtpr-ai/content/3.rest/0.index.md
+++ b/dtpr-ai/content/3.rest/0.index.md
@@ -1,0 +1,39 @@
+---
+title: REST API (v2)
+description: Overview of the DTPR v2 REST API — base URL, headers, authentication, CORS.
+---
+
+# REST API (v2)
+
+The DTPR v2 REST API is a public, read-only JSON + SVG API hosted at:
+
+```
+https://api.dtpr.io/api/v2
+```
+
+It is the underlying HTTP contract behind the [MCP server](/mcp) — every MCP tool has a REST equivalent. Integrate against whichever surface fits your client.
+
+## In this section
+
+- [`GET /schemas`](/rest/schemas) — list schema versions and aliases.
+- [`GET /schemas/:version/manifest`](/rest/manifest) — schema manifest (title, description, content hash).
+- [`GET /schemas/:version/categories`](/rest/categories) — category list for a version.
+- [`GET /schemas/:version/elements`](/rest/elements-list) — paginated element list with filters.
+- [`GET /schemas/:version/elements/:element_id`](/rest/element-detail) — single element with variants + symbol.
+- [`POST /schemas/:version/validate`](/rest/validate) — validate a datachain instance.
+- [Icon routes](/rest/icons) — shapes, symbols, composed icons.
+- [Pagination + fields + locales](/rest/pagination-and-fields) — cursor semantics, projection.
+- [Errors](/rest/errors) — shared error shape and codes.
+
+## Conventions
+
+- **Authentication:** none. All endpoints are public.
+- **CORS:** all `/api/v2/**` endpoints are `Access-Control-Allow-Origin: *`.
+- **Response headers:** every successful response includes `X-DTPR-Version` (canonical version id) and, where applicable, `X-DTPR-Content-Hash` and `Cache-Control`.
+- **Versioning:** the `:version` path segment accepts a canonical id like `ai@2026-04-16` or an alias like `ai@latest`.
+- **Errors:** see [Errors](/rest/errors) for the shared shape.
+
+## Related
+
+- [MCP server](/mcp) — JSON-RPC surface over the same schema.
+- [Icon composition](/icons) — conceptual background for the icon routes.

--- a/dtpr-ai/content/3.rest/0.index.md
+++ b/dtpr-ai/content/3.rest/0.index.md
@@ -27,10 +27,10 @@ It is the underlying HTTP contract behind the [MCP server](/mcp) — every MCP t
 
 ## Conventions
 
-- **Authentication:** none. All endpoints are public.
-- **CORS:** all `/api/v2/**` endpoints are `Access-Control-Allow-Origin: *`.
-- **Response headers:** every successful response includes `X-DTPR-Version` (canonical version id) and, where applicable, `X-DTPR-Content-Hash` and `Cache-Control`.
-- **Versioning:** the `:version` path segment accepts a canonical id like `ai@2026-04-16` or an alias like `ai@latest`.
+- **Authentication:** none. All endpoints are public. Optional `DTPR-Client: <name>` header moves you to a dedicated rate-limit bucket.
+- **CORS:** requests from an explicit allow-list (`dtpr.io`, `docs.dtpr.io`, `studio.nuxt.com`, localhost, preview subdomains) are permitted. No wildcard. Exposed response headers: `X-Request-Id`, `DTPR-Content-Hash`, `Retry-After`.
+- **Response headers:** version-scoped reads stamp `DTPR-Content-Hash` (hex content hash) and `Cache-Control`. The canonical version is echoed inside the JSON body as `"version"` — there is no `X-DTPR-Version` header.
+- **Versioning:** the `:version` path segment accepts a canonical id like `ai@2026-04-16-beta` or an alias like `ai@latest`.
 - **Errors:** see [Errors](/rest/errors) for the shared shape.
 
 ## Related

--- a/dtpr-ai/content/3.rest/1.schemas.md
+++ b/dtpr-ai/content/3.rest/1.schemas.md
@@ -1,0 +1,67 @@
+---
+title: GET /schemas
+description: List registered DTPR schema versions.
+---
+
+# GET /schemas
+
+::callout{type="info"}
+Start here when discovering which versions are available. Returns the same `versions[]` array that `schemas/index.json` publishes.
+::
+
+## Summary
+
+Enumerates every registered schema version and its stability status. Not version-scoped — no `DTPR-Content-Hash` header is set.
+
+## Request
+
+```
+GET https://api.dtpr.io/api/v2/schemas
+```
+
+No query parameters.
+
+## Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "ok": true,
+  "versions": [
+    {
+      "id": "ai@2026-04-16-beta",
+      "status": "beta",
+      "content_hash": "sha256-…",
+      "aliases": ["ai@latest"]
+    }
+  ]
+}
+```
+
+## Errors
+
+| Code | HTTP | Meaning |
+|------|------|---------|
+| `upstream_error` | 502 | Schema index read failed. Retry. |
+| `internal_error` | 500 | Unexpected server error. |
+
+## Example
+
+::code-group
+```bash [curl]
+curl -s https://api.dtpr.io/api/v2/schemas
+```
+
+```http [wire]
+GET /api/v2/schemas HTTP/1.1
+Host: api.dtpr.io
+```
+::
+
+## See also
+
+- [MCP `list_schema_versions`](/mcp/tools/list-schema-versions) — the MCP equivalent.
+- [`GET /schemas/:version/manifest`](/rest/manifest) — fetch one version's manifest.
+- [Versions & releases](/concepts/versions-and-releases)

--- a/dtpr-ai/content/3.rest/2.manifest.md
+++ b/dtpr-ai/content/3.rest/2.manifest.md
@@ -1,0 +1,72 @@
+---
+title: GET /schemas/:version/manifest
+description: Fetch the manifest for one schema version.
+---
+
+# GET /schemas/:version/manifest
+
+::callout{type="info"}
+The manifest is the smallest document that uniquely identifies a version — title, description, status, and `content_hash`.
+::
+
+## Summary
+
+Returns the manifest for a single schema version. Sets `DTPR-Content-Hash` and `Cache-Control`.
+
+## Request
+
+```
+GET https://api.dtpr.io/api/v2/schemas/:version/manifest
+```
+
+| Path param | Description |
+|------------|-------------|
+| `version` | Canonical schema version (e.g. `ai@2026-04-16-beta`) or alias (`ai@latest`). |
+
+## Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+DTPR-Content-Hash: sha256-…
+Cache-Control: no-store
+
+{
+  "ok": true,
+  "manifest": {
+    "id": "ai@2026-04-16-beta",
+    "status": "beta",
+    "content_hash": "sha256-…",
+    "title": [{"locale":"en","value":"DTPR for AI (beta)"}],
+    "description": [{"locale":"en","value":"…"}]
+  }
+}
+```
+
+Stable versions are served with `Cache-Control: public, max-age=86400, immutable`; beta versions with `Cache-Control: no-store` so authoring iterations land immediately.
+
+## Errors
+
+| Code | HTTP | Meaning |
+|------|------|---------|
+| `bad_request` | 400 | Malformed `:version`. |
+| `not_found` | 404 | Version is not registered. |
+
+## Example
+
+::code-group
+```bash [curl]
+curl -s -i https://api.dtpr.io/api/v2/schemas/ai@2026-04-16-beta/manifest
+```
+
+```http [wire]
+GET /api/v2/schemas/ai@2026-04-16-beta/manifest HTTP/1.1
+Host: api.dtpr.io
+```
+::
+
+## See also
+
+- [MCP `get_schema`](/mcp/tools/get-schema) — returns the manifest plus categories (and optionally elements).
+- [`GET /schemas`](/rest/schemas)
+- [Content hash](/concepts/content-hash)

--- a/dtpr-ai/content/3.rest/3.categories.md
+++ b/dtpr-ai/content/3.rest/3.categories.md
@@ -1,0 +1,78 @@
+---
+title: GET /schemas/:version/categories
+description: List the categories defined in a schema version.
+---
+
+# GET /schemas/:version/categories
+
+::callout{type="info"}
+Small, cheap response. Use for populating category pickers or learning the schema's category order.
+::
+
+## Summary
+
+Returns every category in the schema version, in declaration order. Supports locale filtering.
+
+## Request
+
+```
+GET https://api.dtpr.io/api/v2/schemas/:version/categories
+```
+
+| Param | In | Description |
+|-------|-----|-------------|
+| `version` | path | Canonical version or alias. |
+| `locales` | query | Comma-separated locale codes. E.g. `?locales=en,fr`. Omit for every locale. |
+
+## Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+DTPR-Content-Hash: sha256-…
+Cache-Control: no-store
+
+{
+  "ok": true,
+  "version": "ai@2026-04-16-beta",
+  "categories": [
+    {
+      "id": "purpose",
+      "name": [{"locale":"en","value":"Purpose"}],
+      "description": [{"locale":"en","value":"Why the technology is deployed."}],
+      "shape": "hexagon",
+      "context": {
+        "values": [
+          { "id": "commercial", "color": "#…", "label": [{"locale":"en","value":"Commercial"}] }
+        ]
+      }
+    }
+  ]
+}
+```
+
+## Errors
+
+| Code | HTTP | Meaning |
+|------|------|---------|
+| `bad_request` | 400 | Malformed `:version`. |
+| `not_found` | 404 | Version is not registered. |
+
+## Example
+
+::code-group
+```bash [curl]
+curl -s "https://api.dtpr.io/api/v2/schemas/ai@2026-04-16-beta/categories?locales=en"
+```
+
+```http [wire]
+GET /api/v2/schemas/ai@2026-04-16-beta/categories?locales=en HTTP/1.1
+Host: api.dtpr.io
+```
+::
+
+## See also
+
+- [MCP `list_categories`](/mcp/tools/list-categories)
+- [`GET /schemas/:version/elements`](/rest/elements-list) — filter by `category_id`.
+- [Elements & categories](/concepts/elements-categories)

--- a/dtpr-ai/content/3.rest/4.elements-list.md
+++ b/dtpr-ai/content/3.rest/4.elements-list.md
@@ -1,0 +1,85 @@
+---
+title: GET /schemas/:version/elements
+description: Paginated element list with category filter, BM25 search, projection, and locale filtering.
+---
+
+# GET /schemas/:version/elements
+
+::callout{type="info"}
+The default projection is `["id","title","category_id"]`. Pass `?fields=all` for full records.
+::
+
+## Summary
+
+Return elements in a schema version. Supports filtering by `category_id`, BM25 text search via `query`, opaque-cursor pagination, locale filtering, and field projection.
+
+## Request
+
+```
+GET https://api.dtpr.io/api/v2/schemas/:version/elements
+```
+
+| Param | In | Default | Description |
+|-------|-----|---------|-------------|
+| `version` | path | — | Canonical version or alias. |
+| `category_id` | query | — | Restrict to one category. |
+| `locale` | query | `en` | Locale used for the `query` search. |
+| `locales` | query | — | Comma-separated codes retained in localized strings. |
+| `query` | query | — | BM25 search across title (boost 3) + description. |
+| `fields` | query | `id,title,category_id` | Comma-separated field list or `all`. |
+| `limit` | query | `50` | Integer in `[1, 200]`. |
+| `cursor` | query | — | Opaque cursor from a previous response's `meta.next_cursor`. |
+
+## Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+DTPR-Content-Hash: sha256-…
+Cache-Control: no-store
+
+{
+  "ok": true,
+  "version": "ai@2026-04-16-beta",
+  "elements": [
+    { "id": "purpose.example", "title": [{"locale":"en","value":"Example"}], "category_id": "purpose" }
+  ],
+  "meta": {
+    "total": 127,
+    "returned": 50,
+    "next_cursor": "eyJvZmZzZXQiOjUwfQ=="
+  }
+}
+```
+
+`meta.next_cursor` is `null` on the last page.
+
+## Errors
+
+| Code | HTTP | Meaning |
+|------|------|---------|
+| `bad_request` | 400 | Malformed cursor, non-integer `limit`, `limit > 200`. |
+| `not_found` | 404 | Version is not registered. |
+
+## Example: cursor round-trip
+
+::code-group
+```bash [curl]
+# first page
+curl -s "https://api.dtpr.io/api/v2/schemas/ai@2026-04-16-beta/elements?fields=all&limit=50"
+
+# follow-up page
+curl -s "https://api.dtpr.io/api/v2/schemas/ai@2026-04-16-beta/elements?fields=all&limit=50&cursor=eyJvZmZzZXQiOjUwfQ=="
+```
+
+```http [wire]
+GET /api/v2/schemas/ai@2026-04-16-beta/elements?category_id=purpose&query=camera&locales=en&limit=25 HTTP/1.1
+Host: api.dtpr.io
+```
+::
+
+## See also
+
+- [MCP `list_elements`](/mcp/tools/list-elements)
+- [Pagination & fields](/rest/pagination-and-fields)
+- [`GET /schemas/:version/elements/:element_id`](/rest/element-detail)

--- a/dtpr-ai/content/3.rest/5.element-detail.md
+++ b/dtpr-ai/content/3.rest/5.element-detail.md
@@ -1,0 +1,76 @@
+---
+title: GET /schemas/:version/elements/:element_id
+description: Point read for a single element by id.
+---
+
+# GET /schemas/:version/elements/:element_id
+
+::callout{type="info"}
+Default projection is `all`. Inspect `icon_variants` for the variant keys valid in composed-icon URLs.
+::
+
+## Summary
+
+Return a single element's full record, including its `icon_variants` array.
+
+## Request
+
+```
+GET https://api.dtpr.io/api/v2/schemas/:version/elements/:element_id
+```
+
+| Param | In | Default | Description |
+|-------|-----|---------|-------------|
+| `version` | path | — | Canonical version or alias. |
+| `element_id` | path | — | Whitelisted to `[a-zA-Z0-9_-]`. |
+| `locales` | query | — | Comma-separated locale codes. |
+| `fields` | query | `all` | Comma-separated field list or `all`. |
+
+## Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+DTPR-Content-Hash: sha256-…
+Cache-Control: no-store
+
+{
+  "ok": true,
+  "version": "ai@2026-04-16-beta",
+  "element": {
+    "id": "purpose.example",
+    "title": [{"locale":"en","value":"Example purpose"}],
+    "description": [{"locale":"en","value":"Short description."}],
+    "category_id": "purpose",
+    "symbol_id": "example-symbol",
+    "icon_variants": ["default", "dark", "commercial"],
+    "variables": []
+  }
+}
+```
+
+## Errors
+
+| Code | HTTP | Meaning |
+|------|------|---------|
+| `bad_request` | 400 | Malformed `:version` or `:element_id`. |
+| `not_found` | 404 | Version or element not registered. |
+
+## Example
+
+::code-group
+```bash [curl]
+curl -s "https://api.dtpr.io/api/v2/schemas/ai@2026-04-16-beta/elements/purpose.example?locales=en"
+```
+
+```http [wire]
+GET /api/v2/schemas/ai@2026-04-16-beta/elements/purpose.example HTTP/1.1
+Host: api.dtpr.io
+```
+::
+
+## See also
+
+- [MCP `get_element`](/mcp/tools/get-element)
+- [`GET /schemas/:version/elements`](/rest/elements-list)
+- [Icon URLs](/icons/urls) — build URLs from `icon_variants`.

--- a/dtpr-ai/content/3.rest/6.validate.md
+++ b/dtpr-ai/content/3.rest/6.validate.md
@@ -1,0 +1,138 @@
+---
+title: POST /schemas/:version/validate
+description: Validate a datachain instance against a schema version.
+---
+
+# POST /schemas/:version/validate
+
+::callout{type="warning"}
+The HTTP status is **200** for both `ok: true` and `ok: false`. Validation success/failure is a semantic answer carried in the body — it is not a transport failure.
+::
+
+## Summary
+
+Validate a DTPR datachain instance against a schema version. The response carries structured errors with `fix_hint`s that an agent can feed into a repair loop.
+
+## Request
+
+```
+POST https://api.dtpr.io/api/v2/schemas/:version/validate
+Content-Type: application/json
+
+{ "schema_version": "ai@2026-04-16-beta", "elements": [ /* DatachainInstance */ ] }
+```
+
+| Param | In | Description |
+|-------|-----|-------------|
+| `version` | path | Canonical version or alias. |
+| *(body)* | JSON | A `DatachainInstance`. Shape is published in the schema's `schema_json`. |
+
+## Response — valid
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+DTPR-Content-Hash: sha256-…
+Cache-Control: no-store
+
+{
+  "ok": true,
+  "warnings": [
+    { "code": "placement_label_empty", "message": "…", "path": "elements[2].label" }
+  ]
+}
+```
+
+## Response — invalid
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+DTPR-Content-Hash: sha256-…
+Cache-Control: no-store
+
+{
+  "ok": false,
+  "errors": [
+    {
+      "code": "element_required",
+      "message": "Category 'purpose' requires at least one element.",
+      "path": "elements",
+      "fix_hint": "Add an element with category_id='purpose'."
+    }
+  ],
+  "warnings": []
+}
+```
+
+## Response — malformed JSON body
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "ok": false,
+  "errors": [
+    {
+      "code": "bad_request",
+      "message": "Invalid JSON body.",
+      "fix_hint": "Send a valid JSON datachain-instance payload."
+    }
+  ]
+}
+```
+
+## Response — shape errors (400-adjacent)
+
+When the JSON parses but the datachain shape fails Zod validation, the status stays **200** and the body carries `code: parse_error` entries:
+
+```json
+{
+  "ok": false,
+  "errors": [
+    {
+      "code": "parse_error",
+      "message": "Required",
+      "path": "elements.0.element_id",
+      "fix_hint": "Fix the field shape and retry."
+    }
+  ]
+}
+```
+
+## Errors
+
+| Code | HTTP | Meaning |
+|------|------|---------|
+| `bad_request` | 400 | Invalid JSON body or malformed `:version`. |
+| `not_found` | 404 | Version is not registered. |
+| `parse_error` | 200 | Datachain shape failed Zod validation. |
+| Semantic validator codes | 200 | Shape-valid but semantically wrong (`element_required`, placement / cardinality rules, etc.). |
+
+## Example
+
+::code-group
+```bash [curl]
+curl -s https://api.dtpr.io/api/v2/schemas/ai@2026-04-16-beta/validate \
+  -H 'content-type: application/json' \
+  --data '{
+    "schema_version": "ai@2026-04-16-beta",
+    "elements": [{"element_id":"purpose.example","category_id":"purpose"}]
+  }'
+```
+
+```http [wire]
+POST /api/v2/schemas/ai@2026-04-16-beta/validate HTTP/1.1
+Host: api.dtpr.io
+Content-Type: application/json
+
+{"schema_version":"ai@2026-04-16-beta","elements":[…]}
+```
+::
+
+## See also
+
+- [MCP `validate_datachain`](/mcp/tools/validate-datachain) — same validator with the MCP soft-failure envelope.
+- [MCP envelope — soft-failure](/mcp/envelope)
+- [Datachains](/concepts/datachains)

--- a/dtpr-ai/content/3.rest/7.icons.md
+++ b/dtpr-ai/content/3.rest/7.icons.md
@@ -1,0 +1,105 @@
+---
+title: Icon routes
+description: Shape primitives, release-pinned symbols, and composed element icons.
+---
+
+# Icon routes
+
+::callout{type="info"}
+Three related SVG routes. All return `Content-Type: image/svg+xml; charset=utf-8`. Cache-Control varies by version stability (see [conventions](/rest)).
+::
+
+## Summary
+
+| Route | Purpose | Versioned? |
+|-------|---------|------------|
+| `GET /api/v2/shapes/:shape.svg` | Bare shape primitive. | no |
+| `GET /api/v2/schemas/:version/symbols/:symbol_id.svg` | Release-pinned symbol SVG. | yes |
+| `GET /api/v2/schemas/:version/elements/:element_id/icon[.<variant>].svg` | Composed icon (shape × symbol × variant). | yes |
+
+The conceptual model behind these routes — shape, symbol, variant, and the `innerColor` rule — is covered in [Icon composition](/icons).
+
+## `GET /api/v2/shapes/:shape.svg`
+
+Return a 36×36 SVG containing only the shape primitive.
+
+| Param | In | Description |
+|-------|-----|-------------|
+| `shape` | path | One of `circle`, `hexagon`, `octagon`, `rounded-square`. |
+
+```http
+HTTP/1.1 200 OK
+Content-Type: image/svg+xml; charset=utf-8
+Cache-Control: public, max-age=31536000, immutable
+```
+
+Errors: `bad_request` (400) for ids outside `[a-zA-Z0-9_-]`; `not_found` (404) for unknown shape names (the response `fix_hint` lists the valid shape set).
+
+## `GET /api/v2/schemas/:version/symbols/:symbol_id.svg`
+
+Return the release-pinned symbol SVG.
+
+| Param | In | Description |
+|-------|-----|-------------|
+| `version` | path | Canonical version or alias. |
+| `symbol_id` | path | Matches `element.symbol_id`. Whitelisted to `[a-zA-Z0-9_-]`. |
+
+```http
+HTTP/1.1 200 OK
+Content-Type: image/svg+xml; charset=utf-8
+DTPR-Content-Hash: sha256-…
+Cache-Control: public, max-age=3600          # beta
+Cache-Control: public, max-age=31536000, immutable    # stable
+```
+
+## `GET /api/v2/schemas/:version/elements/:element_id/icon[.<variant>].svg`
+
+Return a composed icon for an element.
+
+| Param | In | Description |
+|-------|-----|-------------|
+| `version` | path | Canonical version or alias. |
+| `element_id` | path | Whitelisted to `[a-zA-Z0-9_-]`. |
+| `variant` | path | Optional suffix. Valid values: `default` (implicit — omit to use), `dark`, or any `context.value.id` defined on the element's category. |
+
+URL forms:
+
+```
+/api/v2/schemas/ai@2026-04-16-beta/elements/purpose.example/icon.svg          # default
+/api/v2/schemas/ai@2026-04-16-beta/elements/purpose.example/icon.dark.svg     # dark
+/api/v2/schemas/ai@2026-04-16-beta/elements/purpose.example/icon.commercial.svg  # context-colored
+```
+
+### Fallback behavior
+
+The route first attempts a pre-baked R2 point-read. On miss, it logs an `icon_miss_fallback` event and composes the SVG on the fly using the same pure compositor as the build step — the fallback output is byte-identical to the pre-baked output. Callers observe the same response; only the `Cache-Control` max-age differs (60 s for beta miss, 3600 s for beta hit, `immutable` for stable).
+
+### Errors
+
+| Code | HTTP | Meaning |
+|------|------|---------|
+| `bad_request` | 400 | `element_id` / `variant` outside `[a-zA-Z0-9_-]`. |
+| `not_found` | 404 | Unknown version, element, symbol, or variant. `fix_hint` lists valid variants for `unknown_variant`. |
+
+## Examples
+
+::code-group
+```bash [curl — shape]
+curl -s -i https://api.dtpr.io/api/v2/shapes/hexagon.svg
+```
+
+```bash [curl — symbol]
+curl -s -i https://api.dtpr.io/api/v2/schemas/ai@2026-04-16-beta/symbols/example-symbol.svg
+```
+
+```bash [curl — composed]
+curl -s -i https://api.dtpr.io/api/v2/schemas/ai@2026-04-16-beta/elements/purpose.example/icon.dark.svg
+```
+::
+
+## See also
+
+- [Icon composition overview](/icons)
+- [Composed variants](/icons/composed-variants)
+- [URLs](/icons/urls)
+- [MCP `get_icon_url`](/mcp/tools/get-icon-url)

--- a/dtpr-ai/content/3.rest/8.pagination-and-fields.md
+++ b/dtpr-ai/content/3.rest/8.pagination-and-fields.md
@@ -1,0 +1,82 @@
+---
+title: Pagination & fields
+description: Cursor semantics, limits, field projection, and locale filtering.
+---
+
+# Pagination & fields
+
+::callout{type="info"}
+Shared cross-endpoint behavior. Applies to list endpoints and is mirrored by the MCP counterparts.
+::
+
+## Pagination
+
+List endpoints return an opaque **cursor** — a base64-encoded token the client passes back to fetch the next page.
+
+### Request parameters
+
+| Query param | Default | Range | Description |
+|-------------|---------|-------|-------------|
+| `limit` | `50` | `1 – 200` | Page size. Non-integer or out-of-range → `bad_request`. |
+| `cursor` | *(empty)* | opaque | Omit for the first page. On follow-up pages, pass the `meta.next_cursor` from the previous response. |
+
+### Response
+
+```json
+{
+  "ok": true,
+  "elements": [ "..." ],
+  "meta": {
+    "total": 127,
+    "returned": 50,
+    "next_cursor": "eyJvZmZzZXQiOjUwfQ=="
+  }
+}
+```
+
+`meta.next_cursor` is `null` on the last page. Cursors are opaque — **do not decode, rely on format, or manipulate**. Cursors are version-scoped; discard them when the schema version changes.
+
+### Invalid cursor
+
+```json
+{
+  "ok": false,
+  "errors": [
+    {
+      "code": "bad_request",
+      "message": "Invalid pagination cursor.",
+      "fix_hint": "Discard the cursor and re-issue the request without one, or pass a value previously returned by the API."
+    }
+  ]
+}
+```
+
+## Field projection
+
+Endpoints that return element rows accept a `fields` parameter.
+
+| Value | Meaning |
+|-------|---------|
+| `?fields=id,title,category_id` | Comma-separated field names. `id` is always included. |
+| `?fields=all` | Return the full element record. |
+| *(omitted)* | Endpoint-specific default. `/elements` uses `["id","title","category_id"]`; `/elements/:id` uses `"all"`. |
+
+Unknown field names are silently ignored — you can write feature-detected projection lists safely.
+
+## Locale filtering
+
+Localized fields have the shape `[{ "locale": "en", "value": "…" }, { "locale": "fr", "value": "…" }]`. The `locales` query parameter trims these arrays.
+
+| Value | Meaning |
+|-------|---------|
+| `?locales=en` | Retain only English entries. |
+| `?locales=en,fr` | Retain English and French. |
+| *(omitted)* | Return every locale. |
+
+Unknown locale codes (`?locales=zz`) are tolerated; the filter simply removes nothing for them.
+
+## See also
+
+- [MCP envelope — `meta.next_cursor`](/mcp/envelope)
+- [`GET /schemas/:version/elements`](/rest/elements-list)
+- [MCP `list_elements`](/mcp/tools/list-elements)

--- a/dtpr-ai/content/3.rest/9.errors.md
+++ b/dtpr-ai/content/3.rest/9.errors.md
@@ -1,0 +1,88 @@
+---
+title: Errors
+description: The shared error shape and canonical code list.
+---
+
+# Errors
+
+::callout{type="info"}
+Every error response — REST or MCP — carries the same `{ ok: false, errors: [...] }` shape. `code` is stable; `message` and `fix_hint` are human-readable.
+::
+
+## Shape
+
+```json
+{
+  "ok": false,
+  "errors": [
+    {
+      "code": "element_not_found",
+      "message": "Element 'missing' not found in ai@2026-04-16-beta.",
+      "path": "elements[0].element_id",
+      "fix_hint": "Use GET /api/v2/schemas/:version/elements to enumerate available element ids."
+    }
+  ]
+}
+```
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `code` | yes | Stable machine-readable code from the table below. |
+| `message` | yes | Human-readable diagnostic. |
+| `path` | no | JSON path into the caller's payload (e.g. `elements[3].category_id`). |
+| `fix_hint` | no | Short actionable instruction. |
+
+Adding new `code` values is **additive**; renaming or removing is a breaking change (guarded by snapshot fixtures in the repo).
+
+## Codes
+
+### Transport-level (HTTP status mirrors the code)
+
+| Code | HTTP | Meaning |
+|------|------|---------|
+| `bad_request` | 400 | Malformed input — version path param, query params, request body, or invalid cursor. |
+| `not_found` | 404 | Unknown version, element, symbol, variant, or shape. |
+| `payload_too_large` | 413 | Request body exceeds the configured byte limit. |
+| `rate_limited` | 429 | Client exceeded the rate-limit bucket. `Retry-After` header indicates the wait. |
+| `timeout` | 504 | Request exceeded the per-route wall-clock budget. |
+| `upstream_error` | 502 | Schema-store (R2) read failed. |
+| `internal_error` | 500 | Unexpected server error. |
+
+### Semantic — surfaced in 200 bodies
+
+| Code | Raised by | Meaning |
+|------|-----------|---------|
+| `parse_error` | `POST /validate`, MCP validate / render | Datachain shape failed Zod validation. `path` locates the offending field. |
+| `element_not_found` | MCP `get_elements` (per-id), MCP `get_icon_url`, MCP `get_element` | Element not present in the version. |
+| `element_ids_too_many` | MCP `get_elements` | >100 unique ids after dedupe. |
+| `unknown_version` | MCP tools | Manifest missing for the resolved version. |
+| `unknown_variant` | MCP `get_icon_url` | Variant not in the element's `icon_variants`. `fix_hint` lists valid variants. |
+| `invalid_arguments` | MCP tools | Argument failed the tool's Zod input schema. |
+| Semantic validator codes | `/validate`, `render_datachain`, `validate_datachain` | Shape-valid but semantically wrong — required categories missing, placement invalid, cardinality violated, etc. |
+
+## Rate limiting
+
+Read endpoints share one bucket; `POST /validate` uses a dedicated tighter bucket. Setting `DTPR-Client: <name>` opts your traffic into a per-client bucket. On exceed:
+
+```http
+HTTP/1.1 429 Too Many Requests
+Content-Type: application/json
+Retry-After: 60
+
+{
+  "ok": false,
+  "errors": [
+    {
+      "code": "rate_limited",
+      "message": "Rate limit exceeded.",
+      "fix_hint": "Wait 60 seconds or set `DTPR-Client` for a dedicated bucket."
+    }
+  ]
+}
+```
+
+## See also
+
+- [MCP envelope — `ok`/`errors`/`meta`](/mcp/envelope)
+- [`POST /schemas/:version/validate`](/rest/validate) — semantic validator errors.
+- [MCP `validate_datachain`](/mcp/tools/validate-datachain)

--- a/dtpr-ai/content/4.icons/0.index.md
+++ b/dtpr-ai/content/4.icons/0.index.md
@@ -1,0 +1,27 @@
+---
+title: Icon composition
+description: Shape × symbol × variant mental model behind every DTPR icon.
+---
+
+# Icon composition
+
+Every DTPR icon is a 36×36 SVG composed on demand from three independent inputs:
+
+```
+shape (from category) + symbol (from element) + variant (default | dark | context color) → SVG
+```
+
+This composition is deterministic. The same `(version, element_id, variant)` triple always returns a byte-identical SVG, and the response carries a long `Cache-Control` header and an `X-DTPR-Content-Hash` for cache invalidation.
+
+## In this section
+
+- [Shapes](/icons/shapes) — the primitive shape family and how a category picks one.
+- [Symbols](/icons/symbols) — release-pinned symbol SVGs and the `symbol_id` link.
+- [Composed variants](/icons/composed-variants) — `default`, `dark`, and `{ kind: 'colored', color }`; the inner-color luminance rule.
+- [URLs](/icons/urls) — how to derive and discover icon URLs.
+
+## Related
+
+- [REST: icon routes](/rest/icons) — the HTTP surface.
+- [MCP: `get_icon_url`](/mcp/tools/get-icon-url) — the MCP tool that resolves these URLs.
+- [`@dtpr/ui` `DtprIcon`](/ui/vue) — the Vue component that renders composed icons.

--- a/dtpr-ai/content/4.icons/1.shapes.md
+++ b/dtpr-ai/content/4.icons/1.shapes.md
@@ -1,0 +1,51 @@
+---
+title: Shapes
+description: The four DTPR shape primitives.
+---
+
+# Shapes
+
+::callout{type="info"}
+A category's `shape` field picks one of four bundled primitives. Shapes are not version-pinned — they live in the worker code.
+::
+
+## The primitives
+
+The compositor bundles four shape paths, all in a `36×36` viewBox with `stroke-width="2"`:
+
+| Shape | `d` outline | Where it's used |
+|-------|-------------|-----------------|
+| `circle` | Circle of radius 16 centered at (18, 18). | Decorative / balanced categories. |
+| `hexagon` | Pointed-top regular hexagon inscribed in the 36×36 box. | Default category shape. |
+| `octagon` | Regular octagon. | Warning / attention categories. |
+| `rounded-square` | 30×30 square with 3-px corner radius, inset by 3 from each edge. | Utility / grid categories. |
+
+The exact `d` values live in [`api/src/icons/shapes.ts`](https://github.com/helpful-places/dtpr/blob/main/api/src/icons/shapes.ts).
+
+## How a category picks a shape
+
+Every category in a schema declares a `shape` field on its manifest:
+
+```json
+{
+  "id": "purpose",
+  "shape": "hexagon",
+  "context": { "values": [ { "id": "commercial", "color": "#0052CC" } ] }
+}
+```
+
+You can read a category's shape via [`list_categories`](/mcp/tools/list-categories) or [`GET /schemas/:version/categories`](/rest/categories). Invalid shape names are rejected at schema build time.
+
+## Serving shapes directly
+
+```
+GET /api/v2/shapes/:shape.svg
+```
+
+Returns a bare 36×36 SVG with the shape fragment (stroke `#000`, no fill). See [REST icon routes](/rest/icons#get-apiv2shapesshapesvg).
+
+## See also
+
+- [Symbols](/icons/symbols)
+- [Composed variants](/icons/composed-variants)
+- [REST icon routes](/rest/icons)

--- a/dtpr-ai/content/4.icons/2.symbols.md
+++ b/dtpr-ai/content/4.icons/2.symbols.md
@@ -1,0 +1,50 @@
+---
+title: Symbols
+description: Release-pinned symbol SVGs referenced by element.symbol_id.
+---
+
+# Symbols
+
+::callout{type="info"}
+Symbols are the "what" inside an element's icon. They are pinned to a specific schema release and stored as SVG documents.
+::
+
+## The model
+
+Every element has a `symbol_id` that points at a symbol SVG. Symbols carry the glyph (camera, microphone, person, …); the surrounding shape comes from the element's category, and the color treatment comes from the [variant](/icons/composed-variants).
+
+```json
+{
+  "id": "data.camera",
+  "symbol_id": "camera",
+  "category_id": "data-collected"
+}
+```
+
+The referenced symbol is fetched via:
+
+```
+GET /api/v2/schemas/:version/symbols/:symbol_id.svg
+```
+
+See [REST icon routes](/rest/icons#get-apiv2schemasversionsymbolssymbol_idsvg).
+
+## Release-pinning
+
+A symbol with id `camera` in `ai@2026-04-16-beta` may differ byte-for-byte from `camera` in the next release. Consumers that pin on `DTPR-Content-Hash` will see the change. Symbols are therefore stored under the version prefix in the content store; there is no cross-version "global" symbol namespace.
+
+## File shape
+
+Source symbols follow a narrow shape: a single `<svg viewBox="0 0 36 36" …>` wrapper around one or more `<path>` (occasionally `<g>`) elements. Leading BOM, XML prolog, and HTML comments are rejected at schema build time — the compositor assumes a clean `<svg>…</svg>` document.
+
+When an element's icon is composed, the compositor strips the outer `<svg>` tags and inlines the inner fragment under a `<g color="…">` wrapper whose `color` attribute depends on the [variant](/icons/composed-variants).
+
+## Discovering symbol ids
+
+Read `element.symbol_id` from [`GET /schemas/:version/elements/:element_id`](/rest/element-detail) or [`get_element`](/mcp/tools/get-element). Symbol ids match `[a-zA-Z0-9_-]`.
+
+## See also
+
+- [Shapes](/icons/shapes)
+- [Composed variants](/icons/composed-variants)
+- [URLs](/icons/urls)

--- a/dtpr-ai/content/4.icons/3.composed-variants.md
+++ b/dtpr-ai/content/4.icons/3.composed-variants.md
@@ -1,0 +1,103 @@
+---
+title: Composed variants
+description: default / dark / context-colored variants and the WCAG-inspired innerColor rule.
+---
+
+# Composed variants
+
+::callout{type="info"}
+Every element has two universal variants — `default` and `dark`. Categories that declare a `context` also expose one colored variant per context value.
+::
+
+## The variant union
+
+The compositor accepts three variant forms:
+
+```ts
+type ComposeVariant =
+  | 'default'
+  | 'dark'
+  | { kind: 'colored'; color: string }  // color is #RRGGBB
+```
+
+Each resolves to three colors: the shape fill, the shape stroke, and the inner (symbol) color.
+
+| Variant | Shape fill | Shape stroke | Inner color |
+|---------|------------|--------------|-------------|
+| `default` | `none` (transparent) | `#000` | `#000` |
+| `dark` | `#000` | `#000` | `#FFF` |
+| `{kind:'colored',color}` | `color` | `color` | `innerColorForShape(color)` |
+
+## Why the split exists
+
+`default` and `dark` are universal — every element renders equally well outlined (light UI) or filled (dark UI). **Context-colored** variants exist because each category can declare a `context.values[]` set whose members carry a `color`. An element can therefore render in any context value its category declares.
+
+This keeps the color palette scoped to where it semantically belongs: a category's context, not the element itself.
+
+## Discovering valid variants
+
+The build step materializes an `icon_variants[]` array onto every element. Read it via [`get_element`](/mcp/tools/get-element) or [`GET /schemas/:version/elements/:element_id`](/rest/element-detail):
+
+```json
+{
+  "id": "purpose.example",
+  "icon_variants": ["default", "dark", "commercial", "civic"]
+}
+```
+
+[`get_icon_url`](/mcp/tools/get-icon-url) mirrors this array in its response for convenience.
+
+## The innerColor rule
+
+For colored variants, the inner color is derived from the shape color via WCAG 2 relative luminance:
+
+```
+innerColor = relativeLuminance(shapeColor) >= 0.179 ? '#000' : '#FFF'
+```
+
+The 0.179 threshold matches the common "choose black or white text on a background" heuristic.
+
+### Worked example
+
+Take a category with `context.values[{id:'commercial', color:'#0052CC'}]`:
+
+```
+shapeColor    = #0052CC
+rgb           = (0, 82, 204)
+linearized    = (0.000, 0.0865, 0.6105)
+luminance     = 0.2126·0.000 + 0.7152·0.0865 + 0.0722·0.6105
+              = 0.106
+0.106 < 0.179 → innerColor = #FFF
+```
+
+The `commercial` variant of an element in this category therefore renders with a `#0052CC` shape and white inner glyph.
+
+Take a lighter context color, `#FFDD00` (DTPR warning yellow):
+
+```
+luminance  ≈ 0.81
+0.81 >= 0.179 → innerColor = #000
+```
+
+The rule deliberately biases toward high-contrast symbol legibility at small sizes.
+
+## Output SVG
+
+A composed icon is an inline-compact 36×36 SVG:
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" width="36" height="36">
+  <path d="…shape path…" fill="…" stroke="…" stroke-width="2"/>
+  <g color="…innerColor…">
+    …stripped symbol inner…
+  </g>
+</svg>
+```
+
+Identical inputs produce byte-identical output — no randomness, no timestamps, no environment-dependent behavior.
+
+## See also
+
+- [URLs](/icons/urls) — how the variant maps into a URL.
+- [Shapes](/icons/shapes), [Symbols](/icons/symbols)
+- [MCP `get_icon_url`](/mcp/tools/get-icon-url)

--- a/dtpr-ai/content/4.icons/4.urls.md
+++ b/dtpr-ai/content/4.icons/4.urls.md
@@ -1,0 +1,77 @@
+---
+title: URLs
+description: Derive an icon URL from any (version, element, variant) triple.
+---
+
+# URLs
+
+::callout{type="info"}
+Every composed icon has a single canonical URL. You can always derive it from an element id + an optional variant.
+::
+
+## The layout
+
+```
+/api/v2/schemas/:version/elements/:element_id/icon[.<variant>].svg
+```
+
+| Form | Example | Maps to |
+|------|---------|---------|
+| `icon.svg` | `/api/v2/schemas/ai@2026-04-16-beta/elements/purpose.example/icon.svg` | `default` variant. |
+| `icon.dark.svg` | `/api/v2/schemas/ai@2026-04-16-beta/elements/purpose.example/icon.dark.svg` | `dark` variant. |
+| `icon.<context>.svg` | `/api/v2/schemas/ai@2026-04-16-beta/elements/purpose.example/icon.commercial.svg` | Colored variant whose `<context>` matches a category `context.value.id`. |
+
+Full URL: prefix with `https://api.dtpr.io`.
+
+## Discovering valid variants
+
+Read the element's `icon_variants[]` array:
+
+```bash
+curl -s https://api.dtpr.io/api/v2/schemas/ai@2026-04-16-beta/elements/purpose.example \
+  | jq '.element.icon_variants'
+# [ "default", "dark", "commercial", "civic" ]
+```
+
+Or use [`get_icon_url`](/mcp/tools/get-icon-url) — it returns both the URL and the full variant list in one call, and emits `unknown_variant` errors with `valid_variants` in `fix_hint` when you ask for an invalid one.
+
+## Validation
+
+The server rejects ids outside `[a-zA-Z0-9_-]` with HTTP 400 `bad_request`:
+
+```json
+{
+  "ok": false,
+  "errors": [
+    { "code": "bad_request", "message": "Invalid element_id '…'.", "fix_hint": "Use [a-zA-Z0-9_-] only." }
+  ]
+}
+```
+
+Unknown version, element, or variant returns HTTP 404 `not_found`; the `unknown_variant` variant includes the valid list in its `fix_hint`.
+
+## Fallback
+
+The route first attempts a pre-baked R2 point-read. On miss, it logs an `icon_miss_fallback` structured event and composes the SVG on the fly with the same pure compositor. The response is **byte-identical** to the pre-baked path — consumers never see a degraded fallback. Only `Cache-Control` max-age differs (60 s on a beta miss versus 3600 s on a beta hit).
+
+## MCP equivalent
+
+`get_icon_url` returns the URL as a **relative** string (`/api/v2/...`). Prefix `https://api.dtpr.io` when fetching.
+
+```json
+{
+  "data": {
+    "url": "/api/v2/schemas/ai@2026-04-16-beta/elements/purpose.example/icon.dark.svg",
+    "content_type": "image/svg+xml",
+    "variant": "dark",
+    "valid_variants": ["default", "dark", "commercial", "civic"]
+  }
+}
+```
+
+## See also
+
+- [REST icon routes](/rest/icons)
+- [MCP `get_icon_url`](/mcp/tools/get-icon-url)
+- [Composed variants](/icons/composed-variants)
+- [REST errors](/rest/errors)

--- a/dtpr-ai/content/5.ui/0.index.md
+++ b/dtpr-ai/content/5.ui/0.index.md
@@ -1,0 +1,30 @@
+---
+title: "@dtpr/ui"
+description: Framework-neutral helpers, Vue components, and SSR HTML renderer for DTPR content.
+---
+
+# @dtpr/ui
+
+`@dtpr/ui` is the component library for rendering DTPR datachains. It ships three subpath exports so you can pull only the layer you need.
+
+```bash
+pnpm add @dtpr/ui
+```
+
+| Subpath | For | What's inside |
+|---------|-----|---------------|
+| `@dtpr/ui/core` | Any JavaScript / TypeScript runtime | Framework-neutral helpers (locale projection, category grouping, display derivation, validation). |
+| `@dtpr/ui/vue` | Vue 3 apps | 6 Single-File Components (`DtprIcon`, `DtprElement`, `DtprElementDetail`, `DtprCategorySection`, `DtprDatachain`, `DtprElementGrid`). |
+| `@dtpr/ui/html` | Any server-side Node runtime | `renderDatachainDocument` — SSR HTML for MCP Apps iframes. |
+
+## In this section
+
+- [Core](/ui/core) — framework-neutral helpers + types.
+- [Vue](/ui/vue) — the 6 Vue components with props, slots, examples.
+- [HTML (SSR)](/ui/html) — `renderDatachainDocument` for the MCP Apps flow.
+- [Theming](/ui/theming) — the `dtpr` cascade layer and CSS custom properties.
+
+## Related
+
+- [MCP: `render_datachain`](/mcp/tools/render-datachain) — the tool that produces the HTML served to iframes.
+- [UI quickstart](/getting-started/ui-quickstart) — minimal Vue 3 app fetching from the REST API.

--- a/dtpr-ai/content/5.ui/1.core.md
+++ b/dtpr-ai/content/5.ui/1.core.md
@@ -1,0 +1,174 @@
+---
+title: "@dtpr/ui/core"
+description: Framework-neutral helpers for locale extraction, interpolation, category grouping, display derivation, and validation.
+---
+
+# @dtpr/ui/core
+
+::callout{type="info"}
+Pure TypeScript, no framework dependencies. Import these helpers from any runtime — Node, Bun, Deno, Workers, a Vue app, a React app.
+::
+
+## Import
+
+```ts
+import {
+  extract,
+  extractWithLocale,
+  interpolate,
+  interpolateSegments,
+  groupElementsByCategory,
+  sortCategoriesByOrder,
+  findCategoryDefinition,
+  deriveElementDisplay,
+  validateDatachain,
+  HEXAGON_FALLBACK_DATA_URI,
+} from '@dtpr/ui/core'
+```
+
+## Locale extraction
+
+### `extract(values, locale)`
+
+Return the first `LocaleValue` matching the requested locale, or an empty string.
+
+```ts
+function extract(values: readonly LocaleValue[], locale: string): string
+```
+
+```ts
+extract(
+  [{ locale: 'en', value: 'Camera' }, { locale: 'fr', value: 'Caméra' }],
+  'fr',
+) // → 'Caméra'
+```
+
+### `extractWithLocale(values, locale)`
+
+Like `extract` but returns the matched locale too — useful when you want to know whether the extraction fell back.
+
+```ts
+function extractWithLocale(
+  values: readonly LocaleValue[],
+  locale: string,
+): ExtractWithLocaleResult  // { value: string, locale: string | null }
+```
+
+## Interpolation
+
+### `interpolate(template, vars)`
+
+Replace `{{variable_id}}` tokens in a template string.
+
+```ts
+function interpolate(template: string, vars: Record<string, string>): string
+```
+
+```ts
+interpolate('Shared with {{partner}}', { partner: 'Acme' })
+// → 'Shared with Acme'
+```
+
+### `interpolateSegments(template, vars)`
+
+Tokenize a template into segments so a renderer can style filled vs missing variables differently.
+
+```ts
+function interpolateSegments(
+  template: string,
+  vars: Record<string, string>,
+): readonly InterpolateSegment[]
+```
+
+Each segment is `{ kind: 'text' | 'variable' | 'missing', value: string, variable_id?: string }`. `DtprElementDetail` uses this helper to highlight filled variables and emphasize missing ones.
+
+## Category grouping
+
+### `groupElementsByCategory(elements)`
+
+Bucket a flat element list into `{ [category_id]: Element[] }`.
+
+```ts
+function groupElementsByCategory(elements: readonly Element[]): Record<string, Element[]>
+```
+
+### `sortCategoriesByOrder(categories, order)`
+
+Order categories according to a reference id sequence (e.g. the one declared on `datachainType.categories`). Categories not in `order` land at the end in their natural order.
+
+```ts
+function sortCategoriesByOrder(
+  categories: readonly Category[],
+  order: readonly string[],
+): Category[]
+```
+
+### `findCategoryDefinition(categories, id)`
+
+Lookup helper that returns the `Category` matching `id`, or `undefined`.
+
+## Display derivation
+
+### `deriveElementDisplay(element, placement, locale)`
+
+Compose the pre-rendered display payload consumed by `DtprElement` and `DtprElementDetail`. It resolves the icon URL (including the `HEXAGON_FALLBACK_DATA_URI` when `icon_url` is missing), extracts localized strings, and tees up variables with their filled values.
+
+```ts
+function deriveElementDisplay(
+  element: Element,
+  placement: InstanceElement | undefined,
+  locale: string,
+  options?: DeriveElementDisplayOptions,
+): ElementDisplay
+```
+
+```ts
+const display = deriveElementDisplay(element, placement, 'en')
+// { title, description, citation, icon: {url, alt}, variables: [{id, label, value, type, required}] }
+```
+
+## Validation
+
+### `validateDatachain(instance, source)`
+
+Run the same validator used by [`POST /validate`](/rest/validate) over a `DatachainInstance`, given a `SchemaVersionSource` (manifest + categories + elements + datachain-type).
+
+```ts
+function validateDatachain(
+  instance: DatachainInstance,
+  source: SchemaVersionSource,
+): ValidationResult  // { ok: boolean, errors: SemanticError[], warnings: SemanticError[] }
+```
+
+Use it when you want to run validation client-side without a round-trip.
+
+## Constants
+
+### `HEXAGON_FALLBACK_DATA_URI`
+
+Inline data URI for a neutral hexagon fallback icon. Used by `deriveElementDisplay` when an element lacks an `icon_url` — pass it to `DtprIcon.src` wherever you need a safe placeholder.
+
+```ts
+const HEXAGON_FALLBACK_DATA_URI: string  // 'data:image/svg+xml,...'
+```
+
+## Type exports
+
+`@dtpr/ui/core` also re-exports the schema types so consumers don't have to depend on `@dtpr/api` directly:
+
+| Type | Description |
+|------|-------------|
+| `Element`, `Category`, `LocaleValue`, `Variable`, `VariableType` | Schema primitives. |
+| `InstanceElement`, `InstanceVariableValue`, `DatachainInstance` | Instance primitives. |
+| `SchemaManifest` | Manifest shape. |
+| `InterpolateSegment` | Segment type returned by `interpolateSegments`. |
+| `ElementDisplay`, `ElementDisplayIcon`, `ElementDisplayVariable` | Derived display payload. |
+| `ExtractWithLocaleResult` | `{ value, locale }` from `extractWithLocale`. |
+| `SchemaVersionSource`, `SemanticError`, `Severity`, `ValidationResult` | Validator inputs and outputs. |
+| `DeriveElementDisplayOptions` | Options bag for `deriveElementDisplay`. |
+
+## See also
+
+- [Vue components](/ui/vue)
+- [SSR HTML renderer](/ui/html)
+- [Theming](/ui/theming)

--- a/dtpr-ai/content/5.ui/2.vue.md
+++ b/dtpr-ai/content/5.ui/2.vue.md
@@ -1,0 +1,254 @@
+---
+title: "@dtpr/ui/vue"
+description: Six Vue 3 components for rendering DTPR datachains.
+---
+
+# @dtpr/ui/vue
+
+::callout{type="info"}
+Vue 3 Single-File Components. Pair with `@dtpr/ui/vue/styles.css` for the default tokens and layout.
+::
+
+## Install & import
+
+```bash
+pnpm add @dtpr/ui
+```
+
+```ts
+import {
+  DtprIcon,
+  DtprElement,
+  DtprElementDetail,
+  DtprCategorySection,
+  DtprDatachain,
+  DtprElementGrid,
+} from '@dtpr/ui/vue'
+import '@dtpr/ui/vue/styles.css'
+```
+
+Peer dependency: `vue ^3.5`.
+
+## DtprIcon
+
+Renders a 36×36 `<img>` tag with a hexagon fallback when the source is missing or errors.
+
+### Props
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `src` | `string` | no | `''` | Icon URL. Empty or errored → fallback. |
+| `alt` | `string` | yes | — | Alt text. Pass `''` for decorative mode (sets `role="presentation"`). |
+| `size` | `number` | no | `48` | Square dimension in px. |
+
+### Events
+
+| Event | Payload | When |
+|-------|---------|------|
+| `error` | `Event` | Emitted when the image fails to load. Component then swaps to `HEXAGON_FALLBACK_DATA_URI`. |
+
+### Example
+
+```vue
+<DtprIcon
+  :src="iconUrl"
+  alt="Camera icon"
+  :size="64"
+  @error="onIconError"
+/>
+```
+
+## DtprElement
+
+Compact element card — icon + title.
+
+### Props
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `display` | `ElementDisplay` | yes | — | Pre-derived display data from `deriveElementDisplay`. |
+| `iconSize` | `number` | no | `48` | Icon size in px. |
+
+### Example
+
+```vue
+<script setup lang="ts">
+import { deriveElementDisplay } from '@dtpr/ui/core'
+import { DtprElement } from '@dtpr/ui/vue'
+const display = deriveElementDisplay(element, placement, 'en')
+</script>
+
+<template>
+  <DtprElement :display="display" />
+</template>
+```
+
+## DtprElementDetail
+
+Rich element detail — icon, title, interpolated description, variables (with typed rendering for `url` / `boolean` / `number` / `date`), missing-required warnings, and optional citation.
+
+### Props
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `display` | `ElementDisplay` | yes | — | Pre-derived display data. |
+| `locale` | `string` | no | `'en'` | BCP-47 locale for `Intl.NumberFormat` / `Intl.DateTimeFormat`. |
+| `yesNoLabels` | `{yes: string, no: string}` | no | `{yes:'yes', no:'no'}` | Localized boolean labels. |
+| `descriptionHtml` | `string` | no | — | Pre-sanitized HTML for the description. When omitted, the plain-text path renders via `interpolateSegments`. |
+| `iconSize` | `number` | no | `64` | Icon size in px. |
+
+::callout{type="warning"}
+`descriptionHtml` is injected via `v-html` without sanitization. Pass only HTML you have sanitized (DOMPurify, etc.) or content from a trusted source.
+::
+
+### Slots
+
+| Slot | Default content | Purpose |
+|------|-----------------|---------|
+| `overlay` | Icon + title | Replace the entire header. |
+| `after-description` | — | Inserted after the description paragraph. |
+| `after-variables` | — | Inserted after the variables list. |
+| `after-citation` | — | Inserted after the citation paragraph. |
+
+### Example
+
+```vue
+<DtprElementDetail
+  :display="display"
+  :locale="'en'"
+  :icon-size="96"
+>
+  <template #after-variables>
+    <a :href="helpUrl">Learn more</a>
+  </template>
+</DtprElementDetail>
+```
+
+## DtprCategorySection
+
+Accessible accordion section with an `aria-expanded` header button.
+
+### Props
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `id` | `string` | yes | — | Stable section id (used in `aria-controls`). |
+| `title` | `string` | yes | — | Heading text. |
+| `expanded` | `boolean` | no | — | Controlled expanded state. Omit for uncontrolled. |
+| `disableAccordion` | `boolean` | no | `false` | When true, renders as a non-interactive heading — always expanded. |
+
+### Events
+
+| Event | Payload | When |
+|-------|---------|------|
+| `update:expanded` | `boolean` | Controlled-mode updates (v-model compatible). |
+| `toggle` | `boolean` | Either mode — fires on each toggle. |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| default | Body content rendered inside the panel. |
+
+### Example
+
+```vue
+<DtprCategorySection id="purpose" title="Purpose" v-model:expanded="isOpen">
+  <DtprElement v-for="d in displays" :key="d.title" :display="d" />
+</DtprCategorySection>
+```
+
+## DtprDatachain
+
+Top-level composer. Coordinates an accordion of `DtprCategorySection`s and exposes per-section slots.
+
+### Props
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `sections` | `readonly {id, title}[]` | yes | — | Ordered section descriptors. |
+| `openSectionId` | `string \| null` | no | — | Controlled open-section id. Omit for uncontrolled. |
+| `disableAccordion` | `boolean` | no | `false` | Cascades to all sections — every section always expanded. |
+
+### Events
+
+| Event | Payload |
+|-------|---------|
+| `update:openSectionId` | `string \| null` |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| `section-<id>` | Content for the section with matching `id`. Slot props include `section: {id, title}`. |
+| `empty` | Rendered when `sections.length === 0`. |
+
+### Example
+
+```vue
+<script setup lang="ts">
+import { DtprDatachain, DtprElementDetail, DtprElementGrid } from '@dtpr/ui/vue'
+import '@dtpr/ui/vue/styles.css'
+import { deriveElementDisplay } from '@dtpr/ui/core'
+
+const sections = [
+  { id: 'purpose', title: 'Purpose' },
+  { id: 'data', title: 'Data collected' },
+]
+
+const byCategory: Record<string, Element[]> = {
+  purpose: [/* ... */],
+  data: [/* ... */],
+}
+</script>
+
+<template>
+  <DtprDatachain :sections="sections">
+    <template
+      v-for="section in sections"
+      :key="section.id"
+      #[`section-${section.id}`]
+    >
+      <DtprElementGrid>
+        <DtprElementDetail
+          v-for="el in byCategory[section.id]"
+          :key="el.id"
+          :display="deriveElementDisplay(el, undefined, 'en')"
+        />
+      </DtprElementGrid>
+    </template>
+    <template #empty>
+      <p>No data collected.</p>
+    </template>
+  </DtprDatachain>
+</template>
+```
+
+## DtprElementGrid
+
+Layout-only responsive grid using CSS `@container` queries (columns adapt to the wrapper's inline-size, not the viewport). Consumers place their own cards in the default slot.
+
+### Props
+
+None.
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| default | Card content (e.g. `DtprElement` instances). |
+
+### Example
+
+```vue
+<DtprElementGrid>
+  <DtprElement v-for="d in displays" :key="d.title" :display="d" />
+</DtprElementGrid>
+```
+
+## See also
+
+- [Core helpers](/ui/core)
+- [Theming](/ui/theming)
+- [SSR renderer](/ui/html)
+- [UI quickstart](/getting-started/ui-quickstart)

--- a/dtpr-ai/content/5.ui/3.html.md
+++ b/dtpr-ai/content/5.ui/3.html.md
@@ -1,0 +1,113 @@
+---
+title: "@dtpr/ui/html"
+description: Server-side rendering of datachains as standalone HTML documents for MCP Apps.
+---
+
+# @dtpr/ui/html
+
+::callout{type="info"}
+SSR the same Vue components as an iframe-renderable HTML document. Used by the MCP server's [`render_datachain`](/mcp/tools/render-datachain) tool.
+::
+
+## Import
+
+```ts
+import { renderDatachainDocument, trustAsHtml } from '@dtpr/ui/html'
+import type { RenderedSection, RenderDatachainOptions, SafeHtml } from '@dtpr/ui/html'
+```
+
+Requires `@vue/server-renderer` (installed as a direct dep of `@dtpr/ui`). Runs in any Node-compatible runtime — Node, Bun, Cloudflare Workers (via `nodejs_compat`).
+
+## renderDatachainDocument
+
+Render a complete standalone HTML document — `<!doctype html>`, embedded stylesheet, SSR'd body, and a tiny client-side accordion script.
+
+### Signature
+
+```ts
+async function renderDatachainDocument(
+  sections: readonly RenderedSection[],
+  options?: RenderDatachainOptions,
+): Promise<string>
+```
+
+### Parameters
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `sections` | `readonly RenderedSection[]` | Ordered list of sections with their element displays. |
+| `options.locale` | `string` (default `'en'`) | `<html lang>` and the locale used by `Intl` formatting inside element detail. |
+| `options.title` | `string` (default `'DTPR datachain'`) | `<title>` text. |
+| `options.emptyHtml` | `SafeHtml` | Trusted HTML inserted when `sections` is empty. Declare trust via `trustAsHtml(...)`. |
+
+### Returns
+
+`Promise<string>` — a complete HTML document.
+
+### RenderedSection
+
+```ts
+interface RenderedSection {
+  id: string
+  title: string
+  elements: readonly ElementDisplay[]
+}
+```
+
+Produce `elements` by running each element through `deriveElementDisplay` from [`@dtpr/ui/core`](/ui/core).
+
+## trustAsHtml
+
+Brand a string as `SafeHtml` so it can be passed to `options.emptyHtml`. The brand is a phantom type — there is no runtime sanitization.
+
+```ts
+function trustAsHtml(html: string): SafeHtml
+```
+
+::callout{type="warning"}
+Only call `trustAsHtml` on content you have sanitized (DOMPurify, etc.) or strings you control (static constants, generated markup from trusted sources). Do not wrap raw user input.
+::
+
+## MCP Apps example
+
+The produced HTML is served with the `text/html;profile=mcp-app` mime type (SEP-1865):
+
+```ts
+import { renderDatachainDocument } from '@dtpr/ui/html'
+import { deriveElementDisplay } from '@dtpr/ui/core'
+
+const sections = categories.map((c) => ({
+  id: c.id,
+  title: extractWithLocale(c.name, 'en').value,
+  elements: instance.elements
+    .filter((p) => elementById.get(p.element_id)?.category_id === c.id)
+    .map((p) => deriveElementDisplay(elementById.get(p.element_id)!, p, 'en')),
+}))
+
+const html = await renderDatachainDocument(sections, { locale: 'en' })
+
+return new Response(html, {
+  headers: { 'content-type': 'text/html;profile=mcp-app' },
+})
+```
+
+This is exactly how [`render_datachain`](/mcp/tools/render-datachain) produces the body that `resources/read` returns.
+
+## Empty state
+
+```ts
+import { renderDatachainDocument, trustAsHtml } from '@dtpr/ui/html'
+
+const html = await renderDatachainDocument([], {
+  emptyHtml: trustAsHtml('<p>No datachain to display.</p>'),
+})
+```
+
+Omit `emptyHtml` to get a neutral `<p class="dtpr-empty" role="status">` placeholder.
+
+## See also
+
+- [MCP `render_datachain`](/mcp/tools/render-datachain)
+- [MCP resources](/mcp/resources)
+- [Core](/ui/core) — `deriveElementDisplay`.
+- [Vue components](/ui/vue)

--- a/dtpr-ai/content/5.ui/4.theming.md
+++ b/dtpr-ai/content/5.ui/4.theming.md
@@ -1,0 +1,94 @@
+---
+title: Theming
+description: The dtpr cascade layer and the CSS custom properties used by @dtpr/ui/vue.
+---
+
+# Theming
+
+::callout{type="info"}
+`@dtpr/ui/vue/styles.css` wraps every rule in `@layer dtpr`. Your own cascade layer outranks it by default — overrides "just work."
+::
+
+## Cascade layer
+
+```css
+@import '@dtpr/ui/vue/styles.css';   /* defines @layer dtpr */
+```
+
+Every DTPR style lives in `@layer dtpr`. CSS cascade-layer order means any unlayered CSS, or any higher-priority layer you declare, will win. To guarantee an explicit order, declare the layers first:
+
+```css
+@layer reset, tailwind, dtpr, app;
+
+@import 'tailwindcss';
+@import '@dtpr/ui/vue/styles.css';
+/* your own styles follow, implicitly in layer `app` */
+```
+
+In the example above, `app` wins over `dtpr` wins over `tailwind` wins over `reset`.
+
+## Tokens
+
+All tokens are declared on `:where(html)` so their specificity is zero — override at any root or container.
+
+| Token | Default | Purpose |
+|-------|---------|---------|
+| `--dtpr-color-accent` | `#0f5153` | Primary accent. |
+| `--dtpr-color-accent-contrast` | `#ffffff` | On-accent text color. |
+| `--dtpr-color-border` | `rgba(0, 0, 0, 0.1)` | Borders around cards and sections. |
+| `--dtpr-color-text` | `#111111` | Body text. |
+| `--dtpr-color-text-muted` | `#555555` | Secondary text (variable labels, citations). |
+| `--dtpr-color-surface` | `#ffffff` | Card + section background. |
+| `--dtpr-color-warning` | `#f04a4a` | Missing-required warnings. |
+| `--dtpr-font-heading` | `'Red Hat Text', sans-serif` | Headings. |
+| `--dtpr-font-body` | `'Red Hat Text', sans-serif` | Body text. |
+| `--dtpr-space-xs` | `0.25rem` | Spacing step. |
+| `--dtpr-space-sm` | `0.5rem` | Spacing step. |
+| `--dtpr-space-md` | `1rem` | Spacing step. |
+| `--dtpr-space-lg` | `1.5rem` | Spacing step. |
+| `--dtpr-space-xl` | `2rem` | Spacing step. |
+| `--dtpr-radius-sm` | `0.25rem` | Variable cards, icon frames. |
+| `--dtpr-radius-md` | `0.5rem` | Element + section cards. |
+| `--dtpr-radius-lg` | `1rem` | Reserved. |
+
+## Examples
+
+### Color override
+
+```css
+:root {
+  --dtpr-color-accent: #7c3aed;       /* violet */
+  --dtpr-color-warning: #ef4444;      /* red-500 */
+}
+```
+
+### Font override
+
+```css
+:root {
+  --dtpr-font-heading: 'Inter Tight', system-ui, sans-serif;
+  --dtpr-font-body:    'Inter', system-ui, sans-serif;
+}
+```
+
+### Scoped override
+
+Tokens cascade, so you can swap them inside a container without touching the root:
+
+```css
+.marketing-section {
+  --dtpr-color-accent: #0ea5e9;
+}
+```
+
+All DTPR components rendered under `.marketing-section` pick up the new accent.
+
+## Container queries
+
+The components use CSS `@container (inline-size)` queries instead of viewport media queries. A `DtprElementGrid` goes from 1 column to 2 to 3 based on its wrapper's inline-size — wrap it in a narrow sidebar and it stays one column even on a wide viewport.
+
+## See also
+
+- [Vue components](/ui/vue)
+- [Core helpers](/ui/core)
+- [UI quickstart](/getting-started/ui-quickstart)

--- a/dtpr-ai/content/6.concepts/0.index.md
+++ b/dtpr-ai/content/6.concepts/0.index.md
@@ -1,0 +1,21 @@
+---
+title: Concepts
+description: DTPR vocabulary you will see across the MCP, REST, icon, and UI reference.
+---
+
+# Concepts
+
+Short, reference-focused explanations of the vocabulary you will see across this site. For deeper treatment of the DTPR standard — principles, signage, taxonomy motivation — see [docs.dtpr.io](https://docs.dtpr.io).
+
+## In this section
+
+- [Datachains](/concepts/datachains) — What a datachain is and what it describes.
+- [Elements & categories](/concepts/elements-categories) — How elements are grouped and displayed.
+- [Versions & releases](/concepts/versions-and-releases) — Canonical ids, aliases, and stability.
+- [Content hash](/concepts/content-hash) — How agents detect schema updates.
+
+## Related
+
+- [MCP server reference](/mcp)
+- [REST v2 reference](/rest)
+- [Icon composition](/icons)

--- a/dtpr-ai/content/6.concepts/1.datachains.md
+++ b/dtpr-ai/content/6.concepts/1.datachains.md
@@ -1,0 +1,53 @@
+---
+title: Datachains
+description: The DTPR instance that describes a data-collecting technology.
+---
+
+# Datachains
+
+A **datachain** is a concrete instance of a DTPR schema. It describes one data-collecting technology — what it collects, why, who operates it, and what happens to the data downstream.
+
+## Structure
+
+At the top level, a `DatachainInstance` carries a `schema_version` and an ordered list of `elements`:
+
+```json
+{
+  "schema_version": "ai@2026-04-16-beta",
+  "elements": [
+    { "element_id": "purpose.example", "category_id": "purpose" },
+    { "element_id": "data.camera",    "category_id": "data-collected" }
+  ]
+}
+```
+
+Each entry in `elements[]` is an **element placement** — a reference to an element definition from the schema, optionally carrying:
+
+- a `label` override,
+- `variables` with filled values (the element's description gets interpolated using them),
+- a `citation`.
+
+The schema defines the vocabulary (elements, categories, variables); the datachain picks from it.
+
+## Validation
+
+Datachains are validated against a pinned schema version. See:
+
+- [`POST /schemas/:version/validate`](/rest/validate) — REST.
+- [`validate_datachain`](/mcp/tools/validate-datachain) — MCP.
+
+Both validate both shape (Zod) and semantics (cardinality, required categories, placement rules). Shape errors surface as `parse_error`; semantic errors carry stable codes per rule.
+
+## Rendering
+
+Once valid, a datachain can be rendered to HTML:
+
+- [`render_datachain`](/mcp/tools/render-datachain) (MCP Apps) — produces HTML consumed via `resources/read`.
+- [`@dtpr/ui/vue`](/ui/vue) + `DtprDatachain` — render inside a Vue app.
+- [`@dtpr/ui/html`](/ui/html) `renderDatachainDocument` — SSR the same components to a standalone HTML document.
+
+## See also
+
+- [Elements & categories](/concepts/elements-categories)
+- [Versions & releases](/concepts/versions-and-releases)
+- [Content hash](/concepts/content-hash)

--- a/dtpr-ai/content/6.concepts/2.elements-categories.md
+++ b/dtpr-ai/content/6.concepts/2.elements-categories.md
@@ -1,0 +1,78 @@
+---
+title: Elements & categories
+description: The two-level vocabulary DTPR uses to describe data-collecting technologies.
+---
+
+# Elements & categories
+
+::callout{type="info"}
+An **element** is a single fact. A **category** groups related elements and carries the visual treatment shared across them.
+::
+
+## Categories
+
+A category is the top-level grouping — "Purpose", "Data collected", "Data handling". Every category declares:
+
+- an `id` (stable, used as `category_id` on every element and placement),
+- localized `name` and `description`,
+- a bundled [`shape`](/icons/shapes) primitive,
+- an optional `context` with `values[]` — used to produce [colored icon variants](/icons/composed-variants).
+
+```json
+{
+  "id": "purpose",
+  "name": [{ "locale": "en", "value": "Purpose" }],
+  "shape": "hexagon",
+  "context": {
+    "values": [
+      { "id": "commercial", "color": "#0052CC", "label": [...] },
+      { "id": "civic",      "color": "#FFDD00", "label": [...] }
+    ]
+  }
+}
+```
+
+Access via [`list_categories`](/mcp/tools/list-categories) or [`GET /schemas/:version/categories`](/rest/categories).
+
+## Elements
+
+An element is a single fact within a category:
+
+- an `id` (stable, often `<category>.<name>`),
+- a `category_id` pointing at a category,
+- a `symbol_id` pointing at the [symbol](/icons/symbols) SVG,
+- localized `title` and `description`,
+- optional `variables[]` — values a datachain author fills in per placement,
+- a materialized `icon_variants[]` array listing every valid variant for composed-icon URLs.
+
+```json
+{
+  "id": "purpose.example",
+  "category_id": "purpose",
+  "symbol_id": "example-symbol",
+  "title": [{ "locale": "en", "value": "Example purpose" }],
+  "description": [{ "locale": "en", "value": "Short description with {{partner}} variable." }],
+  "variables": [ { "id": "partner", "label": [...], "type": "text", "required": false } ],
+  "icon_variants": ["default", "dark", "commercial"]
+}
+```
+
+Access via [`list_elements`](/mcp/tools/list-elements), [`get_element`](/mcp/tools/get-element), or [`GET /schemas/:version/elements`](/rest/elements-list).
+
+## Relationship
+
+```
+Category
+  ├── shape  ───► used by every element in the category
+  ├── context.values[] ───► produces colored icon variants per element
+  └── Elements[] (many-to-one)
+        ├── symbol_id ───► symbol SVG
+        ├── variables[] ───► filled per placement in a datachain instance
+        └── icon_variants[] ───► materialized (default + dark + context ids)
+```
+
+## See also
+
+- [Datachains](/concepts/datachains)
+- [Icon composition](/icons)
+- [REST `/elements`](/rest/elements-list), [REST `/categories`](/rest/categories)

--- a/dtpr-ai/content/6.concepts/3.versions-and-releases.md
+++ b/dtpr-ai/content/6.concepts/3.versions-and-releases.md
@@ -1,0 +1,64 @@
+---
+title: Versions & releases
+description: Canonical version ids, aliases, status, and what "release" means for DTPR.
+---
+
+# Versions & releases
+
+::callout{type="info"}
+Version ids are canonical. Aliases are conveniences. Pin on the canonical id for reproducibility.
+::
+
+## Canonical form
+
+```
+<datachain_type>@<YYYY-MM-DD>[-<suffix>]
+```
+
+- `datachain_type` — e.g. `ai` (today the only shipped type).
+- `YYYY-MM-DD` — the release's authorship date.
+- optional `-suffix` — `-beta` during authoring. Stable releases drop the suffix.
+
+Examples: `ai@2026-04-16`, `ai@2026-04-16-beta`.
+
+## Status
+
+Every version has a status:
+
+| Status | Meaning | Cache-Control |
+|--------|---------|---------------|
+| `stable` | Immutable. Content is frozen. | `public, max-age=86400, immutable` |
+| `beta` | In-progress authoring. Content may change. | `no-store` |
+
+Beta versions are served without caching so authoring iterations land immediately. Stable versions are aggressively cached.
+
+## Aliases
+
+`schemas/index.json` ships human-friendly aliases like `ai@latest` that resolve to whichever canonical id is currently the "latest." Aliases are handy for exploration; they are **not** guaranteed stable. For production integrations, discover the canonical id via [`list_schema_versions`](/mcp/tools/list-schema-versions) and pin on it.
+
+## Release flow
+
+```
+beta authoring ──► beta preview ──► stable promotion
+ai@2026-XX-YY-beta                 ai@2026-XX-YY
+   (no-store)                        (immutable)
+```
+
+Once a version is promoted to stable, its `content_hash` stops changing. The [content hash](/concepts/content-hash) is the deterministic handle you can use to detect drift.
+
+## URL encoding
+
+The canonical form contains an `@` which should not require URL encoding, but the API accepts both the raw `ai@2026-04-16-beta` and the `%40`-encoded form:
+
+```
+/api/v2/schemas/ai@2026-04-16-beta/manifest
+/api/v2/schemas/ai%402026-04-16-beta/manifest
+```
+
+Both resolve to the same version.
+
+## See also
+
+- [MCP `list_schema_versions`](/mcp/tools/list-schema-versions)
+- [REST `GET /schemas`](/rest/schemas)
+- [Content hash](/concepts/content-hash)

--- a/dtpr-ai/content/6.concepts/4.content-hash.md
+++ b/dtpr-ai/content/6.concepts/4.content-hash.md
@@ -1,0 +1,60 @@
+---
+title: Content hash
+description: How agents detect DTPR schema content drift without polling.
+---
+
+# Content hash
+
+::callout{type="info"}
+Every version-scoped response carries a `DTPR-Content-Hash` header and — for JSON responses — the same value in `meta.content_hash`. Use it to detect drift.
+::
+
+## What it is
+
+A hex digest computed over the frozen schema content for a version. Same inputs → same hash. Different inputs → different hash. The server never emits a partial or best-effort hash.
+
+Stable versions have a content hash that never changes once promoted. Beta versions emit the current hash on each read; the hash only changes when an author rebuilds the schema.
+
+## Where it appears
+
+**REST, version-scoped endpoints:**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+DTPR-Content-Hash: sha256-f8a2…
+```
+
+**MCP envelopes** — inside `meta`:
+
+```json
+{
+  "ok": true,
+  "data": { "...": "..." },
+  "meta": { "content_hash": "sha256-f8a2…", "version": "ai@2026-04-16-beta" }
+}
+```
+
+## Why agents care
+
+An AI agent that caches DTPR content (element titles, category structure, rendered HTML) can use the content hash as a cache key:
+
+```
+cache_key = content_hash
+```
+
+When the next response carries a different `content_hash`, the cache entry is stale — invalidate and re-fetch. No polling, no version number parsing, no "every 5 minutes check if the schema moved."
+
+## Not a crypto signature
+
+The hash is a fingerprint, not a signature. It detects drift; it does not authenticate origin. If you need authenticated content, rely on TLS to `api.dtpr.io`.
+
+## Beta churn
+
+A beta version's content hash changes on every rebuild. If your client pins on the hash against a beta version, expect cache turnover during active authoring. Pinning on a stable version's hash gives you an immutable handle.
+
+## See also
+
+- [Versions & releases](/concepts/versions-and-releases)
+- [MCP envelope](/mcp/envelope)
+- [REST conventions](/rest) — response headers.

--- a/dtpr-ai/content/7.changelog.md
+++ b/dtpr-ai/content/7.changelog.md
@@ -1,10 +1,62 @@
 ---
 title: Changelog
-description: Dated entries for the MCP server, REST v2 API, icon composition, and @dtpr/ui.
+description: What landed when — MCP, REST v2, icons, @dtpr/ui, and this microsite.
 ---
 
 # Changelog
 
 Most recent first. Grouped by surface. See the [repository](https://github.com/helpful-places/dtpr) for the full commit history.
 
-_Entries populate as each section of this site lands._
+## 2026-04-18
+
+### Icons
+
+- **Icon composition pipeline** ([#270](https://github.com/helpful-places/dtpr/pull/270))
+  Shape × symbol × variant composition with `default` / `dark` / context-colored variants and the WCAG `innerColor` rule. Adds pre-baked R2 point-read with on-the-fly fallback.
+  New REST routes: `GET /api/v2/shapes/:shape.svg`, `GET /api/v2/schemas/:version/symbols/:symbol_id.svg`, `GET /api/v2/schemas/:version/elements/:element_id/icon[.<variant>].svg`.
+  New MCP tool: [`get_icon_url`](/mcp/tools/get-icon-url).
+  References: [Icon composition](/icons), [REST icon routes](/rest/icons).
+
+### Site
+
+- **`dtpr.ai` microsite placeholder** ([#271](https://github.com/helpful-places/dtpr/pull/271))
+  Docus + Nuxt 4 skeleton deployed on Cloudflare Workers with a D1 binding for content queries. Minimal landing; no documentation yet.
+
+## 2026-04-17
+
+### @dtpr/ui
+
+- **Component library + `render_datachain` MCP tool** ([#267](https://github.com/helpful-places/dtpr/pull/267))
+  Three subpath exports: `@dtpr/ui/core` (10 framework-neutral helpers), `@dtpr/ui/vue` (6 Vue 3 SFCs), `@dtpr/ui/html` (SSR via `renderDatachainDocument`). Default stylesheet wraps everything in `@layer dtpr` and exposes a full CSS custom-property token set.
+  New MCP tool: [`render_datachain`](/mcp/tools/render-datachain). New MCP resource: `ui://dtpr/datachain/view.html` (MCP Apps iframe handoff).
+  References: [Vue reference](/ui/vue), [Core reference](/ui/core), [HTML SSR](/ui/html), [Theming](/ui/theming).
+
+### MCP
+
+- **Read path on Cloudflare Workers** ([#265](https://github.com/helpful-places/dtpr/pull/265))
+  Hand-rolled JSON-RPC over HTTP handler (workerd nodejs_compat can't load the SDK's CJS Ajv dep). Supported methods: `initialize`, `notifications/initialized`, `tools/list`, `tools/call`, `resources/list`, `resources/read`, `ping`. Shared `ok` / `err` envelope with `_meta.content_hash` / `_meta.version`.
+  Initial tools: `list_schema_versions`, `get_schema`, `list_categories`, `list_elements`, `get_element`, `get_elements`, `validate_datachain`.
+  References: [Connecting](/mcp/connection), [Envelope](/mcp/envelope).
+
+### REST v2
+
+- **`api.dtpr.io/api/v2` read path** ([#265](https://github.com/helpful-places/dtpr/pull/265))
+  Public, read-only JSON + SVG. Opaque cursor pagination (`MAX_LIMIT = 200`), field/locale projection, `DTPR-Content-Hash` + `Cache-Control` on version-scoped responses, static CORS allow-list. `POST /schemas/:version/validate` runs shape + semantic validation and always returns HTTP 200.
+  References: [REST v2](/rest), [Pagination & fields](/rest/pagination-and-fields), [Errors](/rest/errors).
+
+### API infrastructure
+
+- **Standalone API scaffold + AI content migration** ([#262](https://github.com/helpful-places/dtpr/pull/262))
+  Extracts DTPR content from the v1 site into a standalone API workspace. Establishes the schema authoring flow and migrates the `ai` datachain type.
+- **CI: build @dtpr/ui + api/schema before typecheck** ([#268](https://github.com/helpful-places/dtpr/pull/268))
+  Orders deploy workflows so generated types land before typecheck runs.
+- **Drafting CLI + preview deploys + Claude Code plugin** ([#266](https://github.com/helpful-places/dtpr/pull/266))
+
+### docs.dtpr.io
+
+- **Nuxt Studio with Google + GitHub OAuth** ([#269](https://github.com/helpful-places/dtpr/pull/269))
+  Enables in-browser authoring for the existing v1 docs.
+
+## Source of truth
+
+Every entry maps to a pull request on [github.com/helpful-places/dtpr](https://github.com/helpful-places/dtpr). Commit history on `main` is authoritative if this changelog falls behind.

--- a/dtpr-ai/content/7.changelog.md
+++ b/dtpr-ai/content/7.changelog.md
@@ -1,0 +1,10 @@
+---
+title: Changelog
+description: Dated entries for the MCP server, REST v2 API, icon composition, and @dtpr/ui.
+---
+
+# Changelog
+
+Most recent first. Grouped by surface. See the [repository](https://github.com/helpful-places/dtpr) for the full commit history.
+
+_Entries populate as each section of this site lands._

--- a/dtpr-ai/content/index.md
+++ b/dtpr-ai/content/index.md
@@ -1,9 +1,39 @@
 ---
 title: DTPR for AI
-description: Digital Trust for Places & Routines — AI-focused microsite.
+description: MCP server, REST v2 API, icon composition, and UI library for the Digital Trust for Places & Routines standard.
 navigation: false
 ---
 
-This is an early placeholder for **DTPR for AI** — an AI-focused surface of the [Digital Trust for Places & Routines](https://docs.dtpr.io) standard.
+**DTPR for AI** is the AI-focused surface of the [Digital Trust for Places & Routines](https://docs.dtpr.io) standard. It bundles four integration surfaces so an AI agent, a web client, or a server-side renderer can describe data-collecting technologies in public spaces with a shared vocabulary.
 
-Content is on the way.
+::card-group
+  ::card{title="MCP server" to="/mcp"}
+  9 tools and 1 resource over Streamable HTTP at `https://api.dtpr.io/mcp` — list, fetch, validate, render, resolve icons.
+  ::
+
+  ::card{title="REST API (v2)" to="/rest"}
+  Public, read-only JSON + SVG API at `https://api.dtpr.io/api/v2`. Schemas, categories, elements, validation, icons.
+  ::
+
+  ::card{title="Icon composition" to="/icons"}
+  Shape × symbol × variant pipeline. Compose 36×36 SVG icons pinned to a schema release.
+  ::
+
+  ::card{title="@dtpr/ui" to="/ui"}
+  Framework-neutral helpers, Vue components, and SSR HTML renderer. Ships with MCP Apps support.
+  ::
+::
+
+## Quickstarts
+
+- [MCP in five minutes](/getting-started/mcp-quickstart) — `initialize` → `tools/call` → `resources/read`.
+- [REST in three calls](/getting-started/rest-quickstart) — list schemas, fetch elements, validate a datachain.
+- [UI in a Vue app](/getting-started/ui-quickstart) — render a datachain with `<DtprDatachain>`.
+
+## Background
+
+- [What is DTPR for AI?](/getting-started) — Who this documentation is for.
+- [Concepts](/concepts) — Datachains, elements, categories, versions, content hashes.
+- [Changelog](/changelog) — What landed when.
+
+For the full DTPR standard — design principles, signage, governance, v1 REST — see [docs.dtpr.io](https://docs.dtpr.io).

--- a/dtpr-ai/nuxt.config.ts
+++ b/dtpr-ai/nuxt.config.ts
@@ -5,6 +5,8 @@ export default defineNuxtConfig({
     name: 'DTPR for AI',
   },
 
+  ogImage: { enabled: false },
+
   $production: {
     nitro: {
       preset: 'cloudflare-module',


### PR DESCRIPTION
## Summary
Turns the `dtpr.ai` Docus placeholder into the canonical public docs for the AI-era surfaces landed over the last two weeks: the MCP server at `/mcp` (9 tools + 1 resource), the v2 REST API at `/api/v2`, the shape × symbol × variant icon pipeline, and the `@dtpr/ui` library (core / vue / html). Adds 45 reference + quickstart + concept pages grounded directly in `api/src/**` and `packages/ui/src/**`; pulls every example from the actual Zod schemas and route handlers. Also corrects an early-scaffolding mistake that misnamed the `DTPR-Content-Hash` header and overclaimed CORS. Plan at `docs/plans/2026-04-18-001-feat-dtpr-ai-documentation-structure-plan.md`.

## Test plan
- [x] `pnpm --filter ./dtpr-ai build` passes on final tree
- [ ] Spot-check nav rendering locally (`pnpm --filter ./dtpr-ai dev`)
- [ ] Confirm example curls in the REST + MCP quickstarts succeed against `api.dtpr.io` once the branch is previewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)