### PR TITLE
docs(plugin): broaden DTPR comprehension audience beyond commuter framing

### DIFF
--- a/dtpr-ai/content/7.plugin/2.skills/5.comprehension-audit.md
+++ b/dtpr-ai/content/7.plugin/2.skills/5.comprehension-audit.md
@@ -14,7 +14,7 @@ The three schema-tier skills ([`dtpr-datachain-structure`](/plugin/skills/datach
 - The user asks to grade, audit, or check a DTPR element, category, datachain-instance, or pasted content for public comprehension.
 - The user uses "comprehension audit", "is this clear", "how readable is X", or "does this land for a non-expert".
 - A schema-tier skill's inline Comprehension check needs a deeper standalone second pass.
-- The user pastes YAML, JSON, or markdown and asks whether it would be understood by a commuter or citizen reading a sign.
+- The user pastes YAML, JSON, or markdown and asks whether it would be understood by a non-technical person encountering an AI system — in an app, on a website, in a vehicle, on a kiosk or sign, or any other surface where DTPR content might appear.
 - The user wants to re-grade after the rubric's `rubric_version` has changed.
 
 ## Trigger phrases

--- a/dtpr-ai/content/7.plugin/4.comprehension-rubric.md
+++ b/dtpr-ai/content/7.plugin/4.comprehension-rubric.md
@@ -5,7 +5,7 @@ description: The seven-item rubric that schema-tier skills inline and dtpr-compr
 
 # Comprehension rubric
 
-A qualitative checklist for grading DTPR content (datachain-types, categories, elements, full datachain-instances) against the bar of **"a non-technical commuter understands this in seconds."** There is no scoring math. Each item has pass / fail / partial signals plus an explicit **n/a** when it does not apply to the artifact under review.
+A qualitative checklist for grading DTPR content (datachain-types, categories, elements, full datachain-instances) against the bar of **"a non-technical person encountering an AI system understands this on a quick read."** The audience is anyone meeting an AI system in the wild — in an app, on a website, in a vehicle, on a kiosk or sign, or while moving through public space — with enough time to parse what they see but no prior expertise. There is no scoring math. Each item has pass / fail / partial signals plus an explicit **n/a** when it does not apply to the artifact under review.
 
 This rubric is the shared dependency of [`dtpr-comprehension-audit`](/plugin/skills/comprehension-audit) (standalone use) and the three schema-tier skills ([`dtpr-datachain-structure`](/plugin/skills/datachain-structure), [`dtpr-category-audit`](/plugin/skills/category-audit), [`dtpr-element-design`](/plugin/skills/element-design)), which inline findings using the block template.
 

--- a/plugin/dtpr/evals/comprehension-audit.evals.json
+++ b/plugin/dtpr/evals/comprehension-audit.evals.json
@@ -4,7 +4,11 @@
   "should_trigger": [
     {
       "id": "grade-accept-deny-element",
-      "prompt": "Grade the accept_deny element for comprehension — would a commuter at a transit kiosk understand it on first read?"
+      "prompt": "Grade the accept_deny element for comprehension — would a non-technical person encountering it in an app understand it on first read?"
+    },
+    {
+      "id": "grade-accept-deny-element-transit-kiosk",
+      "prompt": "Subset stress test: grade the accept_deny element for a commuter at a transit kiosk specifically — does it still land in that surface?"
     },
     {
       "id": "category-clear-to-public",

--- a/plugin/dtpr/evals/datachain-structure.evals.json
+++ b/plugin/dtpr/evals/datachain-structure.evals.json
@@ -42,7 +42,7 @@
     },
     {
       "id": "cross-sibling:dtpr-comprehension-audit:grade-accept-deny-element",
-      "prompt": "Grade the accept_deny element for comprehension — would a commuter understand it on first read?"
+      "prompt": "Grade the accept_deny element for comprehension — would a non-technical person encountering it understand it on first read?"
     },
     {
       "id": "refactor-typescript",

--- a/plugin/dtpr/evals/describe-system.evals.json
+++ b/plugin/dtpr/evals/describe-system.evals.json
@@ -66,7 +66,7 @@
     },
     {
       "id": "cross-sibling:dtpr-comprehension-audit:grade-accept-deny-element",
-      "prompt": "Can you grade the `accept_deny` element for public comprehension? I want to know if a commuter would understand it."
+      "prompt": "Can you grade the `accept_deny` element for public comprehension? I want to know if a non-technical person encountering it in an app or on a sign would understand it."
     },
     {
       "id": "cross-sibling:dtpr-category-audit:risks-generative-complete",

--- a/plugin/dtpr/references/comprehension-rubric.md
+++ b/plugin/dtpr/references/comprehension-rubric.md
@@ -4,7 +4,7 @@ rubric_version: 2026-04-20
 
 # Comprehension rubric
 
-A qualitative checklist for grading DTPR content (datachain-types, categories, elements, full datachain-instances) against the bar of **"a non-technical commuter understands this in seconds."**
+A qualitative checklist for grading DTPR content (datachain-types, categories, elements, full datachain-instances) against the bar of **"a non-technical person encountering an AI system understands this on a quick read."** The audience is anyone meeting an AI system in the wild — in an app, on a website, in a vehicle, on a kiosk or sign, or while moving through public space — with enough time to parse what they see but no prior expertise.
 
 Each item has a short definition and pass/fail/partial signals. There is no scoring math. When an item does not apply to the artifact you are grading (e.g., symbol legibility on a category-level critique), mark it **n/a** and note why in the one-line reason.
 
@@ -12,7 +12,7 @@ This rubric is the shared dependency of `dtpr-comprehension-audit` (standalone u
 
 ## Audience fit
 
-Does the content land for the intended audience — a commuter, visitor, or citizen encountering a sign or notice without prior context? A specialist audience (regulator, researcher) does not substitute for the default public audience.
+Does the content land for the intended audience — a non-technical person encountering an AI system without prior context, in any surface where DTPR content might appear (app, website, in-vehicle display, kiosk, public sign, embedded notice)? A specialist audience (regulator, researcher) does not substitute for the default public audience. A specific surface — a transit kiosk a commuter glances at, an in-vehicle display a driver sees mid-trip — is a useful subset stress test, not the only target.
 
 - **pass** — the language, framing, and example would be understood by a non-expert on first read.
 - **partial** — the core idea lands but one or two phrases need a gloss.

--- a/plugin/dtpr/skills/dtpr-comprehension-audit/SKILL.md
+++ b/plugin/dtpr/skills/dtpr-comprehension-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dtpr-comprehension-audit
-description: Grade DTPR (Digital Trust for Places and Routines) content — an element, a category, a datachain-instance, a pasted YAML fragment, or arbitrary markdown — against the public-comprehension rubric. Use whenever a user wants to check whether content is clear to a non-technical commuter. Triggers on phrases like "grade this element", "is this category clear to the public", "comprehension audit", "check this datachain for public understanding", "how readable is X", "does this land for a non-expert", or any request to judge clarity without changing content. Produces Markdown findings against the comprehension rubric plus a one-paragraph summary. For requests to describe an AI system, use `dtpr-describe-system`; to critique the datachain-type shape, use `dtpr-datachain-structure`; to audit one category's elements for coherence, use `dtpr-category-audit`; to design or propose a new element, use `dtpr-element-design`.
+description: Grade DTPR (Digital Trust for Places and Routines) content — an element, a category, a datachain-instance, a pasted YAML fragment, or arbitrary markdown — against the public-comprehension rubric. Use whenever a user wants to check whether content is clear to a non-technical person encountering an AI system (in an app, on a website, in a vehicle, on a kiosk or sign, or anywhere DTPR content might appear). Triggers on phrases like "grade this element", "is this category clear to the public", "comprehension audit", "check this datachain for public understanding", "how readable is X", "does this land for a non-expert", or any request to judge clarity without changing content. Produces Markdown findings against the comprehension rubric plus a one-paragraph summary. For requests to describe an AI system, use `dtpr-describe-system`; to critique the datachain-type shape, use `dtpr-datachain-structure`; to audit one category's elements for coherence, use `dtpr-category-audit`; to design or propose a new element, use `dtpr-element-design`.
 ---
 
 # Grade DTPR content against the comprehension rubric
@@ -14,7 +14,7 @@ The skill grades only. It does not modify schema content, draft new elements, or
 - User asks to grade, audit, or check a DTPR element, category, datachain-instance, or pasted content for public comprehension.
 - User uses the phrase "comprehension audit", "is this clear", "how readable is X", or "does this land for a non-expert".
 - A schema-tier skill's inline Comprehension check needs a deeper, standalone second pass.
-- User pastes YAML, JSON, or markdown and asks whether it would be understood by a commuter or citizen reading a sign.
+- User pastes YAML, JSON, or markdown and asks whether it would be understood by a non-technical person encountering an AI system — in an app, on a website, in a vehicle, on a kiosk or sign, or any other surface where DTPR content might appear.
 - User wants to re-grade content after the rubric has evolved (a new `rubric_version` appears in `comprehension-rubric.md`).
 
 ## Sibling routing


### PR DESCRIPTION
The comprehension rubric and `dtpr-comprehension-audit` skill framed DTPR's default audience as "a non-technical commuter" reading a sign in seconds, which steered agent reasoning toward transit-kiosk framing every time the skill ran. DTPR content is consumed by anyone encountering an AI system — in apps, on websites, in vehicles, on kiosks or public signs — with enough time to parse what they see but no prior expertise.

This rewrites the rubric source of truth (`plugin/dtpr/references/comprehension-rubric.md`), the skill's frontmatter description and "When to use" copy, and the public mirrors under `dtpr-ai/content/7.plugin/`. Eval prompts move to the broadened framing for primary triggers; one transit-kiosk prompt is added explicitly labeled as a subset stress test, and the existing sign-copy readability prompt is retained as a sign-scale stress test. No code, schema, or rubric items change — only audience copy.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
