### PR TITLE
chore(plugin): bump dtpr plugin to 0.2.1 to bust cache

### DIFF
--- a/plugin/dtpr/.claude-plugin/plugin.json
+++ b/plugin/dtpr/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "dtpr",
   "description": "Digital Trust for Places and Routines — an authoring studio for DTPR. Describe AI systems as validated DTPR datachains, critique and design the schema at meta-structure, category, and element tiers, and grade content for public comprehension. Wraps the remote MCP at api.dtpr.io/mcp.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "Helpful Places",
     "url": "https://helpfulplaces.com"


### PR DESCRIPTION
## Summary

Bumps `plugin/dtpr/.claude-plugin/plugin.json` from `0.2.0` → `0.2.1` so Claude Code clients invalidate the cached plugin and pick up the recent skill updates (SVG symbols, `dtpr-translate`, dynamic locales, broadened comprehension audience).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
