### PR TITLE
revert(ai@2026-05-06-beta): restore prior Functional Modes & Risks icons

### DIFF
--- a/api/schemas/ai/2026-05-06-beta/symbols/mode_agentic.svg
+++ b/api/schemas/ai/2026-05-06-beta/symbols/mode_agentic.svg
@@ -1,5 +1,5 @@
 <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="9" cy="26" r="2.25" fill="currentColor"/>
-<path d="M9 23 L9 18 L18 18 L18 12 L24 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M22 9 L25 12 L22 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="9" cy="18" r="2.5" fill="currentColor"/>
+<line x1="11.5" y1="18" x2="24" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+<path d="M22 12 L28 18 L22 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
 </svg>

--- a/api/schemas/ai/2026-05-06-beta/symbols/mode_analytical.svg
+++ b/api/schemas/ai/2026-05-06-beta/symbols/mode_analytical.svg
@@ -1,6 +1,5 @@
 <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M11 26 V21" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-<path d="M18 26 V18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-<path d="M25 26 V14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-<circle cx="25" cy="10.5" r="1.5" fill="currentColor"/>
+<rect x="9" y="20" width="4" height="6" rx="1" fill="currentColor"/>
+<rect x="16" y="15" width="4" height="11" rx="1" fill="currentColor"/>
+<rect x="23" y="10" width="4" height="16" rx="1" fill="currentColor"/>
 </svg>

--- a/api/schemas/ai/2026-05-06-beta/symbols/mode_generative.svg
+++ b/api/schemas/ai/2026-05-06-beta/symbols/mode_generative.svg
@@ -1,5 +1,3 @@
 <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M11 8 H21 L26 13 V28 H11 Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" fill="none"/>
-<path d="M21 8 V13 H26" stroke="currentColor" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" fill="none"/>
-<path d="M27 18 L28 21 L31 22 L28 23 L27 26 L26 23 L23 22 L26 21 Z" fill="currentColor"/>
+<path d="M18 7 L20 16 L29 18 L20 20 L18 29 L16 20 L7 18 L16 16 Z" fill="currentColor"/>
 </svg>

--- a/api/schemas/ai/2026-05-06-beta/symbols/mode_perceptive.svg
+++ b/api/schemas/ai/2026-05-06-beta/symbols/mode_perceptive.svg
@@ -1,5 +1,4 @@
 <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="18" cy="18" r="9" stroke="currentColor" stroke-width="2" fill="none"/>
-<path d="M18 7 V9.5 M29 18 H26.5 M18 29 V26.5 M7 18 H9.5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-<path d="M13 18 Q15 15, 17 18 T21 18 T23 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 18 C 10 12, 14 9, 18 9 C 22 9, 26 12, 30 18 C 26 24, 22 27, 18 27 C 14 27, 10 24, 6 18 Z" stroke="currentColor" stroke-width="1.75" fill="none"/>
+<circle cx="18" cy="18" r="4" fill="currentColor"/>
 </svg>

--- a/api/schemas/ai/2026-05-06-beta/symbols/mode_physical.svg
+++ b/api/schemas/ai/2026-05-06-beta/symbols/mode_physical.svg
@@ -1,7 +1,3 @@
 <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M9 27L16 18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-<path d="M16 18L26 11" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-<path d="M7 27L11 27" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-<path d="M22 21C23.5 19, 24 16.5, 23 14" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
-<circle cx="16" cy="18" r="2.25" fill="currentColor"/>
+<path d="M18 7 L21 11 L19 11 L19 16 L24 16 L24 14 L28 17 L28 19 L24 22 L24 20 L19 20 L19 25 L21 25 L18 29 L15 25 L17 25 L17 20 L12 20 L12 22 L8 19 L8 17 L12 14 L12 16 L17 16 L17 11 L15 11 Z" fill="currentColor"/>
 </svg>

--- a/api/schemas/ai/2026-05-06-beta/symbols/mode_semantic.svg
+++ b/api/schemas/ai/2026-05-06-beta/symbols/mode_semantic.svg
@@ -1,8 +1,8 @@
 <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<line x1="11" y1="11" x2="25" y2="11" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
-<line x1="11" y1="11" x2="18" y2="25" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
-<line x1="25" y1="11" x2="18" y2="25" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
-<circle cx="11" cy="11" r="2.25" stroke="currentColor" stroke-width="1.75"/>
-<circle cx="25" cy="11" r="2.25" stroke="currentColor" stroke-width="1.75"/>
-<circle cx="18" cy="25" r="3" fill="currentColor"/>
+<line x1="11" y1="11" x2="25" y2="11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="11" y1="11" x2="18" y2="25" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="25" y1="11" x2="18" y2="25" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="11" cy="11" r="2.5" fill="currentColor"/>
+<circle cx="25" cy="11" r="2.5" fill="currentColor"/>
+<circle cx="18" cy="25" r="2.5" fill="currentColor"/>
 </svg>

--- a/api/schemas/ai/2026-05-06-beta/symbols/risks_autonomy.svg
+++ b/api/schemas/ai/2026-05-06-beta/symbols/risks_autonomy.svg
@@ -1,8 +1,10 @@
 <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="18" cy="13" r="2" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M18 15 L18 23" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/>
-<path d="M11 26 L25 26" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/>
-<path d="M2 18 L14 18" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/>
-<path d="M22 18 L34 18" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/>
-<path d="M5 15 L2 18 L5 21 M31 15 L34 18 L31 21" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/>
+<g transform="scale(1.0285714285714285)">
+<circle cx="17.5" cy="11" r="2.5" stroke="currentColor" stroke-width="1.4" fill="none"/>
+<path d="M14 24 L14 17 C14 15.5 15.3 14.5 17.5 14.5 C19.7 14.5 21 15.5 21 17 L21 24" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" fill="none"/>
+<path d="M9.5 17.5 L13.5 17.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+<path d="M21.5 17.5 L25.5 17.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+<path d="M11.5 15.5 L9.5 17.5 L11.5 19.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+<path d="M23.5 15.5 L25.5 17.5 L23.5 19.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</g>
 </svg>

--- a/api/schemas/ai/2026-05-06-beta/symbols/risks_civil-liberties.svg
+++ b/api/schemas/ai/2026-05-06-beta/symbols/risks_civil-liberties.svg
@@ -1,7 +1,9 @@
 <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M18 8 L18 27" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
-<path d="M14 27 L22 27" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
-<path d="M9 11 L16.5 11 L17.3 8 L18.7 14 L19.5 11 L27 11" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M7 13 Q9 16.5 11 13" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M25 13 Q27 16.5 29 13" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+<g transform="scale(1.0285714285714285)">
+<path d="M17.5 8 L17.5 26" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+<path d="M14 26 L21 26" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+<path d="M9 13 L17.5 11 L26 14" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+<path d="M9 13 L6.5 19 L11.5 19 Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round" fill="none"/>
+<path d="M26 14 L23 21 L29 21 Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round" fill="none"/>
+</g>
 </svg>

--- a/api/schemas/ai/2026-05-06-beta/symbols/risks_environmental.svg
+++ b/api/schemas/ai/2026-05-06-beta/symbols/risks_environmental.svg
@@ -1,5 +1,7 @@
 <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M19 8 C19.5 11 20.5 13 21.5 14.5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-<path d="M21.5 14.5 C26 16 26.5 22 13 25 C13.5 21 16 17 21.5 14.5 Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M21.5 14.5 C19.5 18 17 22 14 24.5" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+<g transform="scale(1.0285714285714285)">
+<path d="M9 24 C9 17 14 10 24 9 C23 19 16 24 9 24 Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" fill="none"/>
+<path d="M9 24 L20 13" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+<path d="M7 8 L26 27" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+</g>
 </svg>

--- a/api/schemas/ai/2026-05-06-beta/symbols/risks_financial.svg
+++ b/api/schemas/ai/2026-05-06-beta/symbols/risks_financial.svg
@@ -1,6 +1,9 @@
 <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="13" cy="18" r="6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M15 15.5 C15 14.5 14 14 13 14 C12 14 11 14.5 11 15.5 C11 16.5 12 17 13 17.5 C14 18 15 18.5 15 19.5 C15 20.5 14 21 13 21 C12 21 11 20.5 11 19.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M13 13 L13 22" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-<path d="M21 14 L24 17 L27 15 L30 21" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<g transform="scale(1.0285714285714285)">
+<circle cx="17.5" cy="14" r="6" stroke="currentColor" stroke-width="1.4" fill="none"/>
+<path d="M17.5 11 L17.5 17" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+<path d="M15.5 12.3 C15.5 11.6 16.3 11 17.5 11 C18.7 11 19.5 11.6 19.5 12.3 C19.5 13 18.7 13.5 17.5 13.7 C16.3 13.9 15.5 14.5 15.5 15.2 C15.5 15.9 16.3 16.5 17.5 16.5 C18.7 16.5 19.5 15.9 19.5 15.2" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" fill="none"/>
+<path d="M11.5 22 L17.5 26 L23.5 22" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+<path d="M17.5 26 L17.5 21" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+</g>
 </svg>

--- a/api/schemas/ai/2026-05-06-beta/symbols/risks_physical.svg
+++ b/api/schemas/ai/2026-05-06-beta/symbols/risks_physical.svg
@@ -1,5 +1,7 @@
 <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="14" cy="13" r="2.5" stroke="currentColor" stroke-width="1.75"/>
-<path d="M14 16 L14 23 L11 28 M14 23 L17 28 M10 19 L14 18 L18 19" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M25 12 L25 17 M22.5 14.5 L27.5 14.5 M23.2 12.7 L26.8 16.3 M26.8 12.7 L23.2 16.3" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+<g transform="scale(1.0285714285714285)">
+<path d="M17.5 7 L29 25 L6 25 Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="none"/>
+<path d="M17.5 13 L17.5 19" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+<circle cx="17.5" cy="22" r="0.9" fill="currentColor"/>
+</g>
 </svg>

--- a/api/schemas/ai/2026-05-06-beta/symbols/risks_political-economic.svg
+++ b/api/schemas/ai/2026-05-06-beta/symbols/risks_political-economic.svg
@@ -1,7 +1,11 @@
 <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M7 14 L18 8 L29 14 L7 14 Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M6 28 L30 28" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
-<path d="M11 16 L11 26" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
-<path d="M25 16 L25 26" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
-<path d="M18 8 L16 12 L19 16 L17 21 L18 26" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<g transform="scale(1.0285714285714285)">
+<path d="M6 13 L17.5 8 L29 13" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+<path d="M5 26 L30 26" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+<path d="M9 14 L9 19" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+<path d="M14 14 L13 19 L15 22 L13 26" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+<path d="M22 14 L22 26" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+<path d="M26 14 L26 26" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+<path d="M9 22 L9 26" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+</g>
 </svg>

--- a/api/schemas/ai/2026-05-06-beta/symbols/risks_psychological.svg
+++ b/api/schemas/ai/2026-05-06-beta/symbols/risks_psychological.svg
@@ -1,5 +1,7 @@
 <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M21 9 C16.5 9 13 12.5 13 16.5 C13 18 13.5 19 14 20 L14 25 L21 25" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M24 13 L27 16 L24 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M27.5 10 L30.5 13 L27.5 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<g transform="scale(1.0285714285714285)">
+<path d="M11 17 C11 12.5 14 9.5 17.5 9.5 C21 9.5 24 12.5 24 17 L24 22 L20 22 L20 25 L13 25 L13 19 L11 19 Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" fill="none"/>
+<path d="M16 14.5 C16.6 14 17.4 14 18 14.5 C18.6 15 18.6 16 18 16.5 C17.4 17 17 17.5 17 18.5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" fill="none"/>
+<circle cx="17" cy="20.5" r="0.7" fill="currentColor"/>
+</g>
 </svg>

--- a/api/schemas/ai/2026-05-06-beta/symbols/risks_reputational.svg
+++ b/api/schemas/ai/2026-05-06-beta/symbols/risks_reputational.svg
@@ -1,7 +1,7 @@
 <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="14" cy="12" r="2.5" stroke="currentColor" stroke-width="2" fill="none"/>
-<path d="M9.5 23 L9.5 19.5 C9.5 17.3 11.5 16 14 16 C16.5 16 18.5 17.3 18.5 19.5 L18.5 23" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-<path d="M17.5 18 L21 21" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-<path d="M22 19 L28 21 L26.5 26 L20.5 24 Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" fill="none"/>
-<circle cx="23" cy="21.5" r="0.6" stroke="currentColor" stroke-width="1.5" fill="none"/>
+<g transform="scale(1.0285714285714285)">
+<path d="M8 11 L26 11 C26.6 11 27 11.4 27 12 L27 21 C27 21.6 26.6 22 26 22 L17 22 L13 26 L13 22 L8 22 C7.4 22 7 21.6 7 21 L7 12 C7 11.4 7.4 11 8 11 Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" fill="none"/>
+<path d="M13 14.5 L21 18.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+<path d="M21 14.5 L13 18.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+</g>
 </svg>

--- a/api/schemas/ai/2026-05-06-beta/symbols/risks_societal-cultural.svg
+++ b/api/schemas/ai/2026-05-06-beta/symbols/risks_societal-cultural.svg
@@ -1,8 +1,10 @@
 <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="10" cy="14" r="2.5" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M6 24 C6 20.5 7.8 18.5 10 18.5 C12.2 18.5 14 20.5 14 24" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="22" cy="14" r="2.5" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M18 24 C18 20.5 19.8 18.5 22 18.5 C24.2 18.5 26 20.5 26 24" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="29.5" cy="15.5" r="2" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M16 9 L16 27" stroke="currentColor" stroke-width="2.1" stroke-linecap="round"/>
+<g transform="scale(1.0285714285714285)">
+<circle cx="9" cy="13" r="2.2" stroke="currentColor" stroke-width="1.3" fill="none"/>
+<circle cx="17.5" cy="11.5" r="2.5" stroke="currentColor" stroke-width="1.3" fill="none"/>
+<circle cx="26" cy="13" r="2.2" stroke="currentColor" stroke-width="1.3" fill="none"/>
+<path d="M5.5 23 C5.5 19.5 7 17.5 9 17.5 C10.5 17.5 11.5 18.5 12 19.5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" fill="none"/>
+<path d="M22 19.5 C22.5 18.5 23.5 17.5 25 17.5 C27 17.5 28.5 19.5 28.5 23" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" fill="none"/>
+<path d="M14 24 L15.5 16 L17 24 L18.5 16 L20 24" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round" stroke-linecap="round" fill="none"/>
+</g>
 </svg>


### PR DESCRIPTION
## Summary
Reverts the 15 `mode_*` and `risks_*` SVGs in `api/schemas/ai/2026-05-06-beta/symbols/` back to their `2026-04-27-beta` versions, undoing the Functional Modes and Risks & Mitigation portion of the PR #285 icon design pass.

## Test plan
- [ ] Spot-check the affected icons render correctly via `get_icon_url` / datachain rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)