### PR TITLE
fix(dtpr-ai): restore Cmd-K elements/categories + i18n routing fixes

### DIFF
--- a/api/src/middleware/cors.ts
+++ b/api/src/middleware/cors.ts
@@ -9,6 +9,8 @@ const ALLOW_LIST: readonly string[] = [
   'https://dtpr.io',
   'https://www.dtpr.io',
   'https://docs.dtpr.io',
+  'https://dtpr.ai',
+  'https://www.dtpr.ai',
   'https://studio.nuxt.com',
 ]
 

--- a/api/test/unit/middleware/cors.test.ts
+++ b/api/test/unit/middleware/cors.test.ts
@@ -5,7 +5,10 @@ import { _test as corsTest } from '../../../src/middleware/cors.ts'
 describe('middleware: cors', () => {
   it('allows explicit allow-list origins', () => {
     expect(corsTest.isAllowedOrigin('https://dtpr.io')).toBe(true)
+    expect(corsTest.isAllowedOrigin('https://www.dtpr.io')).toBe(true)
     expect(corsTest.isAllowedOrigin('https://docs.dtpr.io')).toBe(true)
+    expect(corsTest.isAllowedOrigin('https://dtpr.ai')).toBe(true)
+    expect(corsTest.isAllowedOrigin('https://www.dtpr.ai')).toBe(true)
   })
 
   it('allows preview subdomains by pattern', () => {

--- a/dtpr-ai/app/components/app/AppHeaderCTA.vue
+++ b/dtpr-ai/app/components/app/AppHeaderCTA.vue
@@ -4,11 +4,12 @@
 // default). This is docus's canonical extension point for right-side
 // header buttons — it renders left of UColorModeButton and the
 // GitHub link.
+const localePath = useLocalePath()
 </script>
 
 <template>
   <UButton
-    to="/taxonomy"
+    :to="localePath('/taxonomy')"
     label="Taxonomy"
     color="neutral"
     variant="ghost"

--- a/dtpr-ai/app/components/content/ProseA.vue
+++ b/dtpr-ai/app/components/content/ProseA.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+// Override of `@nuxt/ui`'s ProseA so markdown links inside content
+// resolve through `useLocalePath` — markdown source uses bare `/mcp`,
+// `/getting-started`, etc., and we need them to render as
+// `/en/mcp`, `/fr/getting-started`, etc. under the i18n `prefix`
+// strategy. Skips:
+//   - protocol-qualified URLs (https://, mailto:, etc.)
+//   - protocol-relative `//host/...`
+//   - paths that already start with a known locale (`/en/...`, `/fr`),
+//     so cross-locale references like `[English](/en)` in `fr/index.md`
+//     don't get re-prefixed into `/fr/en`.
+import { computed } from 'vue'
+import { useI18n } from '#i18n'
+import ULink from '#ui/components/Link.vue'
+
+const props = defineProps<{
+  href?: string
+  target?: string
+  class?: unknown
+  ui?: Record<string, unknown>
+}>()
+
+const localePath = useLocalePath()
+const { locales } = useI18n()
+
+const localeCodes = computed(() => (locales.value as Array<{ code: string }>).map(l => l.code))
+
+const isInternal = (h: string) => h.startsWith('/') && !h.startsWith('//')
+
+const startsWithKnownLocale = (h: string) => {
+  const first = h.split('/')[1]
+  if (!first) return false
+  return localeCodes.value.includes(first)
+}
+
+const resolvedHref = computed(() => {
+  const h = props.href ?? ''
+  if (!h || !isInternal(h)) return h
+  if (startsWithKnownLocale(h)) return h
+  return localePath(h)
+})
+</script>
+
+<template>
+  <ULink :href="resolvedHref" :target="target" :class="props.class" raw>
+    <slot />
+  </ULink>
+</template>

--- a/dtpr-ai/app/components/content/ProseCard.vue
+++ b/dtpr-ai/app/components/content/ProseCard.vue
@@ -1,0 +1,92 @@
+<script>
+import theme from '#build/ui/prose/card'
+</script>
+
+<script setup>
+// Override of `@nuxt/ui`'s `ProseCard` (Card.vue from
+// `@nuxt/ui/dist/runtime/components/prose/Card.vue`). Mirrors upstream
+// verbatim (including the `tv()` theme wiring) except for one change:
+// the `to` prop is routed through `useLocalePath` when it points at an
+// internal absolute path. Markdown source uses bare paths like
+// `to="/mcp"`; under our `strategy: 'prefix'` i18n setup those need
+// to become `/en/mcp` / `/fr/mcp`.
+//
+// On a `@nuxt/ui` bump, re-sync this file against upstream Card.vue
+// to pick up styling or markup changes; the `useLocalePath` rewrite
+// is the only intentional divergence.
+import { computed } from 'vue'
+import { useAppConfig } from '#imports'
+import { useI18n } from '#i18n'
+import { useComponentUI } from '#ui/composables/useComponentUI'
+import { tv } from '#ui/utils/tv'
+import ULink from '#ui/components/Link.vue'
+import UIcon from '#ui/components/Icon.vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  to: { type: null, required: false },
+  target: { type: [String, Object, null], required: false },
+  icon: { type: null, required: false },
+  title: { type: String, required: false },
+  description: { type: String, required: false },
+  color: { type: null, required: false },
+  class: { type: null, required: false },
+  ui: { type: Object, required: false },
+})
+
+const slots = defineSlots()
+const appConfig = useAppConfig()
+const uiProp = useComponentUI('prose.card', props)
+const ui = computed(() => tv({ extend: tv(theme), ...appConfig.ui?.prose?.card || {} })({
+  color: props.color,
+  to: !!props.to,
+  title: !!props.title,
+}))
+
+const localePath = useLocalePath()
+const { locales } = useI18n()
+const localeCodes = computed(() => locales.value.map((l) => l.code))
+const resolvedTo = computed(() => {
+  const t = props.to
+  if (typeof t !== 'string') return t
+  if (!t.startsWith('/') || t.startsWith('//')) return t
+  // Skip if already prefixed with a known locale (e.g., a `/en/...`
+  // link inside `fr/...` content).
+  const first = t.split('/')[1]
+  if (first && localeCodes.value.includes(first)) return t
+  return localePath(t)
+})
+
+const target = computed(() => props.target || (!!props.to && typeof props.to === 'string' && props.to.startsWith('http') ? '_blank' : undefined))
+const ariaLabel = computed(() => (props.title || 'Card link').trim())
+</script>
+
+<template>
+  <div :class="ui.base({ class: [uiProp?.base, props.class] })">
+    <ULink
+      v-if="resolvedTo"
+      :aria-label="ariaLabel"
+      v-bind="{ to: resolvedTo, target, ...$attrs }"
+      class="focus:outline-none"
+      raw
+    >
+      <span class="absolute inset-0" aria-hidden="true" />
+    </ULink>
+
+    <UIcon v-if="icon" :name="icon" :class="ui.icon({ class: uiProp?.icon })" />
+    <UIcon v-if="!!resolvedTo && target === '_blank'" :name="appConfig.ui.icons.external" :class="ui.externalIcon({ class: uiProp?.externalIcon })" />
+
+    <p v-if="title || !!slots.title" :class="ui.title({ class: uiProp?.title })">
+      <slot name="title" mdc-unwrap="p">
+        {{ title }}
+      </slot>
+    </p>
+
+    <div v-if="!!slots.default" :class="ui.description({ class: uiProp?.description })">
+      <slot>
+        {{ description }}
+      </slot>
+    </div>
+  </div>
+</template>

--- a/dtpr-ai/content/en/1.getting-started/0.index.md
+++ b/dtpr-ai/content/en/1.getting-started/0.index.md
@@ -3,8 +3,6 @@ title: Getting started
 description: What DTPR for AI is, who it's for, and how to pick a quickstart.
 ---
 
-# Getting started
-
 **DTPR for AI** is the documentation surface for the AI-era of the [Digital Trust for Places & Routines](https://docs.dtpr.io) standard. If you are integrating DTPR from an MCP host, an HTTP client, or a web or server-side rendering surface, this site is for you.
 
 ## Who this is for

--- a/dtpr-ai/content/en/1.getting-started/1.mcp-quickstart.md
+++ b/dtpr-ai/content/en/1.getting-started/1.mcp-quickstart.md
@@ -3,8 +3,6 @@ title: MCP quickstart
 description: Zero to a working render_datachain + resources/read in five calls.
 ---
 
-# MCP quickstart
-
 ::callout{type="info"}
 Five curls. Five minutes. Ends with a rendered datachain HTML document fetched from the MCP Apps resource.
 ::

--- a/dtpr-ai/content/en/1.getting-started/2.rest-quickstart.md
+++ b/dtpr-ai/content/en/1.getting-started/2.rest-quickstart.md
@@ -3,8 +3,6 @@ title: REST quickstart
 description: Three curls against the v2 REST API.
 ---
 
-# REST quickstart
-
 ::callout{type="info"}
 Three calls. No auth. All responses are JSON.
 ::

--- a/dtpr-ai/content/en/1.getting-started/3.ui-quickstart.md
+++ b/dtpr-ai/content/en/1.getting-started/3.ui-quickstart.md
@@ -3,8 +3,6 @@ title: UI quickstart
 description: Render a datachain in a Vue 3 app with @dtpr/ui/vue.
 ---
 
-# UI quickstart
-
 ::callout{type="info"}
 Minimal Vue 3 + Vite app. Fetches a datachain's elements and renders `<DtprDatachain>`.
 ::

--- a/dtpr-ai/content/en/2.mcp/0.index.md
+++ b/dtpr-ai/content/en/2.mcp/0.index.md
@@ -3,8 +3,6 @@ title: MCP server
 description: Overview of the DTPR MCP server — endpoint, tools, resources, prompts, envelope semantics.
 ---
 
-# MCP server
-
 The DTPR MCP server exposes the DTPR schema, datachain validation, datachain rendering, icon URL resolution, and the DTPR Agent Skills as [Model Context Protocol](https://modelcontextprotocol.io) tools, resources, and prompts. It is hosted at:
 
 ```

--- a/dtpr-ai/content/en/2.mcp/1.connection.md
+++ b/dtpr-ai/content/en/2.mcp/1.connection.md
@@ -3,8 +3,6 @@ title: Connecting
 description: Endpoint, headers, wire format, and batch behavior for the DTPR MCP server.
 ---
 
-# Connecting
-
 ::callout{type="info"}
 The DTPR MCP server implements a read-only subset of the Model Context Protocol over Streamable HTTP. There is no SSE channel and no server-initiated notifications.
 ::

--- a/dtpr-ai/content/en/2.mcp/2.envelope.md
+++ b/dtpr-ai/content/en/2.mcp/2.envelope.md
@@ -3,8 +3,6 @@ title: Envelope
 description: ok / err payload shape, _meta fields, and soft-failure semantics shared across every tool.
 ---
 
-# Envelope
-
 ::callout{type="info"}
 Every DTPR MCP tool returns the same `{ ok, data | errors, meta }` envelope, embedded in the MCP tool-result shape. REST consumers see the identical body shape without the MCP wrapper.
 ::

--- a/dtpr-ai/content/en/2.mcp/3.resources.md
+++ b/dtpr-ai/content/en/2.mcp/3.resources.md
@@ -3,8 +3,6 @@ title: Resources
 description: The ui://dtpr/datachain/view.html MCP App resource and session-scoped rendering.
 ---
 
-# Resources
-
 ::callout{type="info"}
 DTPR exposes one MCP resource — an [MCP App](https://modelcontextprotocol.io) HTML document produced by the [`render_datachain`](/mcp/tools/render-datachain) tool.
 ::

--- a/dtpr-ai/content/en/2.mcp/4.tools/0.index.md
+++ b/dtpr-ai/content/en/2.mcp/4.tools/0.index.md
@@ -3,8 +3,6 @@ title: Tools
 description: The 9 DTPR MCP tools.
 ---
 
-# Tools
-
 Every tool returns the same [envelope](/mcp/envelope) shape (`ok`/`errors`/`meta`). Canonical schema version in all examples: `ai@2026-04-16-beta`.
 
 | Tool | Purpose | Pagination | Soft-failure |

--- a/dtpr-ai/content/en/2.mcp/4.tools/1.list-schema-versions.md
+++ b/dtpr-ai/content/en/2.mcp/4.tools/1.list-schema-versions.md
@@ -3,8 +3,6 @@ title: list_schema_versions
 description: Enumerate DTPR schema versions and their stability.
 ---
 
-# list_schema_versions
-
 ::callout{type="info"}
 Start here when you don't yet know which version to pin. Every other tool takes a `version` argument.
 ::

--- a/dtpr-ai/content/en/2.mcp/4.tools/2.get-schema.md
+++ b/dtpr-ai/content/en/2.mcp/4.tools/2.get-schema.md
@@ -3,8 +3,6 @@ title: get_schema
 description: Fetch the manifest, categories, and optionally all elements for one schema version.
 ---
 
-# get_schema
-
 ::callout{type="info"}
 The fastest way to pull an entire schema version in one call. Pair with `include="full"` when you need every element inline.
 ::

--- a/dtpr-ai/content/en/2.mcp/4.tools/3.list-categories.md
+++ b/dtpr-ai/content/en/2.mcp/4.tools/3.list-categories.md
@@ -3,8 +3,6 @@ title: list_categories
 description: List the categories defined in a schema version, with locale filtering.
 ---
 
-# list_categories
-
 ::callout{type="info"}
 Small, cheap call. Use it to populate a category picker or learn the category order the schema ships with.
 ::

--- a/dtpr-ai/content/en/2.mcp/4.tools/4.list-elements.md
+++ b/dtpr-ai/content/en/2.mcp/4.tools/4.list-elements.md
@@ -3,8 +3,6 @@ title: list_elements
 description: Paginated element list with category filter, BM25 search, projection, and locale filtering.
 ---
 
-# list_elements
-
 ::callout{type="info"}
 The workhorse read. Default projection is `["id","title","category_id"]`; pass `fields: "all"` for the full element shape.
 ::

--- a/dtpr-ai/content/en/2.mcp/4.tools/5.get-element.md
+++ b/dtpr-ai/content/en/2.mcp/4.tools/5.get-element.md
@@ -3,8 +3,6 @@ title: get_element
 description: Point read for a single element by id, with full projection by default.
 ---
 
-# get_element
-
 ::callout{type="info"}
 Default projection is `"all"` — you get every field unless you restrict `fields`.
 ::

--- a/dtpr-ai/content/en/2.mcp/4.tools/6.get-elements.md
+++ b/dtpr-ai/content/en/2.mcp/4.tools/6.get-elements.md
@@ -3,8 +3,6 @@ title: get_elements
 description: Bulk point-read for up to 100 elements in one call, with per-id soft-failure.
 ---
 
-# get_elements
-
 ::callout{type="info"}
 Use this instead of N parallel `get_element` calls when you have a known id list. Cap is **100 unique ids** after server-side dedupe.
 ::

--- a/dtpr-ai/content/en/2.mcp/4.tools/7.validate-datachain.md
+++ b/dtpr-ai/content/en/2.mcp/4.tools/7.validate-datachain.md
@@ -3,8 +3,6 @@ title: validate_datachain
 description: Validate a datachain instance against a schema version — always isError:false.
 ---
 
-# validate_datachain
-
 ::callout{type="info"}
 Invalid is a successful answer. This tool always returns with `isError: false`; semantic failures surface as `ok: false` in the envelope.
 ::

--- a/dtpr-ai/content/en/2.mcp/4.tools/8.render-datachain.md
+++ b/dtpr-ai/content/en/2.mcp/4.tools/8.render-datachain.md
@@ -3,8 +3,6 @@ title: render_datachain
 description: Render a datachain instance as an MCP App HTML document served via resources/read.
 ---
 
-# render_datachain
-
 ::callout{type="info"}
 This tool produces an [MCP App](https://modelcontextprotocol.io) — an HTML document an MCP client can embed in an iframe. The tool response carries a short text summary plus `_meta.ui.resourceUri`; the client follows with `resources/read` on the same session to fetch the HTML.
 ::

--- a/dtpr-ai/content/en/2.mcp/4.tools/9.get-icon-url.md
+++ b/dtpr-ai/content/en/2.mcp/4.tools/9.get-icon-url.md
@@ -3,8 +3,6 @@ title: get_icon_url
 description: Resolve a composed-icon URL for an element + optional variant.
 ---
 
-# get_icon_url
-
 ::callout{type="info"}
 Handy when you want a single URL to hand off to an image renderer or `<img>` tag. The returned URL is the REST icon route.
 ::

--- a/dtpr-ai/content/en/2.mcp/5.prompts.md
+++ b/dtpr-ai/content/en/2.mcp/5.prompts.md
@@ -3,8 +3,6 @@ title: Prompts
 description: The DTPR MCP server registers the seven Agent Skills (and their reference documents) as MCP prompts, so any MCP-aware harness can list and load them.
 ---
 
-# Prompts
-
 The DTPR MCP server exposes each of the [seven DTPR Agent Skills](/plugin/skills) — plus the two shared reference documents the schema-tier skills cite — as registered MCP prompts. Any MCP-aware client (Cursor, Continue, Cline, Claude Desktop, custom clients, the Anthropic Agent SDK) can list and load them via the standard `prompts/list` and `prompts/get` methods.
 
 ::callout{type="info"}

--- a/dtpr-ai/content/en/3.rest/0.index.md
+++ b/dtpr-ai/content/en/3.rest/0.index.md
@@ -3,8 +3,6 @@ title: REST API (v2)
 description: Overview of the DTPR v2 REST API — base URL, headers, authentication, CORS.
 ---
 
-# REST API (v2)
-
 The DTPR v2 REST API is a public, read-only JSON + SVG API hosted at:
 
 ```

--- a/dtpr-ai/content/en/3.rest/1.schemas.md
+++ b/dtpr-ai/content/en/3.rest/1.schemas.md
@@ -3,8 +3,6 @@ title: GET /schemas
 description: List registered DTPR schema versions.
 ---
 
-# GET /schemas
-
 ::callout{type="info"}
 Start here when discovering which versions are available. Returns the same `versions[]` array that `schemas/index.json` publishes.
 ::

--- a/dtpr-ai/content/en/3.rest/2.manifest.md
+++ b/dtpr-ai/content/en/3.rest/2.manifest.md
@@ -3,8 +3,6 @@ title: GET /schemas/:version/manifest
 description: Fetch the manifest for one schema version.
 ---
 
-# GET /schemas/:version/manifest
-
 ::callout{type="info"}
 The manifest is the smallest document that uniquely identifies a version — title, description, status, and `content_hash`.
 ::

--- a/dtpr-ai/content/en/3.rest/3.categories.md
+++ b/dtpr-ai/content/en/3.rest/3.categories.md
@@ -3,8 +3,6 @@ title: GET /schemas/:version/categories
 description: List the categories defined in a schema version.
 ---
 
-# GET /schemas/:version/categories
-
 ::callout{type="info"}
 Small, cheap response. Use for populating category pickers or learning the schema's category order.
 ::

--- a/dtpr-ai/content/en/3.rest/4.elements-list.md
+++ b/dtpr-ai/content/en/3.rest/4.elements-list.md
@@ -3,8 +3,6 @@ title: GET /schemas/:version/elements
 description: Paginated element list with category filter, BM25 search, projection, and locale filtering.
 ---
 
-# GET /schemas/:version/elements
-
 ::callout{type="info"}
 The default projection is `["id","title","category_id"]`. Pass `?fields=all` for full records.
 ::

--- a/dtpr-ai/content/en/3.rest/5.element-detail.md
+++ b/dtpr-ai/content/en/3.rest/5.element-detail.md
@@ -3,8 +3,6 @@ title: GET /schemas/:version/elements/:element_id
 description: Point read for a single element by id.
 ---
 
-# GET /schemas/:version/elements/:element_id
-
 ::callout{type="info"}
 Default projection is `all`. Inspect `icon_variants` for the variant keys valid in composed-icon URLs.
 ::

--- a/dtpr-ai/content/en/3.rest/6.validate.md
+++ b/dtpr-ai/content/en/3.rest/6.validate.md
@@ -3,8 +3,6 @@ title: POST /schemas/:version/validate
 description: Validate a datachain instance against a schema version.
 ---
 
-# POST /schemas/:version/validate
-
 ::callout{type="warning"}
 The HTTP status is **200** for both `ok: true` and `ok: false`. Validation success/failure is a semantic answer carried in the body — it is not a transport failure.
 ::

--- a/dtpr-ai/content/en/3.rest/7.icons.md
+++ b/dtpr-ai/content/en/3.rest/7.icons.md
@@ -3,8 +3,6 @@ title: Icon routes
 description: Shape primitives, release-pinned symbols, and composed element icons.
 ---
 
-# Icon routes
-
 ::callout{type="info"}
 Three related SVG routes. All return `Content-Type: image/svg+xml; charset=utf-8`. Cache-Control varies by version stability (see [conventions](/rest)).
 ::

--- a/dtpr-ai/content/en/3.rest/8.pagination-and-fields.md
+++ b/dtpr-ai/content/en/3.rest/8.pagination-and-fields.md
@@ -3,8 +3,6 @@ title: Pagination & fields
 description: Cursor semantics, limits, field projection, and locale filtering.
 ---
 
-# Pagination & fields
-
 ::callout{type="info"}
 Shared cross-endpoint behavior. Applies to list endpoints and is mirrored by the MCP counterparts.
 ::

--- a/dtpr-ai/content/en/3.rest/9.errors.md
+++ b/dtpr-ai/content/en/3.rest/9.errors.md
@@ -3,8 +3,6 @@ title: Errors
 description: The shared error shape and canonical code list.
 ---
 
-# Errors
-
 ::callout{type="info"}
 Every error response — REST or MCP — carries the same `{ ok: false, errors: [...] }` shape. `code` is stable; `message` and `fix_hint` are human-readable.
 ::

--- a/dtpr-ai/content/en/4.icons/0.index.md
+++ b/dtpr-ai/content/en/4.icons/0.index.md
@@ -3,8 +3,6 @@ title: Icon composition
 description: Shape × symbol × variant mental model behind every DTPR icon.
 ---
 
-# Icon composition
-
 Every DTPR icon is a 36×36 SVG composed on demand from three independent inputs:
 
 ```

--- a/dtpr-ai/content/en/4.icons/1.shapes.md
+++ b/dtpr-ai/content/en/4.icons/1.shapes.md
@@ -3,8 +3,6 @@ title: Shapes
 description: The four DTPR shape primitives.
 ---
 
-# Shapes
-
 ::callout{type="info"}
 A category's `shape` field picks one of four bundled primitives. Shapes are not version-pinned — they live in the worker code.
 ::

--- a/dtpr-ai/content/en/4.icons/2.symbols.md
+++ b/dtpr-ai/content/en/4.icons/2.symbols.md
@@ -3,8 +3,6 @@ title: Symbols
 description: Release-pinned symbol SVGs referenced by element.symbol_id.
 ---
 
-# Symbols
-
 ::callout{type="info"}
 Symbols are the "what" inside an element's icon. They are pinned to a specific schema release and stored as SVG documents.
 ::

--- a/dtpr-ai/content/en/4.icons/3.composed-variants.md
+++ b/dtpr-ai/content/en/4.icons/3.composed-variants.md
@@ -3,8 +3,6 @@ title: Composed variants
 description: default / dark / context-colored variants and the WCAG-inspired innerColor rule.
 ---
 
-# Composed variants
-
 ::callout{type="info"}
 Every element has two universal variants — `default` and `dark`. Categories that declare a `context` also expose one colored variant per context value.
 ::

--- a/dtpr-ai/content/en/4.icons/4.urls.md
+++ b/dtpr-ai/content/en/4.icons/4.urls.md
@@ -3,8 +3,6 @@ title: URLs
 description: Derive an icon URL from any (version, element, variant) triple.
 ---
 
-# URLs
-
 ::callout{type="info"}
 Every composed icon has a single canonical URL. You can always derive it from an element id + an optional variant.
 ::

--- a/dtpr-ai/content/en/5.ui/0.index.md
+++ b/dtpr-ai/content/en/5.ui/0.index.md
@@ -3,8 +3,6 @@ title: "@dtpr/ui"
 description: Framework-neutral helpers, Vue components, and SSR HTML renderer for DTPR content.
 ---
 
-# @dtpr/ui
-
 `@dtpr/ui` is the component library for rendering DTPR datachains. It ships three subpath exports so you can pull only the layer you need.
 
 ```bash

--- a/dtpr-ai/content/en/5.ui/1.core.md
+++ b/dtpr-ai/content/en/5.ui/1.core.md
@@ -3,8 +3,6 @@ title: "@dtpr/ui/core"
 description: Framework-neutral helpers for locale extraction, interpolation, category grouping, display derivation, and validation.
 ---
 
-# @dtpr/ui/core
-
 ::callout{type="info"}
 Pure TypeScript, no framework dependencies. Import these helpers from any runtime — Node, Bun, Deno, Workers, a Vue app, a React app.
 ::

--- a/dtpr-ai/content/en/5.ui/2.vue.md
+++ b/dtpr-ai/content/en/5.ui/2.vue.md
@@ -3,8 +3,6 @@ title: "@dtpr/ui/vue"
 description: Six Vue 3 components for rendering DTPR datachains.
 ---
 
-# @dtpr/ui/vue
-
 ::callout{type="info"}
 Vue 3 Single-File Components. Pair with `@dtpr/ui/vue/styles.css` for the default tokens and layout.
 ::

--- a/dtpr-ai/content/en/5.ui/3.html.md
+++ b/dtpr-ai/content/en/5.ui/3.html.md
@@ -3,8 +3,6 @@ title: "@dtpr/ui/html"
 description: Server-side rendering of datachains as standalone HTML documents for MCP Apps.
 ---
 
-# @dtpr/ui/html
-
 ::callout{type="info"}
 SSR the same Vue components as an iframe-renderable HTML document. Used by the MCP server's [`render_datachain`](/mcp/tools/render-datachain) tool.
 ::

--- a/dtpr-ai/content/en/5.ui/4.theming.md
+++ b/dtpr-ai/content/en/5.ui/4.theming.md
@@ -3,8 +3,6 @@ title: Theming
 description: The dtpr cascade layer and the CSS custom properties used by @dtpr/ui/vue.
 ---
 
-# Theming
-
 ::callout{type="info"}
 `@dtpr/ui/vue/styles.css` wraps every rule in `@layer dtpr`. Your own cascade layer outranks it by default — overrides "just work."
 ::

--- a/dtpr-ai/content/en/6.concepts/0.index.md
+++ b/dtpr-ai/content/en/6.concepts/0.index.md
@@ -3,8 +3,6 @@ title: Concepts
 description: DTPR vocabulary you will see across the MCP, REST, icon, and UI reference.
 ---
 
-# Concepts
-
 Short, reference-focused explanations of the vocabulary you will see across this site. For deeper treatment of the DTPR standard — principles, signage, taxonomy motivation — see [docs.dtpr.io](https://docs.dtpr.io).
 
 ## In this section

--- a/dtpr-ai/content/en/6.concepts/1.datachains.md
+++ b/dtpr-ai/content/en/6.concepts/1.datachains.md
@@ -3,8 +3,6 @@ title: Datachains
 description: The DTPR instance that describes a data-collecting technology.
 ---
 
-# Datachains
-
 A **datachain** is a concrete instance of a DTPR schema. It describes one data-collecting technology — what it collects, why, who operates it, and what happens to the data downstream.
 
 ## Structure

--- a/dtpr-ai/content/en/6.concepts/2.elements-categories.md
+++ b/dtpr-ai/content/en/6.concepts/2.elements-categories.md
@@ -3,8 +3,6 @@ title: Elements & categories
 description: The two-level vocabulary DTPR uses to describe data-collecting technologies.
 ---
 
-# Elements & categories
-
 ::callout{type="info"}
 An **element** is a single fact. A **category** groups related elements and carries the visual treatment shared across them.
 ::

--- a/dtpr-ai/content/en/6.concepts/3.versions-and-releases.md
+++ b/dtpr-ai/content/en/6.concepts/3.versions-and-releases.md
@@ -3,8 +3,6 @@ title: Versions & releases
 description: Canonical version ids, aliases, status, and what "release" means for DTPR.
 ---
 
-# Versions & releases
-
 ::callout{type="info"}
 Version ids are canonical. Aliases are conveniences. Pin on the canonical id for reproducibility.
 ::

--- a/dtpr-ai/content/en/6.concepts/4.content-hash.md
+++ b/dtpr-ai/content/en/6.concepts/4.content-hash.md
@@ -3,8 +3,6 @@ title: Content hash
 description: How agents detect DTPR schema content drift without polling.
 ---
 
-# Content hash
-
 ::callout{type="info"}
 Every version-scoped response carries a `DTPR-Content-Hash` header and — for JSON responses — the same value in `meta.content_hash`. Use it to detect drift.
 ::

--- a/dtpr-ai/content/en/6.concepts/5.shape-contract.md
+++ b/dtpr-ai/content/en/6.concepts/5.shape-contract.md
@@ -3,8 +3,6 @@ title: Shape contract
 description: Advisory mapping from DTPR icon shape primitives to the kind of fact a category holds.
 ---
 
-# Shape contract
-
 ::callout{type="info"}
 **Advisory, not schema-enforced.** The structural schema accepts any of the four bundled shape primitives on any category. The mapping below is a design convention DTPR has used informally; the new beta documents it so authors and reviewers can reach for the same vocabulary.
 ::

--- a/dtpr-ai/content/en/6.concepts/6.subchains.md
+++ b/dtpr-ai/content/en/6.concepts/6.subchains.md
@@ -3,8 +3,6 @@ title: Subchains
 description: Named, ordered groupings of categories at the datachain-type level, and their realizations on a datachain instance.
 ---
 
-# Subchains
-
 ::callout{type="info"}
 A **subchain** is a named group of categories declared on a datachain type (e.g. `data_flow = [input_dataset, processing, output_dataset]`). A **subchain instance** is a concrete realization of one of those subchains on a single datachain instance.
 ::

--- a/dtpr-ai/content/en/7.plugin/0.index.md
+++ b/dtpr-ai/content/en/7.plugin/0.index.md
@@ -3,8 +3,6 @@ title: Claude plugin
 description: Seven-skill authoring studio for describing AI systems as DTPR datachains, iterating on the DTPR schema, drafting element icons, translating locales, and grading content for public comprehension.
 ---
 
-# Claude plugin
-
 The **DTPR authoring plugin** packages seven Agent Skills, the DTPR MCP auto-registration, and a file-based research corpus into a drop-in installation for Claude Code, Claude Cowork, and Claude.ai. It turns the integration surfaces documented elsewhere on this site — [MCP tools](/mcp/tools), [REST](/rest), [concepts](/concepts) — into a workflow for writing and auditing DTPR content.
 
 ::callout{type="info"}

--- a/dtpr-ai/content/en/7.plugin/1.install.md
+++ b/dtpr-ai/content/en/7.plugin/1.install.md
@@ -3,8 +3,6 @@ title: Install
 description: Install the DTPR plugin in Claude Code, Claude Cowork, or Claude.ai, and the capability matrix that determines which skills work fully on each host.
 ---
 
-# Install
-
 The plugin lives inside the [`Helpful-Places/dtpr`](https://github.com/Helpful-Places/dtpr) repository under `plugin/dtpr/`. Installation differs per host.
 
 ## Claude Code

--- a/dtpr-ai/content/en/7.plugin/2.skills/0.index.md
+++ b/dtpr-ai/content/en/7.plugin/2.skills/0.index.md
@@ -3,8 +3,6 @@ title: Skills
 description: The seven peer Agent Skills of the DTPR authoring studio.
 ---
 
-# Skills
-
 The plugin bundles seven Agent Skills. They are peers — there is no runtime router. Users and the agent's description-based skill selector pick based on the judgment tier the question lives at. Every schema-tier skill inlines a [Comprehension check](/plugin/comprehension-rubric) block in its output, and every research-capable skill reads and writes the shared [research corpus](/plugin/research-corpus).
 
 ::callout{type="info"}

--- a/dtpr-ai/content/en/7.plugin/2.skills/1.describe-system.md
+++ b/dtpr-ai/content/en/7.plugin/2.skills/1.describe-system.md
@@ -3,8 +3,6 @@ title: dtpr-describe-system
 description: Describe an AI system as a schema-validated DTPR datachain, optionally from a PDF, URL, or verbal description.
 ---
 
-# `dtpr-describe-system`
-
 The instance-tier skill. Turns a natural-language description of an AI or automated-decision system — optionally accompanied by attached artifacts (PDFs, URLs) — into a **schema-validated DTPR datachain**: a structured JSON artifact that names who runs the system, what decisions it makes, what data it uses, and what rights people have in relation to it.
 
 ## When to fire

--- a/dtpr-ai/content/en/7.plugin/2.skills/2.datachain-structure.md
+++ b/dtpr-ai/content/en/7.plugin/2.skills/2.datachain-structure.md
@@ -3,8 +3,6 @@ title: dtpr-datachain-structure
 description: Critique or propose changes to the datachain-type shape itself — categories, requirements, retirement.
 ---
 
-# `dtpr-datachain-structure`
-
 The meta-structure schema-tier skill. Critiques or proposes changes to the **datachain-type** shape itself — which categories exist, which are required vs optional, whether a whole category should retire or split. This is distinct from auditing elements *inside* one category ([`dtpr-category-audit`](/plugin/skills/category-audit)) or drafting a new element ([`dtpr-element-design`](/plugin/skills/element-design)).
 
 ## When to fire

--- a/dtpr-ai/content/en/7.plugin/2.skills/3.category-audit.md
+++ b/dtpr-ai/content/en/7.plugin/2.skills/3.category-audit.md
@@ -3,8 +3,6 @@ title: dtpr-category-audit
 description: Audit one category's element collection for coherence, overlap, and gaps.
 ---
 
-# `dtpr-category-audit`
-
 The category-tier schema skill. Scope is exactly **one category** — does the element collection cover the expected territory without overlap? Coherence = each element occupies a distinct slot. Overlap = two elements converge on the same meaning. Gaps = a risk or scenario no element captures.
 
 ## When to fire

--- a/dtpr-ai/content/en/7.plugin/2.skills/4.element-design.md
+++ b/dtpr-ai/content/en/7.plugin/2.skills/4.element-design.md
@@ -3,8 +3,6 @@ title: dtpr-element-design
 description: Draft, edit, or retire one element — its title, description, variables, and symbol disposition (reuse / hand-off to dtpr-symbol-design / iterate).
 ---
 
-# `dtpr-element-design`
-
 The element-tier schema skill. Scope is **one proposed element** (add, edit, or retire). Output is a YAML fragment skeleton matching the canonical element shape plus a symbol disposition that either reuses an existing icon or hands off to [`dtpr-symbol-design`](/plugin/skills/symbol-design) for the SVG. Locale coverage is skeleton only — only the English `title` and `description` are drafted; one placeholder row per remaining locale in the active manifest's `locales` allow-list is emitted for [`dtpr-translate`](/plugin/skills/translate) to fill in downstream.
 
 ## When to fire

--- a/dtpr-ai/content/en/7.plugin/2.skills/5.symbol-design.md
+++ b/dtpr-ai/content/en/7.plugin/2.skills/5.symbol-design.md
@@ -3,8 +3,6 @@ title: dtpr-symbol-design
 description: Propose and refine SVG symbols for DTPR elements in the established house style — three variants per round with a local HTML preview, then a finalized icon.
 ---
 
-# `dtpr-symbol-design`
-
 The symbol-tier skill. Scope is **one symbol** — proposing a new one, redesigning an existing one, or iterating to a final choice for an element draft. Output is a set of SVG variants ready to drop into `app/public/dtpr-icons/symbols/<symbol_id>.svg`, a local HTML preview that renders all variants at multiple scales, and (after the user picks one) a finalized SVG with its save path.
 
 The skill produces **three variants per round** rather than a single guess — enough to compare silhouette strategies (object-centric vs. action-centric vs. frame-centric, stroke vs. filled) without overwhelming review. The user picks one, asks for refinements, or requests another round of three with different strategies.

--- a/dtpr-ai/content/en/7.plugin/2.skills/6.translate.md
+++ b/dtpr-ai/content/en/7.plugin/2.skills/6.translate.md
@@ -3,8 +3,6 @@ title: dtpr-translate
 description: Fill in non-English locale rows on a DTPR element, category, datachain-type name, or pasted English fragment — against the active schema manifest's locale allow-list, never a hardcoded list.
 ---
 
-# `dtpr-translate`
-
 The locale-tier skill. Scope is **non-English locale fill-in** for one piece of DTPR content at a time — an element's `title` and `description`, a category's `name` and `description`, a datachain-type's `name`, or an arbitrary English fragment. Output is a YAML fragment in the canonical array-of-`{locale, value}` shape, an inline Comprehension check, and the `schema:new` handoff line.
 
 ::callout{type="info"}

--- a/dtpr-ai/content/en/7.plugin/2.skills/7.comprehension-audit.md
+++ b/dtpr-ai/content/en/7.plugin/2.skills/7.comprehension-audit.md
@@ -3,8 +3,6 @@ title: dtpr-comprehension-audit
 description: Grade any DTPR content (element, category, datachain-instance, pasted YAML, arbitrary markdown) against the public-comprehension rubric.
 ---
 
-# `dtpr-comprehension-audit`
-
 The standalone comprehension-tier skill. Grades DTPR content against the [comprehension rubric](/plugin/comprehension-rubric) and returns a structured findings block plus a one-paragraph summary. **Grading only** — it does not modify schema content, draft elements, or change category structure.
 
 The four authoring skills that emit `schema:new` proposals ([`dtpr-datachain-structure`](/plugin/skills/datachain-structure), [`dtpr-category-audit`](/plugin/skills/category-audit), [`dtpr-element-design`](/plugin/skills/element-design), and [`dtpr-translate`](/plugin/skills/translate)) inline a first-pass Comprehension check in their output. Use this skill for a deeper second pass, a re-grade after the rubric evolves, or a one-off grading without schema work.

--- a/dtpr-ai/content/en/7.plugin/3.research-corpus.md
+++ b/dtpr-ai/content/en/7.plugin/3.research-corpus.md
@@ -3,8 +3,6 @@ title: Research corpus
 description: A file-based, author-seeded knowledge base that compounds across DTPR authoring sessions.
 ---
 
-# Research corpus
-
 `plugin/dtpr/research/` is a file-based, author-seeded knowledge base that all seven skills read from and (where `Write` and `Task` are available) write to. The first time a skill needs a framework (ISO 42001, NIST AI RMF), a regulatory text (EU AI Act), or a prior-art pattern (algorithmic-transparency notices), it dispatches a researcher, captures the synthesis as a corpus entry, and every later session cites it instead of re-researching.
 
 ::callout{type="info"}

--- a/dtpr-ai/content/en/7.plugin/4.comprehension-rubric.md
+++ b/dtpr-ai/content/en/7.plugin/4.comprehension-rubric.md
@@ -3,8 +3,6 @@ title: Comprehension rubric
 description: The seven-item rubric that the four authoring skills inline and dtpr-comprehension-audit grades against.
 ---
 
-# Comprehension rubric
-
 A qualitative checklist for grading DTPR content (datachain-types, categories, elements, full datachain-instances) against the bar of **"a non-technical person encountering an AI system understands this on a quick read."** The audience is anyone meeting an AI system in the wild — in an app, on a website, in a vehicle, on a kiosk or sign, or while moving through public space — with enough time to parse what they see but no prior expertise. There is no scoring math. Each item has pass / fail / partial signals plus an explicit **n/a** when it does not apply to the artifact under review.
 
 This rubric is the shared dependency of [`dtpr-comprehension-audit`](/plugin/skills/comprehension-audit) (standalone use) and the four authoring skills that inline findings — [`dtpr-datachain-structure`](/plugin/skills/datachain-structure), [`dtpr-category-audit`](/plugin/skills/category-audit), [`dtpr-element-design`](/plugin/skills/element-design), and [`dtpr-translate`](/plugin/skills/translate) — which emit a Comprehension check block using the shared template before handing off via `schema:new`.

--- a/dtpr-ai/content/en/8.changelog.md
+++ b/dtpr-ai/content/en/8.changelog.md
@@ -3,8 +3,6 @@ title: Changelog
 description: What landed when — MCP, REST v2, icons, @dtpr/ui, and this microsite.
 ---
 
-# Changelog
-
 Most recent first. Grouped by surface. See the [repository](https://github.com/helpful-places/dtpr) for the full commit history.
 
 ## 2026-05-07

--- a/dtpr-ai/content/en/9.attribution.md
+++ b/dtpr-ai/content/en/9.attribution.md
@@ -3,8 +3,6 @@ title: Attribution
 description: Research foundations and license terms for DTPR for AI and any content adapted from external sources.
 ---
 
-# Attribution
-
 DTPR for AI is an extension of the [Digital Trust for Places & Routines](https://docs.dtpr.io) standard. This page documents the license terms inherited from DTPR and any additional license terms that apply to content adapted from external taxonomies.
 
 ## DTPR core

--- a/dtpr-ai/content/fr/index.md
+++ b/dtpr-ai/content/fr/index.md
@@ -2,8 +2,6 @@
 title: DTPR for AI
 ---
 
-# DTPR for AI
-
 Translated documentation is coming soon. The English documentation
 is available at [/en](/en).
 

--- a/dtpr-ai/nuxt.config.ts
+++ b/dtpr-ai/nuxt.config.ts
@@ -5,7 +5,45 @@ export default defineNuxtConfig({
   // (to add its bundled locale message files) but does not register
   // the module itself. We add it here so `useI18n`, `useLocalePath`,
   // `useSwitchLocalePath`, and `<NuxtLinkLocale>` are wired up.
-  modules: ['@nuxtjs/i18n'],
+  //
+  // The inline module after it patches the two route templates docus
+  // ships with — both were written for the no-i18n / no-prefix case
+  // and break under `strategy: 'prefix'` because `@nuxtjs/i18n`
+  // prepends `/{locale}` to every route's path (`/foo` → `/en/foo`
+  // + `/fr/foo`):
+  //
+  //   1. `lang-index` (landing template, path `/:lang?`) gets prefixed
+  //      to `/en/:lang?`, which then matches *any* single-segment URL
+  //      starting with `/en` — including `/en/getting-started`. The
+  //      docs URL therefore lands on landing.vue, which queries the
+  //      `landing_en` collection (only entry: `/en`) and 404s.
+  //   2. `lang-slug` (docs catchall, path `/:lang?/:slug(.*)*`) gets
+  //      prefixed to `/en/:lang?/:slug(.*)*`, which *also* matches the
+  //      bare `/en` (lang=undefined, slug=[]) and beats the landing
+  //      route, breaking the locale homepage.
+  //
+  // The fix:
+  //   - lang-index → `/` (prefixed to `/en` and `/fr` only)
+  //   - lang-slug  → `/:slug(.+)` (prefixed to `/en/:slug(.+)` and
+  //     `/fr/:slug(.+)`; requires at least one segment after the
+  //     locale, so `/en` falls through to the landing route).
+  //
+  // The patch must run inside a module rather than a top-level
+  // `hooks: { 'pages:extend' }` entry: top-level hooks register before
+  // `extends`-layer modules, so they fire *before* docus's routing
+  // module has appended `lang-index`. Defining the listener in a module
+  // here registers it after docus's, so it runs last.
+  modules: [
+    '@nuxtjs/i18n',
+    (_options, nuxt) => {
+      nuxt.hook('pages:extend', (pages) => {
+        const landing = pages.find(p => p.name === 'lang-index')
+        if (landing) landing.path = '/'
+        const docs = pages.find(p => p.name === 'lang-slug')
+        if (docs) docs.path = '/:slug(.+)'
+      })
+    },
+  ],
 
   site: {
     name: 'DTPR for AI',


### PR DESCRIPTION
## Summary

- **fix(api): CORS allow `dtpr.ai`** — the dtpr-ai microsite at `https://dtpr.ai` was missing from the API's allow-list, so the boot fetch in `useDtprSearchOverlay` silently failed (`.catch()` swallowed CORS errors), leaving the synthetic **Elements** / **Categories** Cmd-K groups empty in production.
- **fix(dtpr-ai): repair routing under `@nuxtjs/i18n` prefix strategy** — docus's `lang-index` and `lang-slug` route templates broke once #287 enabled `strategy: 'prefix'`; patch them via a `pages:extend` module hook so `/en` lands on the landing template and `/en/getting-started` lands on the docs catchall, and pipe the header Taxonomy CTA through `useLocalePath()`.
- **feat(dtpr-ai): locale-aware ProseA + ProseCard overrides** — markdown internal links like `/mcp` now route through `useLocalePath()` so they render as `/en/mcp` / `/fr/mcp`, while protocol-qualified, protocol-relative, and already-locale-prefixed paths fall through unchanged.
- **chore(dtpr-ai): drop redundant H1 from content pages** — docus already renders the frontmatter `title` as the page H1, so the duplicated `# Title` at the top of every markdown file was showing twice; removed across 61 content files (en + fr).

## Test plan

- [ ] After API redeploy, open Cmd-K on https://dtpr.ai and verify the **Elements** and **Categories** groups appear with results
- [ ] Verify `/en` and `/fr` land on the landing template and `/en/getting-started` opens the docs page
- [ ] Click an internal markdown link in the body of any docs page and confirm it stays inside the active locale prefix
- [ ] Verify each docs page renders with a single page heading (no duplicated `# Title` under the title bar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)