### PR TITLE
feat: enable npx skills install path for DTPR plugin

### DIFF
--- a/dtpr-ai/content/en/7.plugin/1.install.md
+++ b/dtpr-ai/content/en/7.plugin/1.install.md
@@ -5,6 +5,34 @@ description: Install the DTPR plugin in Claude Code, Claude Cowork, or Claude.ai
 
 The plugin lives inside the [`Helpful-Places/dtpr`](https://github.com/Helpful-Places/dtpr) repository under `plugin/dtpr/`. Installation differs per host.
 
+## Any host — `npx skills`
+
+The [`skills`](https://github.com/vercel-labs/skills) CLI installs DTPR skills into any agent that reads a local skills directory (Claude Code, Cursor, Codex, Cline, Continue, etc.). Skills install as files on disk; the MCP server still has to be wired up separately by your host.
+
+Install every DTPR skill:
+
+```
+npx skills add Helpful-Places/dtpr
+```
+
+Install one skill:
+
+```
+npx skills add Helpful-Places/dtpr --skill dtpr-describe-system
+```
+
+List what's available before installing:
+
+```
+npx skills add Helpful-Places/dtpr --list
+```
+
+By default `skills` writes to the project-local agent directory it detects (e.g. `.claude/skills/`, `.cursor/skills/`). Pass `--global` to install to your home directory instead. See the [`skills` README](https://github.com/vercel-labs/skills) for symlink-vs-copy and target-agent flags.
+
+::callout{type="warning"}
+`npx skills` only installs the skill files. The DTPR MCP server at `https://api.dtpr.io/mcp` is **not** registered automatically — add it to your host's MCP config manually, or use the Claude Code marketplace install below which bundles `.mcp.json`.
+::
+
 ## Claude Code
 
 Add the repository as a marketplace and install:

--- a/dtpr-ai/content/en/7.plugin/1.install.md
+++ b/dtpr-ai/content/en/7.plugin/1.install.md
@@ -12,7 +12,7 @@ The [`skills`](https://github.com/vercel-labs/skills) CLI installs DTPR skills i
 Install every DTPR skill:
 
 ```
-npx skills add Helpful-Places/dtpr
+npx skills add Helpful-Places/dtpr --all
 ```
 
 Install one skill:

--- a/skills
+++ b/skills
@@ -1,0 +1,1 @@
+plugin/dtpr/skills


### PR DESCRIPTION
DTPR skills can now be installed into any agent host via `npx skills add Helpful-Places/dtpr`. A top-level `skills/` symlink points at `plugin/dtpr/skills/` so the [vercel-labs/skills](https://github.com/vercel-labs/skills) CLI resolves the directory via its convention fast path instead of falling back to a recursive scan. The dtpr-ai install page documents the three commands (all skills, single skill, `--list`) and calls out that the MCP server still has to be wired into the host's config manually — `npx skills` only installs skill files.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
