### PR TITLE
chore: add @dtpr/placeholder to reserve @dtpr npm scope

### DIFF
--- a/packages/placeholder/README.md
+++ b/packages/placeholder/README.md
@@ -1,0 +1,5 @@
+# @dtpr/placeholder
+
+Placeholder package reserving the `@dtpr` npm scope.
+
+The DTPR (Digital Trust for Places and Routines) standard lives at [dtpr.io](https://dtpr.io). Real packages will be published under this scope (`@dtpr/ui`, `@dtpr/api`, etc.) as they are made publish-ready. This package has no runtime use.

--- a/packages/placeholder/index.js
+++ b/packages/placeholder/index.js
@@ -1,0 +1,3 @@
+// Placeholder package reserving the @dtpr npm scope.
+// See https://dtpr.io for the DTPR (Digital Trust for Places and Routines) standard.
+module.exports = {}

--- a/packages/placeholder/package.json
+++ b/packages/placeholder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dtpr/placeholder",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Placeholder package reserving the @dtpr npm scope. See https://dtpr.io.",
   "license": "MIT",
   "homepage": "https://dtpr.io",

--- a/packages/placeholder/package.json
+++ b/packages/placeholder/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://dtpr.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/helpfulplaces/dtpr"
+    "url": "https://github.com/helpful-places/dtpr"
   },
   "files": [
     "index.js",

--- a/packages/placeholder/package.json
+++ b/packages/placeholder/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@dtpr/placeholder",
+  "version": "0.0.1",
+  "description": "Placeholder package reserving the @dtpr npm scope. See https://dtpr.io.",
+  "license": "MIT",
+  "homepage": "https://dtpr.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/helpfulplaces/dtpr"
+  },
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "main": "index.js",
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
The `@dtpr` scope on npm is now locked in. This minimal package (`@dtpr/placeholder@0.0.1`) holds the scope so future real packages, `@dtpr/ui` and `@dtpr/api`, can publish under it once they are publish-ready.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
