### PR TITLE
refactor(api): tighten 2026-05-06-beta category prompts and descriptions

### DIFF
--- a/api/schemas/ai/2026-05-06-beta/categories/access.yaml
+++ b/api/schemas/ai/2026-05-06-beta/categories/access.yaml
@@ -6,14 +6,14 @@ name:
     value: Accéder
 description:
   - locale: en
-    value: The access controls and permissions for the data produced by the AI system.
+    value: Who can see or use the data produced by this AI system.
   - locale: fr
-    value: Les contrôles d’accès et les autorisations pour les données produites par le système d’IA.
+    value: Qui peut voir ou utiliser les données produites par ce système d’IA.
 prompt:
   - locale: en
-    value: Who has access to the data produced by the AI system?
+    value: Who has access to the data?
   - locale: fr
-    value: Qui a accès aux données produites par le système d’IA ?
+    value: Qui a accès aux données ?
 required: false
 order: 9
 datachain_type: ai

--- a/api/schemas/ai/2026-05-06-beta/categories/accountable.yaml
+++ b/api/schemas/ai/2026-05-06-beta/categories/accountable.yaml
@@ -6,9 +6,9 @@ name:
     value: Responsable
 description:
   - locale: en
-    value: The organization accountable for the deployment of this AI system.
+    value: The organization responsible for deploying and operating this AI system.
   - locale: fr
-    value: L'organisation responsable du déploiement de ce système d'IA.
+    value: L’organisation responsable du déploiement et de l’exploitation de ce système d’IA.
 prompt:
   - locale: en
     value: Who is accountable for this AI system?

--- a/api/schemas/ai/2026-05-06-beta/categories/functional_modes.yaml
+++ b/api/schemas/ai/2026-05-06-beta/categories/functional_modes.yaml
@@ -15,9 +15,14 @@ description:
       sémantique, génératif, agentique, perceptif, physique) qu’il compose.
 prompt:
   - locale: en
-    value: What is the AI system doing? Pick one or more functional modes.
+    value: What is the AI system doing?
   - locale: fr
-    value: Que fait ce système d’IA ? Choisissez un ou plusieurs modes fonctionnels.
+    value: Que fait ce système d’IA ?
+authoring_guidance:
+  - locale: en
+    value: Pick one or more functional modes.
+  - locale: fr
+    value: Choisissez un ou plusieurs modes fonctionnels.
 required: true
 order: 3
 datachain_type: ai

--- a/api/schemas/ai/2026-05-06-beta/categories/input_dataset.yaml
+++ b/api/schemas/ai/2026-05-06-beta/categories/input_dataset.yaml
@@ -7,17 +7,17 @@ name:
 description:
   - locale: en
     value: >-
-      The runtime input — the live data this deployed system processes when it operates. Distinct
-      from training data.
+      The input data this deployed system processes when it operates. Distinct from training
+      data.
   - locale: fr
     value: >-
-      L’entrée d’exécution — les données en direct que ce système déployé traite lorsqu’il
-      fonctionne. Distinct des données d’entraînement.
+      Les données d’entrée que ce système déployé traite lorsqu’il fonctionne. Distinctes des
+      données d’entraînement.
 prompt:
   - locale: en
-    value: What live data does this AI system process at runtime?
+    value: What input data does this AI system process?
   - locale: fr
-    value: "Quelles données en direct ce système d’IA traite-t-il à l’exécution\_?"
+    value: Quelles données d’entrée ce système d’IA traite-t-il ?
 required: false
 order: 6
 datachain_type: ai

--- a/api/schemas/ai/2026-05-06-beta/categories/output_dataset.yaml
+++ b/api/schemas/ai/2026-05-06-beta/categories/output_dataset.yaml
@@ -7,18 +7,17 @@ name:
 description:
   - locale: en
     value: >-
-      The runtime output — the live data this deployed system produces when it operates, including
-      decisions it makes, content it generates, and actions it triggers.
+      The output data this deployed system produces when it operates — decisions, content, and
+      actions.
   - locale: fr
     value: >-
-      La sortie d’exécution — les données en direct que ce système déployé produit lorsqu’il
-      fonctionne, y compris les décisions qu’il prend, le contenu qu’il génère et les actions qu’il
-      déclenche.
+      Les données de sortie que ce système déployé produit lorsqu’il fonctionne — décisions,
+      contenu et actions.
 prompt:
   - locale: en
-    value: What does this AI system produce — what decisions, content, or signals come out?
+    value: What does this AI system produce?
   - locale: fr
-    value: "Que produit ce système d’IA — quelles décisions, quel contenu ou quels signaux en sortent\_?"
+    value: Que produit ce système d’IA ?
 required: false
 order: 8
 datachain_type: ai

--- a/api/schemas/ai/2026-05-06-beta/categories/processing.yaml
+++ b/api/schemas/ai/2026-05-06-beta/categories/processing.yaml
@@ -1,23 +1,23 @@
 id: processing
 name:
   - locale: en
-    value: Processing Algorithm or AI
+    value: Algorithm or Model
   - locale: fr
-    value: Algorithme de traitement ou IA
+    value: Algorithme ou modèle
 description:
   - locale: en
     value: >-
-      The technical detail of how the AI works — the algorithm family, model class, or technique
-      used to process inputs into outputs.
+      What processes the input — the algorithm family, model class, or technique used to turn
+      inputs into outputs.
   - locale: fr
     value: >-
-      Le détail technique du fonctionnement de l’IA — la famille d’algorithmes, la classe de modèle
-      ou la technique utilisée pour transformer les entrées en sorties.
+      Ce qui traite les entrées — la famille d’algorithmes, la classe de modèle ou la technique
+      utilisée pour transformer les entrées en sorties.
 prompt:
   - locale: en
-    value: What algorithm family or model class processes inputs into outputs in this system?
+    value: What algorithm or model processes the data?
   - locale: fr
-    value: "Quelle famille d’algorithmes ou classe de modèle traite les entrées en sorties dans ce système\_?"
+    value: Quel algorithme ou modèle traite les données ?
 required: false
 order: 7
 datachain_type: ai

--- a/api/schemas/ai/2026-05-06-beta/categories/purpose.yaml
+++ b/api/schemas/ai/2026-05-06-beta/categories/purpose.yaml
@@ -6,9 +6,9 @@ name:
     value: But
 description:
   - locale: en
-    value: The purpose of this AI system.
+    value: Why this AI system exists — the outcome it’s designed to achieve.
   - locale: fr
-    value: Le but de ce système d’IA.
+    value: La raison d’être de ce système d’IA — le résultat qu’il vise à atteindre.
 prompt:
   - locale: en
     value: What is the purpose of this AI system?

--- a/api/schemas/ai/2026-05-06-beta/categories/retention.yaml
+++ b/api/schemas/ai/2026-05-06-beta/categories/retention.yaml
@@ -6,11 +6,9 @@ name:
     value: Rétention
 description:
   - locale: en
-    value: The policies and practices governing the retention of data produced by the AI system.
+    value: How long the data produced by this AI system is kept.
   - locale: fr
-    value: >-
-      Les politiques et pratiques régissant la conservation des données produites par le système
-      d’IA.
+    value: Combien de temps les données produites par ce système d’IA sont conservées.
 prompt:
   - locale: en
     value: How long is the data kept?

--- a/api/schemas/ai/2026-05-06-beta/categories/rights.yaml
+++ b/api/schemas/ai/2026-05-06-beta/categories/rights.yaml
@@ -6,14 +6,16 @@ name:
     value: Droits
 description:
   - locale: en
-    value: The user's rights in relation to the AI system.
+    value: What you can do in relation to this AI system — how to access, contest, or opt out.
   - locale: fr
-    value: Les droits de l'utilisateur par rapport au système d'IA.
+    value: >-
+      Ce que vous pouvez faire par rapport à ce système d’IA — comment y accéder, le contester ou
+      vous y soustraire.
 prompt:
   - locale: en
-    value: What are the user's rights in relation to the AI system?
+    value: What are your rights?
   - locale: fr
-    value: Quels sont les droits de l’utilisateur par rapport au système d’IA ?
+    value: Quels sont vos droits ?
 required: false
 order: 5
 datachain_type: ai

--- a/api/schemas/ai/2026-05-06-beta/categories/risks_mitigation.yaml
+++ b/api/schemas/ai/2026-05-06-beta/categories/risks_mitigation.yaml
@@ -6,16 +6,14 @@ name:
     value: Risques et atténuation
 description:
   - locale: en
-    value: The risks associated with this AI system and the mitigation strategies in place.
+    value: The risks this AI system could create and how they’re being addressed.
   - locale: fr
-    value: Les risques associés à ce système d’IA et les stratégies d’atténuation en place.
+    value: Les risques que ce système d’IA pourrait créer et la manière dont ils sont traités.
 prompt:
   - locale: en
-    value: What are the risks associated with this AI system and what mitigation strategies are in place?
+    value: What are the risks and how are they mitigated?
   - locale: fr
-    value: >-
-      Quels sont les risques associés à ce système d’IA et quelles stratégies d’atténuation sont en
-      place ?
+    value: Quels sont les risques et comment sont-ils atténués ?
 required: false
 order: 4
 datachain_type: ai

--- a/api/schemas/ai/2026-05-06-beta/categories/storage.yaml
+++ b/api/schemas/ai/2026-05-06-beta/categories/storage.yaml
@@ -6,14 +6,14 @@ name:
     value: Stockage de données
 description:
   - locale: en
-    value: Where the data produced by the AI system is stored.
+    value: Where the data produced by this AI system is kept.
   - locale: fr
-    value: Où sont stockées les données produites par le système d'IA.
+    value: Où sont conservées les données produites par ce système d’IA.
 prompt:
   - locale: en
-    value: Where is the data produced by the AI system stored?
+    value: Where is the data stored?
   - locale: fr
-    value: Où sont stockées les données produites par le système d’IA ?
+    value: Où sont stockées les données ?
 required: false
 order: 11
 datachain_type: ai

--- a/api/schemas/ai/2026-05-06-beta/datachain-type.yaml
+++ b/api/schemas/ai/2026-05-06-beta/datachain-type.yaml
@@ -4,7 +4,15 @@ name:
     value: AI / Algorithm
   - locale: fr
     value: IA / Algorithme
-description: []
+description:
+  - locale: en
+    value: >-
+      A snapshot of how this AI system works — its purpose, what it processes, who's responsible,
+      and your rights.
+  - locale: fr
+    value: >-
+      Un aperçu du fonctionnement de ce système d’IA — son objectif, ce qu’il traite, qui en est
+      responsable et vos droits.
 categories:
   - purpose
   - accountable


### PR DESCRIPTION
## Summary

Rewrites public-facing category text in the `ai/2026-05-06-beta` schema. Category descriptions are now consistently short explanatory sentences and prompts are punchier (e.g. `risks_mitigation` dropped from 17 words to 8). The `processing` category was renamed to "Algorithm or Model", and the previously-empty AI datachain-type `description` is now filled. The `functional_modes` prompt now contains only the public-facing question ("What is the AI system doing?") — the imperative "Pick one or more functional modes." moved into the new `authoring_guidance` attribute, which renders for authors but not on public datachains. All changes mirrored in `fr`.

## Test plan

- [ ] `pnpm test` in `api/` (schema validators + JSON emitter) once deps are installed
- [ ] Visual check of an AI datachain render in studio: category prompts/descriptions reflect the new copy and `functional_modes` no longer shows the "Pick one or more" sentence publicly
