### PR TITLE
refactor(app): swap newsletter form from sendstack to mailcoach

### DIFF
--- a/app/components/NewsletterSignup.vue
+++ b/app/components/NewsletterSignup.vue
@@ -1,3 +1,40 @@
+<script setup>
+const props = defineProps({
+  action: {
+    type: String,
+    required: true,
+  },
+  tags: {
+    type: String,
+    default: '',
+  },
+});
+
+const email = ref('');
+const status = ref('idle'); // idle | submitting | success | error
+
+async function subscribe() {
+  if (!email.value) return;
+
+  status.value = 'submitting';
+
+  try {
+    await $fetch('/api/subscribe', {
+      method: 'POST',
+      body: {
+        email: email.value,
+        action: props.action,
+        tags: props.tags || undefined,
+      },
+    });
+
+    status.value = 'success';
+  } catch (e) {
+    status.value = 'error';
+  }
+}
+</script>
+
 <template>
   <div class="lg:flex lg:items-center">
     <div class="lg:w-0 lg:flex-1">
@@ -6,45 +43,39 @@
     </div>
     <div class="lg:w-full lg:max-w-md mt-4 lg:mt-0">
       <form
-        data-sendstack-form
-        action="https://getsendstack.com/forms/5eb89581-2e83-461a-ab1e-a9175305671b/subscribers"
-        method="post"
-        class="mt-2 sm:mt-0"
+        v-if="status !== 'success'"
+        class="mt-2 sm:mt-0 sm:flex"
+        @submit.prevent="subscribe"
       >
-        <span data-element="success" class="hidden mb-2 text-dtpr-red-950">
-            Success! Please verify your email address to confirm your subscription.
-        </span>
-
-        <ul data-element="errors" class="hidden mb-2 text-dtpr-red-950"></ul>
-
-        <fieldset class="sm:flex">
-          <input 
-            class="w-full rounded-md px-5 py-3 placeholder-gray-500 border-transparent focus:border-transparent focus:outline-none focus:ring-2 focus:ring-dtpr-red focus:ring-offset-2 focus:ring-offset-dtpr-red"
-            type="email"
-            name="email"
-            placeholder="Your email address"
-            required
-          />
-          <input type="hidden" name="tags" value="dtpr.io" />
-          <input
-            class="cursor-pointer mt-3 flex w-full items-center justify-center rounded-md border border-transparent bg-dtpr-red px-5 py-3 text-base font-medium text-white shadow focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-dtpr-red sm:mt-0 sm:ml-3 sm:w-auto sm:flex-shrink-0"
-            type="submit"
-            value="Subscribe"
-          >
-        </fieldset>
+        <input
+          v-model="email"
+          type="email"
+          required
+          placeholder="Your email address"
+          :disabled="status === 'submitting'"
+          class="w-full rounded-md px-5 py-3 placeholder-gray-500 border-transparent focus:border-transparent focus:outline-none focus:ring-2 focus:ring-dtpr-red focus:ring-offset-2 focus:ring-offset-dtpr-red disabled:opacity-60"
+        />
+        <button
+          type="submit"
+          :disabled="status === 'submitting'"
+          class="cursor-pointer mt-3 flex w-full items-center justify-center rounded-md border border-transparent bg-dtpr-red px-5 py-3 text-base font-medium text-white shadow focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-dtpr-red sm:mt-0 sm:ml-3 sm:w-auto sm:flex-shrink-0 disabled:opacity-60"
+        >
+          {{ status === 'submitting' ? 'Subscribing…' : 'Subscribe' }}
+        </button>
       </form>
 
-      <p class="mt-3 text-sm text-dtpr-red-950">
-        We use the privacy-first service <a class="u-line border-dtpr-red" href="https://getsendstack.com/privacy">SendStack</a> for our newsletter.
+      <p
+        v-if="status === 'success'"
+        class="mt-2 font-medium text-dtpr-red-950"
+      >
+        Success! Please check your inbox to confirm your subscription.
+      </p>
+      <p
+        v-if="status === 'error'"
+        class="mt-2 text-sm text-dtpr-red-950"
+      >
+        Something went wrong. Please try again.
       </p>
     </div>
   </div>
 </template>
-
-<script setup>
-useHead({
-  script: [
-    { src: "https://getsendstack.com/js/form.js" }
-  ]
-});
-</script>

--- a/app/pages/get-involved.vue
+++ b/app/pages/get-involved.vue
@@ -31,7 +31,10 @@
 
     <div class="flex gap-8">
       <Card class="bg-dtpr-red-100 w-[100%] md:mt-8">
-        <NewsletterSignup />
+        <NewsletterSignup
+          action="https://helpful-places.mailcoach.app/subscribe/3f3c6a33-15d3-4607-9c07-fb49d65b5006"
+          tags="dtpr.io"
+        />
       </Card>
     </div>
   </div>

--- a/app/server/api/subscribe.post.ts
+++ b/app/server/api/subscribe.post.ts
@@ -1,0 +1,29 @@
+const ALLOWED_ACTION_HOST = 'helpful-places.mailcoach.app';
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event);
+  const { email, action, tags } = body;
+
+  if (!email || !action) {
+    throw createError({ statusCode: 400, statusMessage: 'Email and action are required' });
+  }
+
+  const { hostname } = new URL(action);
+  if (hostname !== ALLOWED_ACTION_HOST) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid action URL' });
+  }
+
+  const formData = new URLSearchParams();
+  formData.append('email', email);
+  if (tags) {
+    formData.append('tags', tags);
+  }
+
+  await $fetch(action, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: formData.toString(),
+  });
+
+  return { success: true };
+});

--- a/app/server/api/subscribe.post.ts
+++ b/app/server/api/subscribe.post.ts
@@ -8,7 +8,12 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Email and action are required' });
   }
 
-  const { hostname } = new URL(action);
+  let hostname: string;
+  try {
+    ({ hostname } = new URL(action));
+  } catch {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid action URL' });
+  }
   if (hostname !== ALLOWED_ACTION_HOST) {
     throw createError({ statusCode: 400, statusMessage: 'Invalid action URL' });
   }
@@ -19,11 +24,15 @@ export default defineEventHandler(async (event) => {
     formData.append('tags', tags);
   }
 
-  await $fetch(action, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: formData.toString(),
-  });
+  try {
+    await $fetch(action, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: formData.toString(),
+    });
+  } catch {
+    throw createError({ statusCode: 502, statusMessage: 'Subscription service unavailable' });
+  }
 
   return { success: true };
 });


### PR DESCRIPTION
The newsletter signup on Get Involved now subscribes through mailcoach instead of SendStack. The form is a native Vue component that posts to a new `/api/subscribe` Nitro endpoint, which proxies to `helpful-places.mailcoach.app` behind a host allowlist; submission state (idle / submitting / success / error) renders inline, replacing the SendStack JS widget's DOM-swap behavior.

The mailcoach list ID matches the one the guide-app already uses, with `tags="dtpr.io"` to keep this signup segmentable.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7-D97757?logo=claude&logoColor=white)
