### PR TITLE
fix(dtpr-ai): datachain visualizer Render now shows the resolved chain

### DIFF
--- a/dtpr-ai/app/components/DatachainVisualizerRender.vue
+++ b/dtpr-ai/app/components/DatachainVisualizerRender.vue
@@ -23,9 +23,9 @@ const expandAll = ref(false)
 
 const sections = computed(() => buildResolvedSections(props.resolved, props.locale))
 
-const title = computed(() => extract(props.resolved.instance.title, props.locale))
+const title = computed(() => extract(props.resolved.title, props.locale))
 const description = computed(() =>
-  extract(props.resolved.instance.description, props.locale),
+  extract(props.resolved.description, props.locale),
 )
 
 // Keep the accordion's open id stable as long as that section still

--- a/dtpr-ai/app/pages/tools/datachain.vue
+++ b/dtpr-ai/app/pages/tools/datachain.vue
@@ -123,8 +123,8 @@ function onSave() {
   if (!resolvedInstance.value) return
   collectionMessage.value = null
   const fallbackName =
-    extract(resolvedInstance.value.instance.title, activeLocale.value) ||
-    resolvedInstance.value.instance.id ||
+    extract(resolvedInstance.value.title, activeLocale.value) ||
+    resolvedInstance.value.id ||
     'Untitled chain'
   try {
     const entry = saveCollectionEntry({ name: fallbackName, json: inputJson.value })

--- a/dtpr-ai/app/utils/datachain-visualizer-api.ts
+++ b/dtpr-ai/app/utils/datachain-visualizer-api.ts
@@ -265,12 +265,21 @@ export async function validateAndResolve(jsonText: string): Promise<ValidateAndR
     ]
     return { ok: false, errors: fallback }
   }
-  const resolveEnvelope = resolveResp.envelope as
-    | ValidateErrorEnvelope
-    | ResolvedDatachainInstance
-  if ((resolveEnvelope as ValidateErrorEnvelope).ok === false) {
-    return { ok: false, errors: (resolveEnvelope as ValidateErrorEnvelope).errors }
+  const envelope = resolveResp.envelope
+  if (isResolveErrorEnvelope(envelope)) {
+    return { ok: false, errors: envelope.errors }
   }
+  return { ok: true, resolved: envelope }
+}
 
-  return { ok: true, resolved: resolveEnvelope as ResolvedDatachainInstance }
+// `ResolvedDatachainInstance` has no `ok` field, so `'ok' in envelope`
+// uniquely identifies the soft-failure envelope. Wrapped as a real type
+// guard so both branches narrow without manual casts at the call site.
+function isResolveErrorEnvelope(
+  envelope: ResolveEnvelope,
+): envelope is ValidateErrorEnvelope {
+  return (
+    'ok' in envelope &&
+    (envelope as { ok: unknown }).ok === false
+  )
 }

--- a/dtpr-ai/app/utils/datachain-visualizer-api.ts
+++ b/dtpr-ai/app/utils/datachain-visualizer-api.ts
@@ -37,15 +37,12 @@ interface ValidateErrorEnvelope {
   warnings?: ApiError[]
 }
 
-interface ResolveOkEnvelope {
-  ok: true
-  version: string
-  resolved: ResolvedDatachainInstance
-  warnings?: ApiError[]
-}
-
+// /resolve returns the bare ResolvedDatachainInstance on success (no
+// envelope), and the same `{ ok: false, errors }` shape on semantic
+// failure. We type the success branch as `ResolvedDatachainInstance`
+// directly and rely on the `ok === false` check to discriminate.
 type ValidateEnvelope = ValidateOkEnvelope | ValidateErrorEnvelope
-type ResolveEnvelope = ResolveOkEnvelope | ValidateErrorEnvelope
+type ResolveEnvelope = ResolvedDatachainInstance | ValidateErrorEnvelope
 
 function readSchemaVersion(jsonText: string):
   | { ok: true; version: string }
@@ -268,9 +265,12 @@ export async function validateAndResolve(jsonText: string): Promise<ValidateAndR
     ]
     return { ok: false, errors: fallback }
   }
-  if (resolveResp.envelope.ok === false) {
-    return { ok: false, errors: resolveResp.envelope.errors }
+  const resolveEnvelope = resolveResp.envelope as
+    | ValidateErrorEnvelope
+    | ResolvedDatachainInstance
+  if ((resolveEnvelope as ValidateErrorEnvelope).ok === false) {
+    return { ok: false, errors: (resolveEnvelope as ValidateErrorEnvelope).errors }
   }
 
-  return { ok: true, resolved: resolveResp.envelope.resolved }
+  return { ok: true, resolved: resolveEnvelope as ResolvedDatachainInstance }
 }

--- a/dtpr-ai/test/datachain-visualizer-api.test.ts
+++ b/dtpr-ai/test/datachain-visualizer-api.test.ts
@@ -29,18 +29,21 @@ afterEach(() => {
 
 describe('validateAndResolve', () => {
   it('returns the resolved instance when both calls succeed', async () => {
+    // The live /resolve endpoint returns the bare ResolvedDatachainInstance
+    // on success (no `{ ok, resolved }` envelope); only failures are
+    // enveloped. See content/en/3.rest/10.resolve.md.
     const resolved = {
+      id: 'demo',
       schema_version: VERSION,
+      title: [{ locale: 'en', value: 'Demo' }],
+      elements: [],
       schema_snapshot: { datachain_type: { categories: [] }, categories: [], elements: [] },
       suggested_elements: [],
-      elements: [],
-      instance: { schema_version: VERSION, id: 'demo' },
     }
     const fetchMock = vi.fn(async (url: string | URL | Request) => {
       const u = String(url)
       if (u.endsWith('/validate')) return fakeResponse({ status: 200, body: { ok: true } })
-      if (u.endsWith('/resolve'))
-        return fakeResponse({ status: 200, body: { ok: true, version: VERSION, resolved } })
+      if (u.endsWith('/resolve')) return fakeResponse({ status: 200, body: resolved })
       throw new Error(`unexpected url: ${u}`)
     })
     vi.stubGlobal('fetch', fetchMock)

--- a/dtpr-ai/test/datachain-visualizer-api.test.ts
+++ b/dtpr-ai/test/datachain-visualizer-api.test.ts
@@ -155,6 +155,30 @@ describe('validateAndResolve', () => {
     expect(result.errors[0].code).toBe('unsupported_schema_version')
   })
 
+  it('forwards a resolve-side semantic failure (HTTP 200 + ok:false)', async () => {
+    // Resolve is the only stage where success is bare and failure is
+    // enveloped; exercise that discriminant explicitly.
+    const resolveError = {
+      code: 'INSTANCE_ELEMENT_UNKNOWN',
+      message: 'Unknown element id "not_a_real_element".',
+      path: 'elements[0]',
+    }
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      const u = String(url)
+      if (u.endsWith('/validate')) return fakeResponse({ status: 200, body: { ok: true } })
+      if (u.endsWith('/resolve'))
+        return fakeResponse({ status: 200, body: { ok: false, errors: [resolveError] } })
+      throw new Error(`unexpected url: ${u}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await validateAndResolve(VALID_INSTANCE)
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.errors).toEqual([resolveError])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
   it('returns network_error when fetch rejects', async () => {
     const fetchMock = vi.fn(async () => {
       throw new TypeError('fetch failed')


### PR DESCRIPTION
## Summary

- The `/resolve` endpoint returns a bare `ResolvedDatachainInstance` on success — only failures use the `{ ok, errors }` envelope. The visualizer client assumed `{ ok: true, resolved }`, so `resolvedInstance.value` silently became `undefined` and the page rendered nothing when you clicked **Render**.
- Two call sites (`DatachainVisualizerRender.vue`, `pages/tools/datachain.vue`'s `onSave`) also dereferenced `.instance.title/.id` on what is already a flat resolved instance — fixed alongside.
- Updated the vitest mock to the real wire shape so this contract drift can't slip through CI again.

## Test plan

- [x] `vitest run test/datachain-visualizer-api.test.ts` — 9/9 pass
- [ ] Load `/tools/datachain`, paste a valid `DatachainInstance`, click **Render**, confirm the resolved chain renders and **Save to my collection** works