### PR TITLE
fix(dtpr-ai): remove duplicate GitHub link from footer

### DIFF
--- a/dtpr-ai/app/app.config.ts
+++ b/dtpr-ai/app/app.config.ts
@@ -6,9 +6,6 @@ export default defineAppConfig({
     title: 'DTPR for AI',
     description: 'Digital Trust for Places & Routines — AI-focused microsite.'
   },
-  socials: {
-    github: 'https://github.com/helpful-places/dtpr'
-  },
   github: {
     url: 'https://github.com/helpful-places/dtpr',
     branch: 'main',

--- a/dtpr-ai/app/components/app/AppHeader.vue
+++ b/dtpr-ai/app/components/app/AppHeader.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+// Local shadow of docus's AppHeader (see node_modules/docus/app/
+// components/app/AppHeader.vue, docus@5.11.0). Mirrors upstream
+// verbatim except the right-slot order: the GitHub link renders
+// *before* UColorModeButton so the cluster reads `gh | dark mode`,
+// matching AppFooterRight. On a docus version bump, re-sync against
+// upstream and re-apply the swap.
+import { useDocusColorMode } from 'docus/app/composables/useDocusColorMode'
+import { useDocusI18n } from 'docus/app/composables/useDocusI18n'
+import { useSubNavigation } from 'docus/app/composables/useSubNavigation'
+
+const appConfig = useAppConfig()
+const { forced: forcedColorMode } = useDocusColorMode()
+
+const { isEnabled: isAssistantEnabled } = useAssistant()
+const { isEnabled, locales } = useDocusI18n()
+const { subNavigationMode } = useSubNavigation()
+
+const links = computed(() => appConfig.github && appConfig.github.url
+  ? [
+      {
+        'icon': 'i-simple-icons-github',
+        'to': appConfig.github.url,
+        'target': '_blank',
+        'aria-label': 'GitHub',
+      },
+    ]
+  : [])
+</script>
+
+<template>
+  <UHeader
+    :ui="{ center: 'flex-1' }"
+    :class="{ 'flex flex-col': subNavigationMode === 'header' }"
+  >
+    <AppHeaderCenter />
+
+    <template #left>
+      <AppHeaderLeft />
+    </template>
+
+    <template #right>
+      <AppHeaderCTA />
+
+      <template v-if="isAssistantEnabled">
+        <AssistantChat />
+      </template>
+
+      <template v-if="isEnabled && locales.length > 1">
+        <ClientOnly>
+          <LanguageSelect />
+
+          <template #fallback>
+            <div class="h-8 w-8 animate-pulse bg-neutral-200 dark:bg-neutral-800 rounded-md" />
+          </template>
+        </ClientOnly>
+
+        <USeparator
+          orientation="vertical"
+          class="h-8"
+        />
+      </template>
+
+      <UContentSearchButton class="lg:hidden" />
+
+      <template v-if="links?.length">
+        <UButton
+          v-for="(link, index) of links"
+          :key="index"
+          v-bind="{ color: 'neutral', variant: 'ghost', ...link }"
+        />
+      </template>
+
+      <ClientOnly v-if="!forcedColorMode">
+        <UColorModeButton />
+
+        <template #fallback>
+          <div class="h-8 w-8 animate-pulse bg-neutral-200 dark:bg-neutral-800 rounded-md" />
+        </template>
+      </ClientOnly>
+    </template>
+
+    <template #toggle="{ open, toggle }">
+      <IconMenuToggle
+        :open="open"
+        class="lg:hidden"
+        @click="toggle"
+      />
+    </template>
+
+    <template #body>
+      <AppHeaderBody />
+    </template>
+
+    <template
+      v-if="subNavigationMode === 'header'"
+      #bottom
+    >
+      <AppHeaderBottom />
+    </template>
+  </UHeader>
+</template>


### PR DESCRIPTION
The footer's right slot now renders a single `gh | dark mode` cluster, matching the header. The `socials.github` entry in `app.config.ts` duplicated the link already produced by `github.url`, so docus's `AppFooterRight` was rendering two GitHub icons side by side.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7-D97757?logo=claude&logoColor=white)
