### PR TITLE
docs(dtpr-ai): scrub public-space framing from the AI microsite

### DIFF
--- a/dtpr-ai/app/pages/object-reference.vue
+++ b/dtpr-ai/app/pages/object-reference.vue
@@ -140,7 +140,7 @@ const objects: ObjectEntry[] = [
     name: 'DatachainInstance',
     group: 'instances',
     blurb:
-      'A concrete authored disclosure (e.g. "Worcester license plate reader"). Pins a `schema_version` and references elements by id. The raw, pre-resolution wire form.',
+      'A concrete authored disclosure (e.g. "Acme resume screener"). Pins a `schema_version` and references elements by id. The raw, pre-resolution wire form.',
     schema: (schemas as any).DatachainInstance,
   },
   {

--- a/dtpr-ai/content/en/10.attribution.md
+++ b/dtpr-ai/content/en/10.attribution.md
@@ -83,7 +83,7 @@ The ShareAlike clause on AIAAIC-derived content is scoped to the risk-taxonomy c
 
 ## Contributing back
 
-Gaps or extensions identified while authoring the DTPR risk catalog that are also relevant to AIAAIC's general-purpose taxonomy — for example, harm framings specific to public-space AI deployment — will be proposed back to the [AIAAIC working group](https://www.aiaaic.org/) as upstream contributions, in the spirit of the ShareAlike license.
+Gaps or extensions identified while authoring the DTPR risk catalog that are also relevant to AIAAIC's general-purpose taxonomy — for example, harm framings specific to AI deployment — will be proposed back to the [AIAAIC working group](https://www.aiaaic.org/) as upstream contributions, in the spirit of the ShareAlike license.
 
 ## Per-element citation
 

--- a/dtpr-ai/content/en/3.rest/10.resolve.md
+++ b/dtpr-ai/content/en/3.rest/10.resolve.md
@@ -11,7 +11,7 @@ Resolve runs `validate` first (R7). On semantic failure, the response is HTTP 20
 
 ## Summary
 
-Compose a thin `DatachainInstance` and the pinned schema's lean subset (datachain_type + referenced categories + referenced elements) into a single self-contained `ResolvedDatachainInstance`. Downstream consumers can render the snapshot offline, ship it to signage / PDFs / admin UIs, or persist it as an audit artifact — no further schema fetch required.
+Compose a thin `DatachainInstance` and the pinned schema's lean subset (datachain_type + referenced categories + referenced elements) into a single self-contained `ResolvedDatachainInstance`. Downstream consumers can render the snapshot offline, ship it to product surfaces / PDFs / admin UIs, or persist it as an audit artifact — no further schema fetch required.
 
 `ResolvedDatachainInstance` is a strict structural superset of `DatachainInstance`. Stripping `schema_snapshot`, `suggested_elements`, and `authoring_provenance` returns a thin instance equivalent (post-parse) to the input.
 

--- a/dtpr-ai/content/en/6.concepts/1.datachains.md
+++ b/dtpr-ai/content/en/6.concepts/1.datachains.md
@@ -13,13 +13,13 @@ At the top level, a `DatachainInstance` carries an `id`, an optional `title` and
 
 ```json
 {
-  "id": "worcester-lpr",
-  "title": [{ "locale": "en", "value": "Worcester license plate reader" }],
-  "description": [{ "locale": "en", "value": "Parking enforcement automation." }],
+  "id": "acme-resume-screener",
+  "title": [{ "locale": "en", "value": "Acme resume screener" }],
+  "description": [{ "locale": "en", "value": "Pre-screens job applicants against the role brief." }],
   "schema_version": "ai@2026-04-16-beta",
   "elements": [
     { "element_id": "purpose.example" },
-    { "element_id": "data.camera" }
+    { "element_id": "data.applicant_documents" }
   ]
 }
 ```
@@ -67,7 +67,7 @@ Content-Type: application/json
   "schema_version": "ai@2026-04-16-beta",
   "elements": [
     { "element_id": "purpose.example" },
-    { "element_id": "data.camera" }
+    { "element_id": "data.applicant_documents" }
   ]
 }
 ```
@@ -77,7 +77,7 @@ Content-Type: application/json
   "schema_version": "ai@2026-04-16-beta",
   "elements": [
     { "element_id": "purpose.example" },
-    { "element_id": "data.camera" }
+    { "element_id": "data.applicant_documents" }
   ],
   "schema_snapshot": {
     "datachain_type": { "/* DatachainType */": "..." },
@@ -115,13 +115,13 @@ In practice: rendering and offline persistence work against the resolved form. R
     "model": "claude-sonnet-4-6",
     "generated_at": "2026-05-07T18:42:00Z",
     "element_provenance": {
-      "data.camera": {
-        "rationale": "Operator's privacy notice describes a roof-mounted camera per intersection.",
+      "data.applicant_documents": {
+        "rationale": "Operator's privacy notice describes uploading resumes and cover letters at intake.",
         "confidence": "high",
         "source_references": [
           {
-            "quote": "Each enforcement vehicle carries an outward-facing license plate camera.",
-            "context": "Privacy notice §2 — Equipment"
+            "quote": "Applicants upload a resume and cover letter; both are sent to the screening model.",
+            "context": "Privacy notice §2 — Inputs"
           }
         ],
         "variable_rationale": {
@@ -129,7 +129,7 @@ In practice: rendering and offline persistence work against the resolved form. R
         }
       },
       "purpose.example": {
-        "rationale": "Inferred from the operator's stated parking-enforcement use case.",
+        "rationale": "Inferred from the operator's stated applicant-screening use case.",
         "confidence": "medium"
       }
     }

--- a/dtpr-ai/content/en/6.concepts/6.subchains.md
+++ b/dtpr-ai/content/en/6.concepts/6.subchains.md
@@ -9,7 +9,7 @@ A **subchain** is a named group of categories declared on a datachain type (e.g.
 
 ## Why
 
-Modern AI systems are compositional. A smart intersection might compose a perceptive model (cameras → vehicle detection) with an analytical model (predict congestion) and an agentic actuator (re-time the signal). Each leg has its own input → processing → output flow. The flat `elements` list of a datachain cannot tell three flows apart.
+Modern AI systems are compositional. A customer-support assistant might compose a perceptive model (transcribe the inbound call) with an analytical model (classify intent and retrieve relevant policy) and an agentic actuator (draft a reply and file a ticket). Each leg has its own input → processing → output flow. The flat `elements` list of a datachain cannot tell three flows apart.
 
 Subchains let an author group categories into named flows on the datachain type, and then realize those flows multiple times on a single instance.
 
@@ -47,13 +47,13 @@ Categories may belong to multiple subchains. The subchain is purely a grouping; 
 
 Each element in `DatachainInstance.elements[]` may carry a `subchain_instance_id`. Elements with one render inside their subchain instance; elements without one render at the datachain root (Accountable, Purpose, Rights, Risks).
 
-## Smart-intersection example
+## Worked example — customer-support assistant
 
-A single intersection deployment composes three modes — perceptive, analytical, agentic. Each mode heads one realization of `data_flow`:
+A single deployment composes three modes — perceptive, analytical, agentic. Each mode heads one realization of `data_flow`:
 
-- **Perceptive flow:** camera feed → vehicle detection model → bounding boxes.
-- **Analytical flow:** vehicle counts → congestion forecaster → predicted queue length.
-- **Agentic flow:** predicted queue length → signal re-timer → updated phase plan.
+- **Perceptive flow:** call audio → speech-to-text model → transcript.
+- **Analytical flow:** transcript → intent classifier + policy retriever → ranked policy snippets.
+- **Agentic flow:** ranked policy snippets → reply drafter + ticket-filing tool → sent reply and filed ticket.
 
 Authoring this as one datachain instance: three `subchain_instances` (each with `subchain_id: data_flow`), one functional-mode element per flow (heads it via `head_refs`), and the input / processing / output elements per flow each carry the matching `subchain_instance_id`.
 

--- a/dtpr-ai/content/en/7.plugin/1.install.md
+++ b/dtpr-ai/content/en/7.plugin/1.install.md
@@ -106,7 +106,7 @@ When a capability is listed as "Probe at session start", the expected behavior i
 Any of the seven skills should respond to their trigger phrases after install. A minimal smoke test:
 
 ```
-> describe our facial-recognition parking kiosk as a DTPR datachain
+> describe our resume-screening model as a DTPR datachain
 ```
 
 If `dtpr-describe-system` fires and calls `list_schema_versions`, the plugin is wired up correctly. If no skill fires, try an explicit phrasing (`use dtpr-describe-system for …`) and check `/plugin list` on Claude Code or the upload confirmation on Cowork/Claude.ai.

--- a/dtpr-ai/content/en/7.plugin/2.skills/1.describe-system.md
+++ b/dtpr-ai/content/en/7.plugin/2.skills/1.describe-system.md
@@ -8,7 +8,7 @@ The instance-tier skill. Turns a natural-language description of an AI or automa
 ## When to fire
 
 - The user asks to describe, document, disclose, or publish how an AI system works.
-- The user references a specific system (a chatbot, a camera-based kiosk, a resume screener, a facial-recognition system) and wants a structured artifact.
+- The user references a specific system (a chatbot, a recommender, a resume screener, a fraud-detection model) and wants a structured artifact.
 - The user explicitly mentions DTPR, datachain, or transparency disclosure.
 - The user attaches a PDF, AIA, policy URL, or other artifact describing the system.
 

--- a/dtpr-ai/content/en/7.plugin/2.skills/5.symbol-design.md
+++ b/dtpr-ai/content/en/7.plugin/2.skills/5.symbol-design.md
@@ -11,9 +11,9 @@ The skill produces **three variants per round** rather than a single guess — e
 
 - The user wants an SVG symbol for a proposed or existing DTPR element, drawn in the DTPR house style.
 - The user wants to compare a few icon directions before committing — "show me three options for X".
-- The user wants to refine an existing symbol — strip clutter, simplify the silhouette, redo at sign scale.
+- The user wants to refine an existing symbol — strip clutter, simplify the silhouette, redo at small render size.
 - A [`dtpr-element-design`](/plugin/skills/element-design) session reaches the symbol step and hands off here.
-- The user wants to redesign an icon that fails legibility at sign scale (~24×24).
+- The user wants to redesign an icon that fails legibility at small render size (~24×24).
 
 ## Trigger phrases
 
@@ -25,7 +25,7 @@ The skill produces **three variants per round** rather than a single guess — e
 
 **Phase 1 — Sibling read.** Reads 2–3 sibling SVGs from the target category in `app/public/dtpr-icons/symbols/` to match house style. For an existing-symbol redesign, also reads the current SVG. Captures the silhouette family, dominant drawing technique, and any frame motif (alert triangle for `risks_*`, person figure for `rights_*`, input/output arrows for `processing_*`).
 
-**Phase 2 — Draft three variants.** Each carries a different silhouette strategy across three axes: **reading** (object-centric / action-centric / frame-centric), **technique** (stroke line-work / filled silhouette / hybrid), and **composition** (single object / two-object relation / contained). Every variant holds the house style — 36×36 viewBox, `currentColor` only, ~2px rounded line weight, ≤6 distinct shapes, single concept, sign-scale legibility.
+**Phase 2 — Draft three variants.** Each carries a different silhouette strategy across three axes: **reading** (object-centric / action-centric / frame-centric), **technique** (stroke line-work / filled silhouette / hybrid), and **composition** (single object / two-object relation / contained). Every variant holds the house style — 36×36 viewBox, `currentColor` only, ~2px rounded line weight, ≤6 distinct shapes, single concept, legibility at small render size.
 
 **Phase 3 — Write the local HTML preview.** Writes the three variant SVGs and an `index.html` to `.context/dtpr-symbols/<symbol_id>/` (or an OS temp dir fallback). The preview renders each variant at 16/24/36/64 px in a `prefers-color-scheme`-aware page so `currentColor` reads in both light and dark mode. Variants are inlined into the page rather than loaded via `<img>` so `currentColor` resolves against the surrounding HTML — an `<img src>`-loaded SVG resolves it against the SVG document's own default (black). Surfaces the absolute `file://` URL for the user to open.
 
@@ -41,7 +41,7 @@ On finalize, the **Variants** section collapses to a single **Final** section wi
 
 ## Non-goals
 
-No raster output — SVG only. No external image generation in this version — variants are drawn by the model from the house-style rules and sibling reads. No file-system writes outside the preview root. No YAML drafting — element fields belong to [`dtpr-element-design`](/plugin/skills/element-design). No category-wide visual review — that belongs to [`dtpr-category-audit`](/plugin/skills/category-audit). No comprehension grading — full rubric grading belongs to [`dtpr-comprehension-audit`](/plugin/skills/comprehension-audit). No animation or multi-state variants — a symbol is one static icon, monochrome, sized for sign-scale rendering.
+No raster output — SVG only. No external image generation in this version — variants are drawn by the model from the house-style rules and sibling reads. No file-system writes outside the preview root. No YAML drafting — element fields belong to [`dtpr-element-design`](/plugin/skills/element-design). No category-wide visual review — that belongs to [`dtpr-category-audit`](/plugin/skills/category-audit). No comprehension grading — full rubric grading belongs to [`dtpr-comprehension-audit`](/plugin/skills/comprehension-audit). No animation or multi-state variants — a symbol is one static icon, monochrome, sized for small render-scale rendering.
 
 ## Source
 

--- a/dtpr-ai/content/en/7.plugin/2.skills/7.comprehension-audit.md
+++ b/dtpr-ai/content/en/7.plugin/2.skills/7.comprehension-audit.md
@@ -12,7 +12,7 @@ The four authoring skills that emit `schema:new` proposals ([`dtpr-datachain-str
 - The user asks to grade, audit, or check a DTPR element, category, datachain-instance, or pasted content for public comprehension.
 - The user uses "comprehension audit", "is this clear", "how readable is X", or "does this land for a non-expert".
 - A schema-tier skill's inline Comprehension check needs a deeper standalone second pass.
-- The user pastes YAML, JSON, or markdown and asks whether it would be understood by a non-technical person encountering an AI system — in an app, on a website, in a vehicle, on a kiosk or sign, or any other surface where DTPR content might appear.
+- The user pastes YAML, JSON, or markdown and asks whether it would be understood by a non-technical person encountering an AI system — in an app, on a website, in product documentation, in a model card, or any other surface where DTPR content might appear.
 - The user wants to re-grade after the rubric's `rubric_version` has changed.
 
 ## Trigger phrases

--- a/dtpr-ai/content/en/7.plugin/4.comprehension-rubric.md
+++ b/dtpr-ai/content/en/7.plugin/4.comprehension-rubric.md
@@ -3,7 +3,7 @@ title: Comprehension rubric
 description: The seven-item rubric that the four authoring skills inline and dtpr-comprehension-audit grades against.
 ---
 
-A qualitative checklist for grading DTPR content (datachain-types, categories, elements, full datachain-instances) against the bar of **"a non-technical person encountering an AI system understands this on a quick read."** The audience is anyone meeting an AI system in the wild — in an app, on a website, in a vehicle, on a kiosk or sign, or while moving through public space — with enough time to parse what they see but no prior expertise. There is no scoring math. Each item has pass / fail / partial signals plus an explicit **n/a** when it does not apply to the artifact under review.
+A qualitative checklist for grading DTPR content (datachain-types, categories, elements, full datachain-instances) against the bar of **"a non-technical person encountering an AI system understands this on a quick read."** The audience is anyone meeting an AI system — in an app, on a website, in product documentation, in a model card, or any other surface where DTPR content might appear — with enough time to parse what they see but no prior expertise. There is no scoring math. Each item has pass / fail / partial signals plus an explicit **n/a** when it does not apply to the artifact under review.
 
 This rubric is the shared dependency of [`dtpr-comprehension-audit`](/plugin/skills/comprehension-audit) (standalone use) and the four authoring skills that inline findings — [`dtpr-datachain-structure`](/plugin/skills/datachain-structure), [`dtpr-category-audit`](/plugin/skills/category-audit), [`dtpr-element-design`](/plugin/skills/element-design), and [`dtpr-translate`](/plugin/skills/translate) — which emit a Comprehension check block using the shared template before handing off via `schema:new`.
 
@@ -13,7 +13,7 @@ This rubric is the shared dependency of [`dtpr-comprehension-audit`](/plugin/ski
 | --- | --- |
 | **Audience fit** | The language, framing, and example are understood by a non-expert on first read. |
 | **Plain-language** | Every noun and verb is everyday English or glossed once with a plain-English anchor. |
-| **Symbol legibility** | Silhouette is clear at sign scale; meaning carries even without caption. (**n/a** when the artifact has no symbol.) |
+| **Symbol legibility** | Silhouette is clear at small render size (~24×24); meaning carries even without caption. (**n/a** when the artifact has no symbol.) |
 | **Ambiguity flags** | No ambiguities, or every ambiguity is explicitly flagged in the content. |
 | **Locale coverage** | Every claim is translatable without idiom loss; placeholder syntax supports all required locales. |
 | **Variable-substitution clarity** | Variable placeholders render cleanly across the expected value range. (**n/a** when the artifact has no variables.) |

--- a/dtpr-ai/content/en/index.md
+++ b/dtpr-ai/content/en/index.md
@@ -4,7 +4,7 @@ description: MCP server, REST v2 API, icon composition, UI library, and the Clau
 navigation: false
 ---
 
-**DTPR for AI** is the AI-focused surface of the [Digital Trust for Places & Routines](https://docs.dtpr.io) standard. It bundles five integration surfaces so an AI agent, a web client, a server-side renderer, or an authoring team using Agent Skills can describe data-collecting technologies in public spaces with a shared vocabulary.
+**DTPR for AI** is the AI-focused surface of the [Digital Trust for Places & Routines](https://docs.dtpr.io) standard. It bundles five integration surfaces so an AI agent, a web client, a server-side renderer, or an authoring team using Agent Skills can describe AI systems and the data they collect with a shared vocabulary.
 
 ::card-group
   ::card{title="MCP server" to="/mcp"}


### PR DESCRIPTION
## Summary

- Removed "public space", "cities", "kiosk/sign/vehicle", and "sign scale" framing across the dtpr-ai site — DTPR for AI is not about cities or physical signage like the original DTPR.
- Reframed the home page headline, swapped the Worcester LPR / parking-enforcement worked example on the Datachains concept page (and object-reference blurb) for an Acme resume-screener, and replaced the smart-intersection subchains example with a customer-support assistant.
- Retuned the comprehension rubric audience description and three "sign scale" mentions in symbol-design to "small render size (~24×24)".
- Updated the install smoke test prompt and describe-system trigger examples to AI-system prompts, and tidied stray public-space language in attribution and REST resolve copy.

## Test plan

- [ ] `pnpm --filter dtpr-ai dev` and verify the home page, Datachains, Subchains, comprehension-rubric, and plugin install pages render with no broken links and no remaining public-space framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)