### PR TITLE
fix(content): replace Portuguese leakage in French elements

### DIFF
--- a/app/content/dtpr.v0/elements/fr/process__de_identified.md
+++ b/app/content/dtpr.v0/elements/fr/process__de_identified.md
@@ -1,12 +1,13 @@
 ---
 category: process
-name: Desidentificado
+name: Dé-identifié
 id: de_identified
-description: Dados que são processados para remover valores de identificação,
-  normalmente para proteger a privacidade. A desidentificação pode ocorrer em
-  qualquer ponto de um processo de recolha de dados, por exemplo, antes de serem
-  armazenados numa base de dados ou antes de serem publicados. Aqui, definimo-la
-  como sendo depois de os dados já terem saído de um dispositivo de hardware, ou
-  depois de terem sido armazenados numa base de dados.
+description: Données qui sont traitées pour supprimer les valeurs
+  d'identification, généralement afin de protéger la vie privée. La
+  dé-identification peut intervenir à n'importe quel moment d'un processus de
+  collecte de données, par exemple avant que les données soient stockées dans
+  une base de données ou avant leur publication. Ici, nous la définissons comme
+  intervenant après que les données ont déjà quitté un appareil matériel, ou
+  après qu'elles ont été stockées dans une base de données.
 icon: /dtpr-icons/de_identified.svg
 ---

--- a/app/content/dtpr.v0/elements/fr/tech__weighing_scale.md
+++ b/app/content/dtpr.v0/elements/fr/tech__weighing_scale.md
@@ -1,9 +1,9 @@
 ---
 category: tech
-name: Balança de pesagem
+name: Balance
 id: weighing_scale
-description: Uma balança é um dispositivo para medir o peso ou a massa. Neste
-  caso, não são recolhidos dados de
-  identificação.
+description: Une balance est un dispositif servant à mesurer le poids ou la
+  masse. Dans ce cas, aucune donnée d'identification
+  n'est collectée.
 icon: /dtpr-icons/weighing_scale.svg
 ---

--- a/app/content/dtpr.v1/elements/fr/process__de_identified.md
+++ b/app/content/dtpr.v1/elements/fr/process__de_identified.md
@@ -1,15 +1,16 @@
 ---
 category:
   - device__process
-name: Desidentificado
+name: Dé-identifié
 id: de_identified
 description: >-
-  Dados que são processados para remover valores de identificação, normalmente
-  para proteger a privacidade. A desidentificação pode ocorrer em qualquer ponto
-  de um processo de recolha de dados, por exemplo, antes de serem armazenados
-  numa base de dados ou antes de serem publicados. Aqui, definimo-la como sendo
-  depois de os dados já terem saído de um dispositivo de hardware, ou depois de
-  terem sido armazenados numa base de dados.
+  Données qui sont traitées pour supprimer les valeurs d'identification,
+  généralement afin de protéger la vie privée. La dé-identification peut
+  intervenir à n'importe quel moment d'un processus de collecte de données, par
+  exemple avant que les données soient stockées dans une base de données ou
+  avant leur publication. Ici, nous la définissons comme intervenant après que
+  les données ont déjà quitté un appareil matériel, ou après qu'elles ont été
+  stockées dans une base de données.
 icon: /dtpr-icons/de_identified.svg
 symbol: /dtpr-icons/symbols/privacy.svg
 updated_at: 2025-08-29T00:00:00Z

--- a/app/content/dtpr.v1/elements/fr/tech__weighing_scale.md
+++ b/app/content/dtpr.v1/elements/fr/tech__weighing_scale.md
@@ -1,11 +1,11 @@
 ---
 category:
   - device__tech
-name: Balança de pesagem
+name: Balance
 id: weighing_scale
 description: >-
-  Uma balança é um dispositivo para medir o peso ou a massa. Neste caso, não são
-  recolhidos dados de identificação.
+  Une balance est un dispositif servant à mesurer le poids ou la masse. Dans ce
+  cas, aucune donnée d'identification n'est collectée.
 icon: /dtpr-icons/weighing_scale.svg
 symbol: /dtpr-icons/symbols/weight.svg
 updated_at: 2025-08-29T00:00:00Z


### PR DESCRIPTION
## Summary
Two French element files contained Portuguese text in their `name` and `description` fields — `process__de_identified` (`Desidentificado` + Portuguese body) and `tech__weighing_scale` (`Balança de pesagem` + Portuguese body) — in both `dtpr.v0` and `dtpr.v1`. Replaced all four with proper French translations drawn from the canonical English source.

Verified the rest of `fr/` is clean: byte-for-byte body comparison against `pt/`/`es/`/`tl/`/`km/` plus an orthographic sweep for Portuguese-only signals (`ão`, `ões`, `ç[ãõ]`, PT function words) and Spanish-only signals (`ñ`, `¿¡`, `-ción`, `está`, `qué`, etc.) returns no further leaks.

## Test plan
- [ ] Spot-check rendered French copy for `de_identified` and `weighing_scale` in the v1 visualizer
- [ ] Confirm no schema validation regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)