### PR TITLE
fix(dtpr-ai): hydrate pinned ?v= links with their own schema version

### DIFF
--- a/dtpr-ai/app/pages/taxonomy/categories/[id].vue
+++ b/dtpr-ai/app/pages/taxonomy/categories/[id].vue
@@ -62,8 +62,11 @@ const elementsUrl = computed(() => {
   return `${DTPR_API_BASE}/schemas/${activeVersion.value}/elements?fields=all&limit=200&locales=${activeLocale.value},en&category_id=${encodeURIComponent(categoryId.value)}`
 })
 
+// Version + locale live in the keys so a pinned `?v=` landing on the
+// prerendered page misses the baked latest-version payload and
+// refetches the pinned version (see taxonomy/index.vue).
 const { data: categoriesData } = await useAsyncData<CategoriesResponse | undefined>(
-  'dtpr-category-detail-categories',
+  () => `dtpr-category-detail-categories-${activeVersion.value}-${activeLocale.value}`,
   () =>
     categoriesUrl.value
       ? $fetch<CategoriesResponse>(categoriesUrl.value, { timeout: DTPR_FETCH_TIMEOUT_MS })
@@ -75,7 +78,7 @@ const { data: categoriesData } = await useAsyncData<CategoriesResponse | undefin
 // the previous payload immediately rather than leaving the prior
 // elements list visible while the new fetch is in flight.
 const { data: elementsData } = await useAsyncData<ElementsResponse | undefined>(
-  () => `dtpr-category-detail-elements-${categoryId.value}`,
+  () => `dtpr-category-detail-elements-${categoryId.value}-${activeVersion.value}-${activeLocale.value}`,
   () =>
     elementsUrl.value
       ? $fetch<ElementsResponse>(elementsUrl.value, { timeout: DTPR_FETCH_TIMEOUT_MS })

--- a/dtpr-ai/app/pages/taxonomy/elements/[id].vue
+++ b/dtpr-ai/app/pages/taxonomy/elements/[id].vue
@@ -66,9 +66,11 @@ const categoriesUrl = computed(() => {
 // Key includes the element id so SPA navigation between elements drops
 // the previous payload immediately rather than leaving the prior
 // element's title and category breadcrumb visible while the new fetch
-// is in flight.
+// is in flight — and version + locale so a pinned `?v=` landing on the
+// prerendered page misses the baked latest-version payload and
+// refetches the pinned version (see taxonomy/index.vue).
 const { data: elementData, error: elementError } = await useAsyncData<ElementResponse | undefined>(
-  () => `dtpr-element-detail-${elementId.value}`,
+  () => `dtpr-element-detail-${elementId.value}-${activeVersion.value}-${activeLocale.value}`,
   () =>
     elementUrl.value
       ? $fetch<ElementResponse>(elementUrl.value, { timeout: DTPR_FETCH_TIMEOUT_MS })
@@ -77,7 +79,7 @@ const { data: elementData, error: elementError } = await useAsyncData<ElementRes
 )
 
 const { data: categoriesData } = await useAsyncData<CategoriesResponse | undefined>(
-  'dtpr-element-detail-categories',
+  () => `dtpr-element-detail-categories-${activeVersion.value}-${activeLocale.value}`,
   () =>
     categoriesUrl.value
       ? $fetch<CategoriesResponse>(categoriesUrl.value, { timeout: DTPR_FETCH_TIMEOUT_MS })

--- a/dtpr-ai/app/pages/taxonomy/index.vue
+++ b/dtpr-ai/app/pages/taxonomy/index.vue
@@ -77,8 +77,14 @@ const queryString = computed(() => {
   return ''
 })
 
+// Keys carry version + locale because this route is prerendered with
+// the latest schema: a visitor landing on a pinned `?v=` link would
+// otherwise hydrate the baked latest-version payload under the static
+// key and never refetch, showing one version's content labeled as
+// another. A version-scoped key misses the payload and fetches the
+// pinned version instead; unpinned landings still hit the payload.
 const { data: catsData } = await useAsyncData(
-  'dtpr-categories',
+  () => `dtpr-categories-${activeVersion.value}-${activeLocale.value}`,
   () =>
     activeVersion.value
       ? $fetch<CategoriesResponse>(
@@ -90,7 +96,7 @@ const { data: catsData } = await useAsyncData(
 )
 
 const { data: elsData } = await useAsyncData(
-  'dtpr-elements',
+  () => `dtpr-elements-${activeVersion.value}-${activeLocale.value}`,
   () =>
     activeVersion.value
       ? $fetch<ElementsResponse>(

--- a/dtpr-ai/app/pages/taxonomy/print.vue
+++ b/dtpr-ai/app/pages/taxonomy/print.vue
@@ -64,8 +64,11 @@ const ELEMENTS_PAGE_LIMIT = 200
 
 const { activeVersion, activeLocale } = useDtprState()
 
+// Version + locale live in the keys so a pinned `?v=` landing on the
+// prerendered page misses the baked latest-version payload and
+// refetches the pinned version (see taxonomy/index.vue).
 const { data: catsData } = await useAsyncData(
-  'dtpr-print-categories',
+  () => `dtpr-print-categories-${activeVersion.value}-${activeLocale.value}`,
   () =>
     activeVersion.value
       ? $fetch<CategoriesResponse>(
@@ -77,7 +80,7 @@ const { data: catsData } = await useAsyncData(
 )
 
 const { data: elsData } = await useAsyncData(
-  'dtpr-print-elements',
+  () => `dtpr-print-elements-${activeVersion.value}-${activeLocale.value}`,
   () =>
     activeVersion.value
       ? $fetch<ElementsResponse>(


### PR DESCRIPTION
Landing on a taxonomy deep link pinned to an older schema version (`?v=ai@2026-05-06-beta`) rendered the latest version's categories and elements while the header claimed the pinned version — newly reachable now that api.dtpr.io serves two versions (`ai@2026-05-06-beta`, `ai@2026-08-12-beta`) and the header's version selector renders. The cause: the taxonomy routes are prerendered with the latest schema baked into the Nuxt payload, and static `useAsyncData` keys let that payload survive hydration regardless of the pin. All four taxonomy pages now scope their data keys by `${activeVersion}-${activeLocale}`, so pinned landings miss the payload and fetch the pinned version, while unpinned landings still hydrate from the payload with no extra request. Verified via dev-server SSR against the live API: the old pin renders its 11-category set (no "People affected"), the `people` element correctly shows not-found under it, payload keys carry the version, and all 37 vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
