### PR TITLE
fix(dtpr-ai): re-sync ProseCard override for @nuxt/ui 4.9, pin docus

### DIFF
--- a/dtpr-ai/app/components/content/ProseCard.vue
+++ b/dtpr-ai/app/components/content/ProseCard.vue
@@ -14,17 +14,22 @@ import theme from '#build/ui/prose/card'
 // On a `@nuxt/ui` bump, re-sync this file against upstream Card.vue
 // to pick up styling or markup changes; the `useLocalePath` rewrite
 // is the only intentional divergence.
+//
+// Synced against @nuxt/ui 4.9.0, which replaced `useComponentUI` (a
+// computed of the merged `ui` object) with `useComponentProps` (a proxy
+// over the raw props that folds in theme defaults per-key). Hence the
+// `_props` / `props` split, and `props.ui?.x` in place of `uiProp?.x`.
 import { computed } from 'vue'
 import { useAppConfig } from '#imports'
 import { useI18n } from '#i18n'
-import { useComponentUI } from '#ui/composables/useComponentUI'
+import { useComponentProps } from '#ui/composables/useComponentProps'
 import { tv } from '#ui/utils/tv'
 import ULink from '#ui/components/Link.vue'
 import UIcon from '#ui/components/Icon.vue'
 
 defineOptions({ inheritAttrs: false })
 
-const props = defineProps({
+const _props = defineProps({
   to: { type: null, required: false },
   target: { type: [String, Object, null], required: false },
   icon: { type: null, required: false },
@@ -36,8 +41,8 @@ const props = defineProps({
 })
 
 const slots = defineSlots()
+const props = useComponentProps('prose.card', _props)
 const appConfig = useAppConfig()
-const uiProp = useComponentUI('prose.card', props)
 const ui = computed(() => tv({ extend: tv(theme), ...appConfig.ui?.prose?.card || {} })({
   color: props.color,
   to: !!props.to,
@@ -63,7 +68,7 @@ const ariaLabel = computed(() => (props.title || 'Card link').trim())
 </script>
 
 <template>
-  <div :class="ui.base({ class: [uiProp?.base, props.class] })">
+  <div :class="ui.base({ class: [props.ui?.base, props.class] })">
     <ULink
       v-if="resolvedTo"
       :aria-label="ariaLabel"
@@ -74,18 +79,18 @@ const ariaLabel = computed(() => (props.title || 'Card link').trim())
       <span class="absolute inset-0" aria-hidden="true" />
     </ULink>
 
-    <UIcon v-if="icon" :name="icon" :class="ui.icon({ class: uiProp?.icon })" />
-    <UIcon v-if="!!resolvedTo && target === '_blank'" :name="appConfig.ui.icons.external" :class="ui.externalIcon({ class: uiProp?.externalIcon })" />
+    <UIcon v-if="props.icon" :name="props.icon" :class="ui.icon({ class: props.ui?.icon })" />
+    <UIcon v-if="!!resolvedTo && target === '_blank'" :name="appConfig.ui.icons.external" :class="ui.externalIcon({ class: props.ui?.externalIcon })" />
 
-    <p v-if="title || !!slots.title" :class="ui.title({ class: uiProp?.title })">
+    <p v-if="props.title || !!slots.title" :class="ui.title({ class: props.ui?.title })">
       <slot name="title" mdc-unwrap="p">
-        {{ title }}
+        {{ props.title }}
       </slot>
     </p>
 
-    <div v-if="!!slots.default" :class="ui.description({ class: uiProp?.description })">
+    <div v-if="!!slots.default" :class="ui.description({ class: props.ui?.description })">
       <slot>
-        {{ description }}
+        {{ props.description }}
       </slot>
     </div>
   </div>

--- a/dtpr-ai/package.json
+++ b/dtpr-ai/package.json
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@dtpr/ui": "workspace:*",
-    "@nuxt/ui": "^4.5.1",
+    "@nuxt/ui": "4.9.0",
     "@nuxtjs/i18n": "^10.2.4",
-    "docus": "latest",
+    "docus": "5.12.3",
     "mermaid": "^11.14.0",
     "nuxt": "^4.0.0",
     "nuxt-schema-org": "^6.0.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,7 @@ importers:
         version: 12.11.1
       docus:
         specifier: latest
-        version: 5.12.3(466483178df62d36632161c651a26fcc)
+        version: 5.12.3(f52e727ee15bb3598577c5758db6f65d)
       nuxt:
         specifier: ^4.0.0
         version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@22.20.0)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.11.1)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.11.1))(esbuild@0.28.1)(eslint@10.6.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.62.2))(rollup@4.62.2)(srvx@0.11.21)(terser@5.48.0)(tsx@4.23.0)(typescript@5.9.3)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
@@ -152,14 +152,14 @@ importers:
         specifier: workspace:*
         version: link:../packages/ui
       '@nuxt/ui':
-        specifier: ^4.5.1
+        specifier: 4.9.0
         version: 4.9.0(6599bec541d25e13d8a014b870817142)
       '@nuxtjs/i18n':
         specifier: ^10.2.4
         version: 10.4.0(@vue/compiler-dom@3.5.39)(db0@0.3.4(better-sqlite3@12.11.1))(esbuild@0.28.1)(eslint@10.6.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(rolldown@1.1.4)(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))
       docus:
-        specifier: latest
-        version: 5.12.3(be3d7295ff09c907810a9cf79aa6faa7)
+        specifier: 5.12.3
+        version: 5.12.3(57f4cbc6d25aea87b2642ebaac8e78f2)
       mermaid:
         specifier: ^11.14.0
         version: 11.16.0
@@ -17970,7 +17970,7 @@ snapshots:
     dependencies:
       dns-packet: 5.6.1
 
-  docus@5.12.3(466483178df62d36632161c651a26fcc):
+  docus@5.12.3(57f4cbc6d25aea87b2642ebaac8e78f2):
     dependencies:
       '@ai-sdk/gateway': 3.0.144(zod@4.4.3)
       '@ai-sdk/mcp': 1.0.59(zod@4.4.3)
@@ -18121,7 +18121,7 @@ snapshots:
       - webpack
       - yup
 
-  docus@5.12.3(be3d7295ff09c907810a9cf79aa6faa7):
+  docus@5.12.3(f52e727ee15bb3598577c5758db6f65d):
     dependencies:
       '@ai-sdk/gateway': 3.0.144(zod@4.4.3)
       '@ai-sdk/mcp': 1.0.59(zod@4.4.3)
@@ -18153,7 +18153,7 @@ snapshots:
       motion-v: 2.3.0(@vueuse/core@14.3.0(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))
       nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@22.20.0)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.11.1)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.11.1))(esbuild@0.28.1)(eslint@10.6.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.62.2))(rollup@4.62.2)(srvx@0.11.21)(terser@5.48.0)(tsx@4.23.0)(typescript@5.9.3)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
       nuxt-llms: 0.2.0(magicast@0.5.3)
-      nuxt-og-image: 6.6.0(76582fcd437672d3cd6a6d34cd628a2f)
+      nuxt-og-image: 6.6.0(8557069322d851e82943ecda8bbd272d)
       pathe: 2.0.3
       pkg-types: 2.3.1
       scule: 1.3.0
@@ -20721,118 +20721,6 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  nitropack@2.13.4(better-sqlite3@12.11.1)(oxc-parser@0.128.0)(rolldown@1.1.4)(srvx@0.11.21)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
-    dependencies:
-      '@cloudflare/kv-asset-handler': 0.4.2
-      '@rollup/plugin-alias': 6.0.0(rollup@4.62.2)
-      '@rollup/plugin-commonjs': 29.0.3(rollup@4.62.2)
-      '@rollup/plugin-inject': 5.0.5(rollup@4.62.2)
-      '@rollup/plugin-json': 6.1.0(rollup@4.62.2)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.2)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.62.2)
-      '@rollup/plugin-terser': 1.0.0(rollup@4.62.2)
-      '@vercel/nft': 1.10.2(rollup@4.62.2)
-      archiver: 7.0.1
-      c12: 3.3.4(magicast@0.5.3)
-      chokidar: 5.0.0
-      citty: 0.2.2
-      compatx: 0.2.0
-      confbox: 0.2.4
-      consola: 3.4.2
-      cookie-es: 2.0.1
-      croner: 10.0.1
-      crossws: 0.3.5
-      db0: 0.3.4(better-sqlite3@12.11.1)
-      defu: 6.1.7
-      destr: 2.0.5
-      dot-prop: 10.1.0
-      esbuild: 0.28.1
-      escape-string-regexp: 5.0.0
-      etag: 1.8.1
-      exsolve: 1.1.0
-      globby: 16.2.1
-      gzip-size: 7.0.0
-      h3: 1.15.11
-      hookable: 5.5.3
-      httpxy: 0.5.4
-      ioredis: 5.11.1
-      jiti: 2.7.0
-      klona: 2.0.6
-      knitwork: 1.3.0
-      listhen: 1.10.0(srvx@0.11.21)
-      magic-string: 0.30.21
-      magicast: 0.5.3
-      mime: 4.1.0
-      mlly: 1.8.2
-      node-fetch-native: 1.6.7
-      node-mock-http: 1.0.4
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      pkg-types: 2.3.1
-      pretty-bytes: 7.1.0
-      radix3: 1.1.2
-      rollup: 4.62.2
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.4)(rollup@4.62.2)
-      scule: 1.3.0
-      semver: 7.8.5
-      serve-placeholder: 2.0.2
-      serve-static: 2.2.1
-      source-map: 0.7.6
-      std-env: 4.1.0
-      ufo: 1.6.4
-      ultrahtml: 1.6.0
-      uncrypto: 0.1.3
-      unctx: 2.5.0
-      unenv: 2.0.0-rc.24
-      unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.128.0)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
-      unplugin-utils: 0.3.2
-      unstorage: 1.17.5(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)
-      untyped: 2.0.0
-      unwasm: 0.5.3
-      youch: 4.1.1
-      youch-core: 0.3.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@farmfe/core'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@rspack/core'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - bun-types-no-globals
-      - drizzle-orm
-      - encoding
-      - idb-keyval
-      - mysql2
-      - oxc-parser
-      - react-native-b4a
-      - rolldown
-      - sqlite3
-      - srvx
-      - supports-color
-      - unloader
-      - uploadthing
-      - vite
-      - webpack
-    optional: true
-
   nitropack@2.13.4(better-sqlite3@12.11.1)(oxc-parser@0.133.0)(rolldown@1.1.4)(srvx@0.11.21)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
@@ -21167,6 +21055,118 @@ snapshots:
       - webpack
     optional: true
 
+  nitropack@2.13.4(better-sqlite3@12.11.1)(oxc-parser@0.137.0)(rolldown@1.1.4)(srvx@0.11.21)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@rollup/plugin-alias': 6.0.0(rollup@4.62.2)
+      '@rollup/plugin-commonjs': 29.0.3(rollup@4.62.2)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.62.2)
+      '@rollup/plugin-json': 6.1.0(rollup@4.62.2)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.2)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.62.2)
+      '@rollup/plugin-terser': 1.0.0(rollup@4.62.2)
+      '@vercel/nft': 1.10.2(rollup@4.62.2)
+      archiver: 7.0.1
+      c12: 3.3.4(magicast@0.5.3)
+      chokidar: 5.0.0
+      citty: 0.2.2
+      compatx: 0.2.0
+      confbox: 0.2.4
+      consola: 3.4.2
+      cookie-es: 2.0.1
+      croner: 10.0.1
+      crossws: 0.3.5
+      db0: 0.3.4(better-sqlite3@12.11.1)
+      defu: 6.1.7
+      destr: 2.0.5
+      dot-prop: 10.1.0
+      esbuild: 0.28.1
+      escape-string-regexp: 5.0.0
+      etag: 1.8.1
+      exsolve: 1.1.0
+      globby: 16.2.1
+      gzip-size: 7.0.0
+      h3: 1.15.11
+      hookable: 5.5.3
+      httpxy: 0.5.4
+      ioredis: 5.11.1
+      jiti: 2.7.0
+      klona: 2.0.6
+      knitwork: 1.3.0
+      listhen: 1.10.0(srvx@0.11.21)
+      magic-string: 0.30.21
+      magicast: 0.5.3
+      mime: 4.1.0
+      mlly: 1.8.2
+      node-fetch-native: 1.6.7
+      node-mock-http: 1.0.4
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.1
+      pretty-bytes: 7.1.0
+      radix3: 1.1.2
+      rollup: 4.62.2
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.4)(rollup@4.62.2)
+      scule: 1.3.0
+      semver: 7.8.5
+      serve-placeholder: 2.0.2
+      serve-static: 2.2.1
+      source-map: 0.7.6
+      std-env: 4.1.0
+      ufo: 1.6.4
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unenv: 2.0.0-rc.24
+      unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.137.0)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      unplugin-utils: 0.3.2
+      unstorage: 1.17.5(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)
+      untyped: 2.0.0
+      unwasm: 0.5.3
+      youch: 4.1.1
+      youch-core: 0.3.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@farmfe/core'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - bun-types-no-globals
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - mysql2
+      - oxc-parser
+      - react-native-b4a
+      - rolldown
+      - sqlite3
+      - srvx
+      - supports-color
+      - unloader
+      - uploadthing
+      - vite
+      - webpack
+    optional: true
+
   node-abi@3.94.0:
     dependencies:
       semver: 7.8.5
@@ -21259,7 +21259,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-og-image@6.6.0(76582fcd437672d3cd6a6d34cd628a2f):
+  nuxt-og-image@6.6.0(8557069322d851e82943ecda8bbd272d):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
@@ -21298,7 +21298,7 @@ snapshots:
     optionalDependencies:
       '@takumi-rs/core': 1.8.7
       fontless: 0.2.1(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
-      nitropack: 2.13.4(better-sqlite3@12.11.1)(oxc-parser@0.128.0)(rolldown@1.1.4)(srvx@0.11.21)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      nitropack: 2.13.4(better-sqlite3@12.11.1)(oxc-parser@0.137.0)(rolldown@1.1.4)(srvx@0.11.21)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       sharp: 0.34.5
       tailwindcss: 4.3.2
       unifont: 0.7.4
@@ -23995,36 +23995,6 @@ snapshots:
       unplugin: 2.3.11
       unplugin-utils: 0.3.2
 
-  unimport@6.3.0(esbuild@0.28.1)(oxc-parser@0.128.0)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
-    dependencies:
-      acorn: 8.17.0
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      local-pkg: 1.2.1
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      pkg-types: 2.3.1
-      scule: 1.3.0
-      strip-literal: 3.1.0
-      tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
-      unplugin-utils: 0.3.2
-    optionalDependencies:
-      oxc-parser: 0.128.0
-      rolldown: 1.1.4
-    transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@rspack/core'
-      - bun-types-no-globals
-      - esbuild
-      - rollup
-      - unloader
-      - vite
-      - webpack
-    optional: true
-
   unimport@6.3.0(esbuild@0.28.1)(oxc-parser@0.133.0)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       acorn: 8.17.0
@@ -24101,6 +24071,36 @@ snapshots:
       unplugin-utils: 0.3.2
     optionalDependencies:
       oxc-parser: 0.135.0
+      rolldown: 1.1.4
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rollup
+      - unloader
+      - vite
+      - webpack
+    optional: true
+
+  unimport@6.3.0(esbuild@0.28.1)(oxc-parser@0.137.0)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
+    dependencies:
+      acorn: 8.17.0
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      local-pkg: 1.2.1
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      pkg-types: 2.3.1
+      scule: 1.3.0
+      strip-literal: 3.1.0
+      tinyglobby: 0.2.17
+      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      unplugin-utils: 0.3.2
+    optionalDependencies:
+      oxc-parser: 0.137.0
       rolldown: 1.1.4
     transitivePeerDependencies:
       - '@farmfe/core'


### PR DESCRIPTION
## Problem

Every `::card` in dtpr-ai content is rendered by a vendored copy of upstream's `Card.vue`, which imported `#ui/composables/useComponentUI`. That composable was **renamed to `useComponentProps` in @nuxt/ui 4.9.0**, so the import resolves to nothing:

- content pages using `::card` 500 under SSR (`/en`, `/en/tools`, `/fr/tools`)
- `nuxt build` fails outright — **dtpr-ai has not been deployable from `main` since the bump landed**

## Root cause

Not a deliberate upgrade. `docus` was specified as `"latest"`, so the lockfile refresh in c3c4420d moved it **5.7.0 → 5.12.3**, and docus 5.12.3 requires `@nuxt/ui ^4.9.0` — which pulled @nuxt/ui up past dtpr-ai's then-`^4.5.1` range.

It stayed invisible because no CI job builds or SSR-renders dtpr-ai, and long-lived local checkouts still had 4.5.1 sitting in `node_modules`. Only a clean install surfaces it.

## Fix

Re-syncs `ProseCard.vue` against upstream 4.9.0, per the instruction in the file's own header comment. Upstream's 4.5.1 → 4.9.0 diff is **purely** the composable refactor (`useComponentUI` returned a merged `ui` computed; `useComponentProps` returns a proxy over props folding theme defaults in per key), so this is the mechanical port: `_props`/`props` split, `props.x` in the template, `props.ui?.x` for `uiProp?.x`. The `useLocalePath` rewrite remains the only intentional divergence.

Pins `docus` and `@nuxt/ui` to their resolved versions so the next unrelated lockfile refresh can't drag the layer forward again. Pinning @nuxt/ui alone would have been wrong — docus requires `^4.9.0`, so an exact pin at any older version forks the tree into two @nuxt/ui copies behind one `#ui` alias.

`ProseA.vue` needs no change: it only imports `#ui/utils/tv` and `#ui/components/Link.vue`, both still present in 4.9.0.

## Side effect worth reviewing

Re-resolving the docus subtree also floats **`oxc-parser` 0.128.0 → 0.137.0** under nitropack/unimport. Confirmed this comes from the pin, not ambient drift — resetting and running a bare `pnpm install` is a clean no-op. It's latent either way (the range already permits it); this makes it explicit and tested. Drop the `docus` pin if you'd rather not carry it — the ProseCard fix stands alone.

## Verification

| check | result |
|---|---|
| dtpr-ai production build | exit 0, full prerender |
| dtpr-ai tests | 37 passed |
| app unit tests | 32 passed |
| @dtpr/ui tests | 185 passed |
| `/en`, `/en/tools`, `/fr/tools`, `/fr` via dev server | 200, cards render, locale prefixes intact |

## Follow-up not in this PR

**No CI job builds or SSR-renders dtpr-ai** — that's why this shipped broken, and pinning only narrows the hole. A workflow running `pnpm --filter ./dtpr-ai build` on PRs would have caught it on day one, and would catch the next one regardless of mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)