### PR TITLE
fix(docs-site): stop rejecting listed Studio moderators with a 403

### DIFF
--- a/docs-site/docs/studio-setup.md
+++ b/docs-site/docs/studio-setup.md
@@ -65,7 +65,11 @@ echo -n "$MODS" | pnpm -F dtpr-docs exec wrangler secret put STUDIO_GITHUB_MODER
 # Then redeploy so the Worker picks up the new secrets.
 ```
 
-For GitHub OAuth: list the primary email on each moderator's GitHub account. A user's `@users.noreply.github.com` address won't match a real address.
+Matching rules (see [Patched `nuxt-studio`](#patched-nuxt-studio) below):
+
+- **GitHub OAuth:** any **verified** email on the moderator's GitHub account matches — primary, public, or secondary. A `@users.noreply.github.com` address won't match a real address.
+- **Google OAuth:** the Google account's email must match.
+- Both lists are compared case-insensitively and with surrounding whitespace trimmed, so `Alice@Example.com, bob@example.com` still works. Keep the canonical list lowercase and space-free anyway.
 
 ## Cloudflare Workers secrets (production)
 
@@ -88,6 +92,8 @@ Verify what's configured (values are not shown):
 pnpm exec wrangler secret list
 ```
 
+`wrangler` must be logged into the Cloudflare account that owns the `dtpr-docs` Worker (the `account_id` in `wrangler.toml`). If `wrangler whoami` shows a different account, every `secret`/`deployments`/`tail` command fails with `Authentication error [code: 10000]` and a warning that the configured `account_id` does not match — run `pnpm exec wrangler login` with the right account, or export a `CLOUDFLARE_API_TOKEN` scoped to it.
+
 Use the **prod** GitHub OAuth App credentials for `STUDIO_GITHUB_CLIENT_ID`/`_SECRET` (not the dev app's).
 
 ## Local dev setup
@@ -101,6 +107,16 @@ Use the **prod** GitHub OAuth App credentials for `STUDIO_GITHUB_CLIENT_ID`/`_SE
 
 Any test commits made from local dev land on `main` the same way production commits do. Prefer using a sandbox file (or immediately reverting) when testing.
 
+## Patched `nuxt-studio`
+
+`nuxt-studio` is installed with a pnpm patch (`patches/nuxt-studio@1.7.0.patch`, registered under `patchedDependencies` in the root `pnpm-workspace.yaml`). Upstream compares the allowlist by exact string match against a single email — the GitHub account's public email, or its primary email if no public one is set ([nuxt-content/nuxt-studio#308](https://github.com/nuxt-content/nuxt-studio/issues/308)). Anyone whose listed address is a secondary email, or whose list entry differs only in case/whitespace, gets a `403`. The patch:
+
+- GitHub: authorizes if **any verified** email on the account is on the list (fetched from `GET /user/emails`, which the requested `user:email` scope already allows). The session still stores upstream's public-or-primary email, so commit attribution is unchanged.
+- GitHub + Google: trims and lowercases both sides before comparing, and ignores empty entries.
+- Logs a `[Nuxt Studio] … login rejected` warning on `403` so `wrangler tail` shows *why*.
+
+**Upgrading `nuxt-studio`:** pnpm refuses to install if the patched version no longer matches. Re-create the patch against the new version (`pnpm patch nuxt-studio@<version> --edit-dir /tmp/ns-patch`, re-apply the same edits, `pnpm patch-commit /tmp/ns-patch`), remove the old entry, and check whether upstream has since fixed #308 — if so, drop the patch entirely. Note that upstream `main` already moved env reads into a runtime middleware after 1.7.0 (`STUDIO_*` vars become `runtimeConfig.studio.auth.<provider>.moderators`), so the patch will need to be rewritten rather than rebased.
+
 ## Troubleshooting
 
 **Editor won't load / blank page at `/_studio`**
@@ -113,9 +129,15 @@ Any test commits made from local dev land on `main` the same way production comm
 - Compare the redirect URI in the OAuth app exactly against `http(s)://<host>/__nuxt_studio/auth/<provider>`.
 - Verify the other provider's three secrets are set (`wrangler secret list`).
 
+**`403` / "Page not found" right after the GitHub (or Google) redirect**
+- The URL is `/__nuxt_studio/auth/github?code=…&state=…` (or `/google`) and the page says `403 Page not found — We are sorry but this page could not be found.`
+- This is *not* a missing route. Docus's `error.vue` replaces every error's title/description with the localized "Page not found" copy, so the status code is the only real signal. `403` on the callback is `nuxt-studio`'s moderator check: the email it resolved for you is not in `STUDIO_GITHUB_MODERATORS` / `STUDIO_GOOGLE_MODERATORS`.
+- The Worker logs a `[Nuxt Studio] GitHub login rejected: none of [...] is in STUDIO_GITHUB_MODERATORS` (or `Google login rejected: …`) warning naming the email(s) it compared and how many allowlist entries it had. Capture it with `pnpm exec wrangler tail dtpr-docs --format pretty` while retrying the sign-in.
+- Other callback failures use different codes: `400` = state cookie missing/mismatch (retry from `/_studio`), `500` = missing client ID/secret or token exchange failure.
+
 **"You are not a moderator" despite being on the list**
 - Check for typos in the moderator list (extra spaces, wrong domain).
-- For GitHub OAuth: confirm the user's primary email on GitHub matches the list. A `@users.noreply.github.com` email won't match if we listed their real email.
+- For GitHub OAuth: confirm the listed address is a **verified** email on the user's GitHub account (Settings → Emails). A `@users.noreply.github.com` email won't match if we listed their real email.
 - Confirm both `STUDIO_GOOGLE_MODERATORS` and `STUDIO_GITHUB_MODERATORS` were updated on the last moderator change.
 
 **Commits not appearing after save**

--- a/docs-site/docs/studio-setup.md
+++ b/docs-site/docs/studio-setup.md
@@ -70,6 +70,8 @@ Matching rules (see [Patched `nuxt-studio`](#patched-nuxt-studio) below):
 - **GitHub OAuth:** any **verified** email on the moderator's GitHub account matches — primary, public, or secondary. A `@users.noreply.github.com` address won't match a real address.
 - **Google OAuth:** the Google account's email must match.
 - Both lists are compared case-insensitively and with surrounding whitespace trimmed, so `Alice@Example.com, bob@example.com` still works. Keep the canonical list lowercase and space-free anyway.
+- A list that is **set but blank** (`""`, `" "`, `",,"`) matches nobody and locks everyone out — it never degrades into "no allowlist".
+- Leaving `STUDIO_GITHUB_MODERATORS` **entirely unset** means *no GitHub restriction at all* — any GitHub account that completes the OAuth flow gets in. This is upstream `nuxt-studio` behaviour, and it is why the secret must be present in production. (`STUDIO_GOOGLE_MODERATORS` has no such hole: Google auth always requires a match.)
 
 ## Cloudflare Workers secrets (production)
 
@@ -113,6 +115,7 @@ Any test commits made from local dev land on `main` the same way production comm
 
 - GitHub: authorizes if **any verified** email on the account is on the list (fetched from `GET /user/emails`, which the requested `user:email` scope already allows). The session still stores upstream's public-or-primary email, so commit attribution is unchanged.
 - GitHub + Google: trims and lowercases both sides before comparing, and ignores empty entries.
+- GitHub: decides *whether an allowlist exists* from the presence of the env var, not from how many entries survived that normalization. Keying off the surviving count would let a set-but-blank value collapse to an empty list and skip the check entirely, admitting any authenticated GitHub account; upstream failed closed there and so does the patch.
 - Logs a `[Nuxt Studio] … login rejected` warning on `403` so `wrangler tail` shows *why*.
 
 **Upgrading `nuxt-studio`:** pnpm refuses to install if the patched version no longer matches. Re-create the patch against the new version (`pnpm patch nuxt-studio@<version> --edit-dir /tmp/ns-patch`, re-apply the same edits, `pnpm patch-commit /tmp/ns-patch`), remove the old entry, and check whether upstream has since fixed #308 — if so, drop the patch entirely. Note that upstream `main` already moved env reads into a runtime middleware after 1.7.0 (`STUDIO_*` vars become `runtimeConfig.studio.auth.<provider>.moderators`), so the patch will need to be rewritten rather than rebased.

--- a/patches/nuxt-studio@1.7.0.patch
+++ b/patches/nuxt-studio@1.7.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/module/runtime/server/routes/auth/github.get.js b/dist/module/runtime/server/routes/auth/github.get.js
-index f4a97afec535469a233c33292d2a0c141d7b05c6..23ddd8b381d6b111446af5a4fbd84702693129a0 100644
+index f4a97afec535469a233c33292d2a0c141d7b05c6..e48b9efb062736503efe514b3fd073db7fa89bcf 100644
 --- a/dist/module/runtime/server/routes/auth/github.get.js
 +++ b/dist/module/runtime/server/routes/auth/github.get.js
 @@ -1,9 +1,12 @@
@@ -42,7 +42,7 @@ index f4a97afec535469a233c33292d2a0c141d7b05c6..23ddd8b381d6b111446af5a4fbd84702
      const primaryEmail = emails.find((email) => email.primary);
      if (!primaryEmail) {
        throw createError({
-@@ -103,12 +113,28 @@ export default eventHandler(async (event) => {
+@@ -103,12 +113,33 @@ export default eventHandler(async (event) => {
      }
      user.email = primaryEmail.email;
    }
@@ -52,8 +52,13 @@ index f4a97afec535469a233c33292d2a0c141d7b05c6..23ddd8b381d6b111446af5a4fbd84702
 -      statusCode: 403,
 -      message: "You are not authorized to access the studio"
 -    });
-+  const moderators = (process.env.STUDIO_GITHUB_MODERATORS || "").split(",").map(normalizeEmail).filter(Boolean);
-+  if (moderators.length > 0) {
++  const configuredModerators = process.env.STUDIO_GITHUB_MODERATORS;
++  const moderators = (configuredModerators || "").split(",").map(normalizeEmail).filter(Boolean);
++  // Patched (dtpr): gate on whether an allowlist is configured at all, not on how many
++  // entries survived normalization. A set-but-blank value ("", " ", ",,") normalizes to an
++  // empty list, and keying off its length would skip the check and let any authenticated
++  // GitHub account in. Upstream failed closed there; so must we.
++  if (configuredModerators !== void 0) {
 +    // Patched (dtpr): authorize against every verified email on the GitHub account,
 +    // not only the public/primary one. Upstream: nuxt-content/nuxt-studio#308
 +    const candidateEmails = new Set([normalizeEmail(user.email)].filter(Boolean));

--- a/patches/nuxt-studio@1.7.0.patch
+++ b/patches/nuxt-studio@1.7.0.patch
@@ -1,0 +1,98 @@
+diff --git a/dist/module/runtime/server/routes/auth/github.get.js b/dist/module/runtime/server/routes/auth/github.get.js
+index f4a97afec535469a233c33292d2a0c141d7b05c6..23ddd8b381d6b111446af5a4fbd84702693129a0 100644
+--- a/dist/module/runtime/server/routes/auth/github.get.js
++++ b/dist/module/runtime/server/routes/auth/github.get.js
+@@ -1,9 +1,12 @@
+ import { useRuntimeConfig } from "#imports";
++import { consola } from "consola";
+ import { createError, deleteCookie, eventHandler, getCookie, getQuery, getRequestURL, sendRedirect } from "h3";
+ import { withQuery, withoutTrailingSlash } from "ufo";
+ import { generateOAuthState, requestAccessToken, validateOAuthState } from "../../utils/auth.js";
+ import { setInternalStudioUserSession } from "../../utils/session.js";
+ import { mergeConfig } from "../../utils/object.js";
++const logger = consola.withTag("Nuxt Studio");
++const normalizeEmail = (value) => String(value || "").trim().toLowerCase();
+ export default eventHandler(async (event) => {
+   const studioConfig = useRuntimeConfig(event).studio;
+   const instanceUrl = withoutTrailingSlash(studioConfig?.auth?.github?.instanceUrl || studioConfig?.repository?.instanceUrl || "https://github.com");
+@@ -86,13 +89,20 @@ export default eventHandler(async (event) => {
+       "Authorization": `token ${accessToken}`
+     }
+   });
++  let githubEmails;
++  const listGithubEmails = async () => {
++    if (!githubEmails) {
++      githubEmails = await $fetch(`${config.apiURL}/user/emails`, {
++        headers: {
++          "User-Agent": `Github-OAuth-${config.clientId}`,
++          "Authorization": `token ${accessToken}`
++        }
++      });
++    }
++    return githubEmails;
++  };
+   if (!user.email && config.emailRequired) {
+-    const emails = await $fetch(`${config.apiURL}/user/emails`, {
+-      headers: {
+-        "User-Agent": `Github-OAuth-${config.clientId}`,
+-        "Authorization": `token ${accessToken}`
+-      }
+-    });
++    const emails = await listGithubEmails();
+     const primaryEmail = emails.find((email) => email.primary);
+     if (!primaryEmail) {
+       throw createError({
+@@ -103,12 +113,28 @@ export default eventHandler(async (event) => {
+     }
+     user.email = primaryEmail.email;
+   }
+-  const moderators = process.env.STUDIO_GITHUB_MODERATORS?.split(",") || [];
+-  if (moderators.length > 0 && !moderators.includes(String(user.email))) {
+-    throw createError({
+-      statusCode: 403,
+-      message: "You are not authorized to access the studio"
+-    });
++  const moderators = (process.env.STUDIO_GITHUB_MODERATORS || "").split(",").map(normalizeEmail).filter(Boolean);
++  if (moderators.length > 0) {
++    // Patched (dtpr): authorize against every verified email on the GitHub account,
++    // not only the public/primary one. Upstream: nuxt-content/nuxt-studio#308
++    const candidateEmails = new Set([normalizeEmail(user.email)].filter(Boolean));
++    try {
++      for (const entry of await listGithubEmails() || []) {
++        if (entry?.verified && entry.email) {
++          candidateEmails.add(normalizeEmail(entry.email));
++        }
++      }
++    } catch (error) {
++      logger.warn("Could not list GitHub emails for the moderator check:", error?.message || error);
++    }
++    const isModerator = [...candidateEmails].some((email) => moderators.includes(email));
++    if (!isModerator) {
++      logger.warn(`GitHub login rejected: none of [${[...candidateEmails].join(", ")}] is in STUDIO_GITHUB_MODERATORS (${moderators.length} entries)`);
++      throw createError({
++        statusCode: 403,
++        message: "You are not authorized to access the studio"
++      });
++    }
+   }
+   await setInternalStudioUserSession(event, {
+     providerId: user.id.toString(),
+diff --git a/dist/module/runtime/server/routes/auth/google.get.js b/dist/module/runtime/server/routes/auth/google.get.js
+index 0c86c5cc2a0ff85972894081b7dae33ffd971c9d..33a7abd386e8baa053f118e1f2ceabaa4618d295 100644
+--- a/dist/module/runtime/server/routes/auth/google.get.js
++++ b/dist/module/runtime/server/routes/auth/google.get.js
+@@ -97,8 +97,12 @@ export default eventHandler(async (event) => {
+       data: user
+     });
+   }
+-  const moderators = process.env.STUDIO_GOOGLE_MODERATORS?.split(",") || [];
+-  if (!moderators.includes(user.email)) {
++  const normalizeEmail = (value) => String(value || "").trim().toLowerCase();
++  const moderators = (process.env.STUDIO_GOOGLE_MODERATORS || "").split(",").map(normalizeEmail).filter(Boolean);
++  if (!moderators.includes(normalizeEmail(user.email))) {
++    if (moderators.length > 0) {
++      logger.warn(`Google login rejected: ${normalizeEmail(user.email)} is not in STUDIO_GOOGLE_MODERATORS (${moderators.length} entries)`);
++    }
+     if (import.meta.dev && moderators.length === 0) {
+       logger.warn([
+         "No moderators defined. Moderators are required for Google authentication.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   typescript: 5.9.3
 
 patchedDependencies:
-  nuxt-studio@1.7.0: 4467102fb34e4379b7db102b539a3f224bbdb867ac8618ebc6ef7efe3bf71c72
+  nuxt-studio@1.7.0: 416fbcfb2425fb019aea7def52ae056f8b32f6e040b1545591d3415d3b5e87a7
 
 importers:
 
@@ -143,7 +143,7 @@ importers:
         version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@22.20.0)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.11.1)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.11.1))(esbuild@0.28.1)(eslint@10.6.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.62.2))(rollup@4.62.2)(srvx@0.11.21)(terser@5.48.0)(tsx@4.23.0)(typescript@5.9.3)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
       nuxt-studio:
         specifier: ^1.6.0
-        version: 1.7.0(patch_hash=4467102fb34e4379b7db102b539a3f224bbdb867ac8618ebc6ef7efe3bf71c72)(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)(magicast@0.5.3)(srvx@0.11.21)(vue@3.5.39(typescript@5.9.3))
+        version: 1.7.0(patch_hash=416fbcfb2425fb019aea7def52ae056f8b32f6e040b1545591d3415d3b5e87a7)(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)(magicast@0.5.3)(srvx@0.11.21)(vue@3.5.39(typescript@5.9.3))
     devDependencies:
       wrangler:
         specifier: ^4.83.0
@@ -21450,7 +21450,7 @@ snapshots:
       - vue
       - zod
 
-  nuxt-studio@1.7.0(patch_hash=4467102fb34e4379b7db102b539a3f224bbdb867ac8618ebc6ef7efe3bf71c72)(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)(magicast@0.5.3)(srvx@0.11.21)(vue@3.5.39(typescript@5.9.3)):
+  nuxt-studio@1.7.0(patch_hash=416fbcfb2425fb019aea7def52ae056f8b32f6e040b1545591d3415d3b5e87a7)(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)(magicast@0.5.3)(srvx@0.11.21)(vue@3.5.39(typescript@5.9.3)):
     dependencies:
       '@ai-sdk/gateway': 3.0.144(zod@4.4.3)
       '@ai-sdk/vue': 3.0.220(vue@3.5.39(typescript@5.9.3))(zod@4.4.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 overrides:
   typescript: 5.9.3
 
+patchedDependencies:
+  nuxt-studio@1.7.0: 4467102fb34e4379b7db102b539a3f224bbdb867ac8618ebc6ef7efe3bf71c72
+
 importers:
 
   .: {}
@@ -140,7 +143,7 @@ importers:
         version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@22.20.0)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.11.1)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.11.1))(esbuild@0.28.1)(eslint@10.6.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.62.2))(rollup@4.62.2)(srvx@0.11.21)(terser@5.48.0)(tsx@4.23.0)(typescript@5.9.3)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
       nuxt-studio:
         specifier: ^1.6.0
-        version: 1.7.0(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)(magicast@0.5.3)(srvx@0.11.21)(vue@3.5.39(typescript@5.9.3))
+        version: 1.7.0(patch_hash=4467102fb34e4379b7db102b539a3f224bbdb867ac8618ebc6ef7efe3bf71c72)(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)(magicast@0.5.3)(srvx@0.11.21)(vue@3.5.39(typescript@5.9.3))
     devDependencies:
       wrangler:
         specifier: ^4.83.0
@@ -21447,7 +21450,7 @@ snapshots:
       - vue
       - zod
 
-  nuxt-studio@1.7.0(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)(magicast@0.5.3)(srvx@0.11.21)(vue@3.5.39(typescript@5.9.3)):
+  nuxt-studio@1.7.0(patch_hash=4467102fb34e4379b7db102b539a3f224bbdb867ac8618ebc6ef7efe3bf71c72)(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)(magicast@0.5.3)(srvx@0.11.21)(vue@3.5.39(typescript@5.9.3)):
     dependencies:
       '@ai-sdk/gateway': 3.0.144(zod@4.4.3)
       '@ai-sdk/vue': 3.0.220(vue@3.5.39(typescript@5.9.3))(zod@4.4.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,3 +38,5 @@ overrides:
   # pull TypeScript 6.x, which fails the @dtpr/ui dts build (stricter Vue
   # `h()` prop + CSS side-effect import checks).
   typescript: 5.9.3
+patchedDependencies:
+  nuxt-studio@1.7.0: patches/nuxt-studio@1.7.0.patch


### PR DESCRIPTION
## Summary

Moderators listed by a secondary or differently-cased email address can now open the Studio editor instead of bouncing off a silent `403` at the OAuth callback. Upstream `nuxt-studio` compares `STUDIO_GITHUB_MODERATORS` by exact string against one email — the GitHub account's public address, or its primary if no public one is set — so anyone listed by a secondary address had no way in and no way to tell why.

The fix is a pnpm patch (`patches/nuxt-studio@1.7.0.patch`, the repo's first) over the two OAuth callback handlers:

- **GitHub:** authorizes when *any* verified email on the account is on the allowlist, read from `GET /user/emails` under the `user:email` scope the app already requests. The session still stores upstream's public-or-primary email, so commit attribution is unchanged.
- **GitHub and Google:** both sides of the comparison are trimmed and lowercased, and blank allowlist entries are dropped.
- **Both:** a rejection now logs `[Nuxt Studio] … login rejected` naming the emails it compared and the allowlist size, so `wrangler tail` shows the reason. Until now the failure was indistinguishable from a bad route, because Docus's `error.vue` rewrites every error — whatever its status — to "Page not found".

The boundary itself is unchanged: an unlisted account still gets a `403`, and an unverified email never matches.

## Maintenance cost

pnpm hard-fails the install once the patched version stops matching, so the upgrade path is written up in `docs-site/docs/studio-setup.md` alongside the moderator matching rules and a `403` troubleshooting entry. Rebasing the patch onto a newer `nuxt-studio` will not work — upstream `main` has already moved these env reads into runtime middleware — so the next bump means rewriting the patch, or deleting it if upstream has fixed the bug by then. The docs change also picks up an unrelated `wrangler` note: `secret`/`tail`/`deploy` fail with `Authentication error [code: 10000]` when the CLI is logged into a different Cloudflare account than the one that owns the Worker.

## Validation

`pnpm install --frozen-lockfile` resolves and applies the patch, and both patched handlers parse under `node --check`. The OAuth callback was not exercised end to end — that needs a deploy of the `dtpr-docs` Worker under the Cloudflare account that owns it.

Related: nuxt-content/nuxt-studio#308
